### PR TITLE
superchain: contract implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The superchain configs are made available in minimal form, to embed in OP-Stack 
 Full deployment artifacts and genesis-states can be derived from the minimal form
 using the reference [`op-chain-ops`] tooling.
 
+The `semver.yaml` file represents the semantic versioning lockfile for the smart contracts in the superchain.
+
 ## Go Module
 
 Superchain configs can be imported as Go-module:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ The superchain configs are made available in minimal form, to embed in OP-Stack 
 Full deployment artifacts and genesis-states can be derived from the minimal form
 using the reference [`op-chain-ops`] tooling.
 
-The `semver.yaml` file represents the semantic versioning lockfile for the smart contracts in the superchain.
+The `semver.yaml` file represents the semantic versioning lockfile for the all of the smart contracts in the superchain.
+It is meant to be used when building transactions that upgrade the implementations set in the proxies.
 
 ## Go Module
 

--- a/superchain/go.mod
+++ b/superchain/go.mod
@@ -2,4 +2,7 @@ module github.com/ethereum-optimism/superchain-registry/superchain
 
 go 1.19
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/superchain/go.mod
+++ b/superchain/go.mod
@@ -4,5 +4,6 @@ go 1.19
 
 require (
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
+	golang.org/x/mod v0.12.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/superchain/go.sum
+++ b/superchain/go.sum
@@ -1,3 +1,5 @@
+golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
+golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/superchain/go.sum
+++ b/superchain/go.sum
@@ -1,5 +1,7 @@
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
+golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
+golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/superchain/implementations/README.md
+++ b/superchain/implementations/README.md
@@ -1,0 +1,8 @@
+# implementations
+
+The implementation contract addresses live here. When deployed with a `CREATE2`
+[deterministic deployment factory](https://github.com/Arachnid/deterministic-deployment-proxy),
+the contract addresses will be the same on all networks given the same salt is used. These
+contract addresses live in `implementations.yaml`. If the contract address differs on a per network
+basis, it should exist in a `yaml` file named after the network inside of the `networks` directory.
+

--- a/superchain/implementations/implementations.yaml
+++ b/superchain/implementations/implementations.yaml
@@ -1,0 +1,14 @@
+l1_cross_domain_messenger:
+  1.6.0: 0xf4d5682dA3ad1820ea83E1cEE5Fd92a3A7BabC30
+l1_erc721_bridge:
+  1.3.0: 0x8ADd7FB53A242e827373519d260EE3B8F7612Ba1
+l1_standard_bridge:
+  1.3.0: 0x9c540e769B9453d174EdB683a90D9170e6559F16
+l2_output_oracle:
+  1.5.0: 0x7a811C9862ab54E677EEdA7e6F075aC86a1f551e
+optimism_mintable_erc20_factory:
+  1.4.0: 0x135B9097A0e1e56190251c62f111B676Fb4Ec494
+optimism_portal:
+  1.9.0: 0x8Cfa294bD0c6F63cD65d492bdB754eAcf684D871
+system_config:
+  1.7.0: 0x09323D05868393c7EBa8190BAc173f843b82030a

--- a/superchain/implementations/networks/goerli.yaml
+++ b/superchain/implementations/networks/goerli.yaml
@@ -1,0 +1,14 @@
+l1_cross_domain_messenger:
+  1.5.1: 0xb5df97bB67f5AA7254d40E1B7034bBFF7F183a38
+l1_erc721_bridge:
+  1.2.1: 0x53C115eD8D9902f4999fDBd8B93Ea79BF37cb588
+l1_standard_bridge:
+  1.2.1: 0xd9aA10f75a2a93Bfc73AaDD41ae777e900CEdBc9
+l2_output_oracle:
+  1.4.1: 0xaBd96C062c6B640d5670455E9d1cD98383Dd23CA
+optimism_mintable_erc20_factory:
+  1.3.0: 0xdfe97868233d1aa22e815a266982f2cf17685a27
+optimism_portal:
+  1.8.1: 0x345D27c7B6C90fef5beA9631037C36119f4bF93e
+system_config:
+  1.6.0: 0x543bA4AADBAb8f9025686Bd03993043599c6fB04

--- a/superchain/implementations/networks/mainnet.yaml
+++ b/superchain/implementations/networks/mainnet.yaml
@@ -1,0 +1,7 @@
+l1_cross_domain_messenger:
+l1_erc721_bridge:
+l1_standard_bridge:
+l2_output_oracle:
+optimism_mintable_erc20_factory:
+optimism_portal:
+system_config:

--- a/superchain/implementations/networks/sepolia.yaml
+++ b/superchain/implementations/networks/sepolia.yaml
@@ -1,0 +1,14 @@
+l1_cross_domain_messenger:
+  1.5.1: 0xDAF83496D1E2bF53EB60F29Ca141189118db1B0A
+l1_erc721_bridge:
+  1.2.1: 0xceB2C93DC16C99ffd07EeE057FFd7fDb06794D5f
+l1_standard_bridge:
+  1.2.1: 0xE944d76522C46455eaB847C0aF9af0c72A62b53f
+l2_output_oracle:
+  1.4.1: 0x1DD8545d8df76199a2E678Fe3662C40540BF326c
+optimism_mintable_erc20_factory:
+  1.1.2: 0x2d3B8721EF4c3aa0Ddb9c11B1Bf8BbC1f68B9b28
+optimism_portal:
+  1.8.1: 0xBD37f7Ee2681af0156c0bA11fa2F6b1D197d0F12
+system_config:
+  1.5.0: 0xab9cf6d9f717f57386624a66E59102f7eFCd33f3

--- a/superchain/semver.yaml
+++ b/superchain/semver.yaml
@@ -1,0 +1,8 @@
+l1_cross_domain_messenger: 1.6.0
+l1_erc721_bridge: 1.3.0
+l1_standard_bridge: 1.3.0
+l2_output_oracle: 1.5.0
+optimism_mintable_erc20_factory: 1.4.0
+optimism_portal: 1.9.0
+system_config: 1.7.0
+

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -59,6 +59,7 @@ type ChainConfig struct {
 	Chain string `yaml:"-"`
 }
 
+// AddressList represents the set of network specific contracts for a given network.
 type AddressList struct {
 	AddressManager                    Address `json:"AddressManager"`
 	L1CrossDomainMessengerProxy       Address `json:"L1CrossDomainMessengerProxy"`
@@ -70,17 +71,124 @@ type AddressList struct {
 	ProxyAdmin                        Address `json:"ProxyAdmin"`
 }
 
+// ImplementationList represents the set of implementation contracts to be used together
+// for a network.
+type ImplementationList struct {
+	L1CrossDomainMessenger       VersionedContract `json:"L1CrossDomainMessenger"`
+	L1ERC721Bridge               VersionedContract `json:"L1ERC721Bridge"`
+	L1StandardBridge             VersionedContract `json:"L1StandardBridge"`
+	L2OutputOracle               VersionedContract `json:"L2OutputOracle"`
+	OptimismMintableERC20Factory VersionedContract `json:"OptimismMintableERC20Factory"`
+	OptimismPortal               VersionedContract `json:"OptimismPortal"`
+	SystemConfig                 VersionedContract `json:"SystemConfig"`
+}
+
 // ContractImplementations represent a set of contract implementations on a given network.
 // The key in the map represents the semantic version of the contract and the value is the
 // address that the contract is deployed to.
 type ContractImplementations struct {
-	L1CrossDomainMessenger       map[string]Address `yaml:"l1_cross_domain_messenger"`
-	L1ERC721Bridge               map[string]Address `yaml:"l1_erc721_bridge"`
-	L1StandardBridge             map[string]Address `yaml:"l1_standard_bridge"`
-	L2OutputOracle               map[string]Address `yaml:"l2_output_oracle"`
-	OptimismMintableERC20Factory map[string]Address `yaml:"optimism_mintable_erc20_factory"`
-	OptimismPortal               map[string]Address `yaml:"optimism_portal"`
-	SystemConfig                 map[string]Address `yaml:"system_config"`
+	L1CrossDomainMessenger       AddressSet `yaml:"l1_cross_domain_messenger"`
+	L1ERC721Bridge               AddressSet `yaml:"l1_erc721_bridge"`
+	L1StandardBridge             AddressSet `yaml:"l1_standard_bridge"`
+	L2OutputOracle               AddressSet `yaml:"l2_output_oracle"`
+	OptimismMintableERC20Factory AddressSet `yaml:"optimism_mintable_erc20_factory"`
+	OptimismPortal               AddressSet `yaml:"optimism_portal"`
+	SystemConfig                 AddressSet `yaml:"system_config"`
+}
+
+// AddressSet represents a set of addresses for a given
+// contract. They are keyed by the semantic version.
+type AddressSet map[string]Address
+
+// VersionedContract represents a contract that has a semantic version.
+type VersionedContract struct {
+	Version string  `json:"version"`
+	Address Address `json:"address"`
+}
+
+// Get will handle getting semantic versions from the set
+// in the case where the semver string is not prefixed with
+// a "v" as well as if it does have a "v" prefix.
+func (a AddressSet) Get(key string) Address {
+	if strings.HasPrefix(key, "v") {
+		if addr, ok := a[key]; ok {
+			return addr
+		}
+		if addr, ok := a[strings.TrimPrefix(key, "v")]; ok {
+			return addr
+		}
+	}
+	return a[key]
+}
+
+// Versions will return the list of semantic versions for a contract.
+// It handles the case where the versions are not prefixed with a "v".
+func (a AddressSet) Versions() []string {
+	keys := maps.Keys(a)
+	for i, k := range keys {
+		if !strings.HasPrefix(k, "v") {
+			keys[i] = "v" + k
+		}
+	}
+	semver.Sort(keys)
+	return keys
+}
+
+// Resolve will return a set of addresses that resolve a given
+// semantic version set.
+func (c ContractImplementations) Resolve(versions ContractVersions) (ImplementationList, error) {
+	var implementations ImplementationList
+	var err error
+	if implementations.L1CrossDomainMessenger, err = resolve(c.L1CrossDomainMessenger, versions.L1CrossDomainMessenger); err != nil {
+		return implementations, fmt.Errorf("L1CrossDomainMessenger: %w", err)
+	}
+	if implementations.L1ERC721Bridge, err = resolve(c.L1ERC721Bridge, versions.L1ERC721Bridge); err != nil {
+		return implementations, fmt.Errorf("L1ERC721Bridge: %w", err)
+	}
+	if implementations.L1StandardBridge, err = resolve(c.L1StandardBridge, versions.L1StandardBridge); err != nil {
+		return implementations, fmt.Errorf("L1StandardBridge: %w", err)
+	}
+	if implementations.L2OutputOracle, err = resolve(c.L2OutputOracle, versions.L2OutputOracle); err != nil {
+		return implementations, fmt.Errorf("L2OutputOracle: %w", err)
+	}
+	if implementations.OptimismMintableERC20Factory, err = resolve(c.OptimismMintableERC20Factory, versions.OptimismMintableERC20Factory); err != nil {
+		return implementations, fmt.Errorf("OptimismMintableERC20Factory: %w", err)
+	}
+	if implementations.OptimismPortal, err = resolve(c.OptimismPortal, versions.OptimismPortal); err != nil {
+		return implementations, fmt.Errorf("OptimismPortal: %w", err)
+	}
+	if implementations.SystemConfig, err = resolve(c.SystemConfig, versions.SystemConfig); err != nil {
+		return implementations, fmt.Errorf("SystemConfig: %w", err)
+	}
+	return implementations, nil
+}
+
+// resolve returns a VersionedContract that matches the passed in semver version
+// given a set of addresses.
+func resolve(set AddressSet, version string) (VersionedContract, error) {
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+
+	var out VersionedContract
+	keys := set.Versions()
+	if len(keys) == 0 {
+		return out, fmt.Errorf("no implementations found")
+	}
+
+	for _, k := range keys {
+		res := semver.Compare(k, version)
+		if res >= 0 {
+			out = VersionedContract{
+				Version: k,
+				Address: set.Get(k),
+			}
+		}
+	}
+	if out == (VersionedContract{}) {
+		return out, fmt.Errorf("cannot resolve semver")
+	}
+	return out, nil
 }
 
 // ContractVersions represents the desired semantic version of the contracts
@@ -120,41 +228,64 @@ func (c ContractVersions) Check() error {
 	return nil
 }
 
-// NewContractImplementations returns a new empty ContractImplementations.
+// newContractImplementations returns a new empty ContractImplementations.
 // Use this constructor to ensure that none of struct fields are nil.
-// The path argument is relative to the embedded fs that contains the implementations.
-func NewContractImplementations(path string) (ContractImplementations, error) {
+// It will also merge the local network implementations into the global implementations
+// because the global implementations were deployed with create2 and therefore should
+// be on every network.
+func newContractImplementations(network string) (ContractImplementations, error) {
+	var globals ContractImplementations
+	globalData, err := implementationsFS.ReadFile(path.Join("implementations", "implementations.yaml"))
+	if err != nil {
+		return globals, fmt.Errorf("failed to read implementations: %w", err)
+	}
+	if err := yaml.Unmarshal(globalData, &globals); err != nil {
+		return globals, fmt.Errorf("failed to decode implementations: %w", err)
+	}
+	setAddressSetsIfNil(&globals)
+	if network == "" {
+		return globals, nil
+	}
+
+	filepath := path.Join("implementations", "networks", network+".yaml")
 	var impls ContractImplementations
-	data, err := implementationsFS.ReadFile(path)
+	data, err := implementationsFS.ReadFile(filepath)
 	if err != nil {
 		return impls, fmt.Errorf("failed to read implementations: %w", err)
 	}
 	if err := yaml.Unmarshal(data, &impls); err != nil {
 		return impls, fmt.Errorf("failed to decode implementations: %w", err)
 	}
+	setAddressSetsIfNil(&impls)
+	globals.Merge(impls)
 
+	return globals, nil
+}
+
+// setAddressSetsIfNil will ensure that all of the struct values on a
+// ContractImplementations struct are non nil.
+func setAddressSetsIfNil(impls *ContractImplementations) {
 	if impls.L1CrossDomainMessenger == nil {
-		impls.L1CrossDomainMessenger = make(map[string]Address)
+		impls.L1CrossDomainMessenger = make(AddressSet)
 	}
 	if impls.L1ERC721Bridge == nil {
-		impls.L1ERC721Bridge = make(map[string]Address)
+		impls.L1ERC721Bridge = make(AddressSet)
 	}
 	if impls.L1StandardBridge == nil {
-		impls.L1StandardBridge = make(map[string]Address)
+		impls.L1StandardBridge = make(AddressSet)
 	}
 	if impls.L2OutputOracle == nil {
-		impls.L2OutputOracle = make(map[string]Address)
+		impls.L2OutputOracle = make(AddressSet)
 	}
 	if impls.OptimismMintableERC20Factory == nil {
-		impls.OptimismMintableERC20Factory = make(map[string]Address)
+		impls.OptimismMintableERC20Factory = make(AddressSet)
 	}
 	if impls.OptimismPortal == nil {
-		impls.OptimismPortal = make(map[string]Address)
+		impls.OptimismPortal = make(AddressSet)
 	}
 	if impls.SystemConfig == nil {
-		impls.SystemConfig = make(map[string]Address)
+		impls.SystemConfig = make(AddressSet)
 	}
-	return impls, nil
 }
 
 // copySemverMap is a concrete implementation of maps.Copy for map[string]Address.
@@ -262,15 +393,9 @@ var SuperchainSemver = ContractVersions{}
 
 func init() {
 	var err error
-	SuperchainSemver, err = NewContractVersions()
+	SuperchainSemver, err = newContractVersions()
 	if err != nil {
 		panic(fmt.Errorf("failed to read semver.yaml: %w", err))
-	}
-
-	// read the global implementations
-	globalImpls, err := NewContractImplementations(path.Join("implementations", "implementations.yaml"))
-	if err != nil {
-		panic(fmt.Errorf("failed to read implementations: %w", err))
 	}
 
 	superchainTargets, err := superchainFS.ReadDir("configs")
@@ -350,22 +475,18 @@ func init() {
 
 		Superchains[superchainEntry.Superchain] = &superchainEntry
 
-		networkImpls, err := NewContractImplementations(path.Join("implementations", "networks", s.Name()+".yaml"))
+		implementations, err := newContractImplementations(s.Name())
 		if err != nil {
 			panic(fmt.Errorf("failed to read implementations of superchain target %s: %w", s.Name(), err))
 		}
 
-		implementations := globalImpls.Copy()
-		implementations.Merge(networkImpls)
-
-		chainID := superchainEntry.Config.L1.ChainID
-		Implementations[chainID] = implementations
+		Implementations[superchainEntry.Config.L1.ChainID] = implementations
 	}
 }
 
-// NewContractVersions will read the contract versions from semver.yaml
+// newContractVersions will read the contract versions from semver.yaml
 // and check to make sure that it is valid.
-func NewContractVersions() (ContractVersions, error) {
+func newContractVersions() (ContractVersions, error) {
 	var versions ContractVersions
 	semvers, err := semverFS.ReadFile("semver.yaml")
 	if err != nil {

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -389,7 +389,7 @@ var GenesisSystemConfigs = map[uint64]*GenesisSystemConfig{}
 var Implementations = map[uint64]ContractImplementations{}
 
 // SuperchainSemver represents a global mapping of contract name to desired semver version.
-var SuperchainSemver = ContractVersions{}
+var SuperchainSemver ContractVersions
 
 func init() {
 	var err error

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -213,14 +213,6 @@ var GenesisSystemConfigs = map[uint64]*GenesisSystemConfig{}
 
 var Implementations = map[uint64]ContractImplementations{}
 
-// networkToChainID maps a network name to a chain ID. Only the superchain targets
-// are required to be in this mapping
-var networkToChainID = map[string]uint64{
-	"mainnet": 1,
-	"goerli":  5,
-	"sepolia": 11155111,
-}
-
 func init() {
 	// read the global implementations
 	globalImpls, err := NewContractImplementations(path.Join("implementations", "implementations.yaml"))
@@ -313,11 +305,7 @@ func init() {
 		implementations := globalImpls.Copy()
 		implementations.Merge(networkImpls)
 
-		// Add the implementations to the global mapping
-		chainID, ok := networkToChainID[s.Name()]
-		if !ok {
-			panic(fmt.Errorf("chain id unknown for network %q", s.Name()))
-		}
+		chainID := superchainEntry.Config.L1.ChainID
 		Implementations[chainID] = implementations
 	}
 }

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -84,3 +84,11 @@ func TestContractImplementations(t *testing.T) {
 		t.Fatal("wrong SystemConfig address")
 	}
 }
+
+// TestContractVersions will fail if the superchain semver file
+// is not read correctly.
+func TestContractVersions(t *testing.T) {
+	if err := SuperchainSemver.Check(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -1,7 +1,6 @@
 package superchain
 
 import (
-	"path"
 	"testing"
 )
 
@@ -58,37 +57,174 @@ func TestImplementations(t *testing.T) {
 // TestContractImplementations tests specific contracts implementations are set
 // correctly.
 func TestContractImplementations(t *testing.T) {
-	impls, err := NewContractImplementations(path.Join("implementations", "implementations.yaml"))
+	impls, err := newContractImplementations("")
 	if err != nil {
 		t.Fatalf("failed to load contract implementations: %v", err)
 	}
-	if impls.L1CrossDomainMessenger["1.6.0"] != HexToAddress("0xf4d5682dA3ad1820ea83E1cEE5Fd92a3A7BabC30") {
+	if impls.L1CrossDomainMessenger.Get("1.6.0") != HexToAddress("0xf4d5682dA3ad1820ea83E1cEE5Fd92a3A7BabC30") {
 		t.Fatal("wrong L1CrossDomainMessenger address")
 	}
-	if impls.L1ERC721Bridge["1.3.0"] != HexToAddress("0x8ADd7FB53A242e827373519d260EE3B8F7612Ba1") {
+	if impls.L1ERC721Bridge.Get("1.3.0") != HexToAddress("0x8ADd7FB53A242e827373519d260EE3B8F7612Ba1") {
 		t.Fatal("wrong L1ERC721Bridge address")
 	}
-	if impls.L1StandardBridge["1.3.0"] != HexToAddress("0x9c540e769B9453d174EdB683a90D9170e6559F16") {
+	if impls.L1StandardBridge.Get("1.3.0") != HexToAddress("0x9c540e769B9453d174EdB683a90D9170e6559F16") {
 		t.Fatal("wrong L1StandardBridge address")
 	}
-	if impls.L2OutputOracle["1.5.0"] != HexToAddress("0x7a811C9862ab54E677EEdA7e6F075aC86a1f551e") {
+	if impls.L2OutputOracle.Get("1.5.0") != HexToAddress("0x7a811C9862ab54E677EEdA7e6F075aC86a1f551e") {
 		t.Fatal("wrong L2OutputOracle address")
 	}
-	if impls.OptimismMintableERC20Factory["1.4.0"] != HexToAddress("0x135B9097A0e1e56190251c62f111B676Fb4Ec494") {
+	if impls.OptimismMintableERC20Factory.Get("1.4.0") != HexToAddress("0x135B9097A0e1e56190251c62f111B676Fb4Ec494") {
 		t.Fatal("wrong OptimismMintableERC20 address")
 	}
-	if impls.OptimismPortal["1.9.0"] != HexToAddress("0x8Cfa294bD0c6F63cD65d492bdB754eAcf684D871") {
+	if impls.OptimismPortal.Get("1.9.0") != HexToAddress("0x8Cfa294bD0c6F63cD65d492bdB754eAcf684D871") {
 		t.Fatal("wrong OptimismPortal address")
 	}
-	if impls.SystemConfig["1.7.0"] != HexToAddress("0x09323D05868393c7EBa8190BAc173f843b82030a") {
+	if impls.SystemConfig.Get("1.7.0") != HexToAddress("0x09323D05868393c7EBa8190BAc173f843b82030a") {
 		t.Fatal("wrong SystemConfig address")
 	}
 }
 
-// TestContractVersions will fail if the superchain semver file
+// TestContractVersionsCheck will fail if the superchain semver file
 // is not read correctly.
-func TestContractVersions(t *testing.T) {
+func TestContractVersionsCheck(t *testing.T) {
 	if err := SuperchainSemver.Check(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestContractVersionsResolve will test that the high lever interface used works.
+func TestContractVersionsResolve(t *testing.T) {
+	impls, err := newContractImplementations("goerli")
+	if err != nil {
+		t.Fatalf("failed to load contract implementations: %v", err)
+	}
+
+	if impls.L1CrossDomainMessenger.Get("1.6.0") == (Address{}) {
+		t.Fatal("wrong L1CrossDomainMessenger address")
+	}
+	if impls.L1ERC721Bridge.Get("1.3.0") == (Address{}) {
+		t.Fatal("wrong L1ERC721Bridge address")
+	}
+	if impls.L1StandardBridge.Get("1.3.0") == (Address{}) {
+		t.Fatal("wrong L1StandardBridge address")
+	}
+	if impls.L2OutputOracle.Get("1.5.0") == (Address{}) {
+		t.Fatal("wrong L2OutputOracle address")
+	}
+	if impls.OptimismMintableERC20Factory.Get("1.4.0") == (Address{}) {
+		t.Fatal("wrong OptimismMintableERC20 address")
+	}
+	if impls.OptimismPortal.Get("1.9.0") == (Address{}) {
+		t.Fatal("wrong OptimismPortal address")
+	}
+	if impls.SystemConfig.Get("1.7.0") == (Address{}) {
+		t.Fatal("wrong SystemConfig address")
+	}
+
+	versions := ContractVersions{
+		L1CrossDomainMessenger:       "1.6.0",
+		L1ERC721Bridge:               "1.3.0",
+		L1StandardBridge:             "1.3.0",
+		L2OutputOracle:               "1.5.0",
+		OptimismMintableERC20Factory: "1.4.0",
+		OptimismPortal:               "1.9.0",
+		SystemConfig:                 "1.7.0",
+	}
+
+	list, err := impls.Resolve(versions)
+	if err != nil {
+		t.Fatalf("unable to resolve: %s", err)
+	}
+
+	if list.L1CrossDomainMessenger.Version != "v1.6.0" {
+		t.Fatalf("wrong L1CrossDomainMessenger version: %s", list.L1CrossDomainMessenger.Version)
+	}
+	if list.L1ERC721Bridge.Version != "v1.3.0" {
+		t.Fatalf("wrong L1ERC721Bridge version: %s", list.L1ERC721Bridge.Version)
+	}
+	if list.L1StandardBridge.Version != "v1.3.0" {
+		t.Fatalf("wrong L1StandardBridge version: %s", list.L1StandardBridge.Version)
+	}
+	if list.L2OutputOracle.Version != "v1.5.0" {
+		t.Fatalf("wrong L2OutputOracle version: %s", list.L2OutputOracle.Version)
+	}
+	if list.OptimismMintableERC20Factory.Version != "v1.4.0" {
+		t.Fatalf("wrong OptimismMintableERC20Factory version: %s", list.OptimismMintableERC20Factory.Version)
+	}
+	if list.OptimismPortal.Version != "v1.9.0" {
+		t.Fatalf("wrong OptimismPortal version: %s", list.OptimismPortal.Version)
+	}
+	if list.SystemConfig.Version != "v1.7.0" {
+		t.Fatalf("wrong SystemConfig version: %s", list.SystemConfig.Version)
+	}
+}
+
+// TestResolve ensures that the low level resolve function works on semantic
+// versioning correctly. It will return the highest version that matches the
+// given semver string.
+func TestResolve(t *testing.T) {
+	cases := []struct {
+		name    string
+		set     AddressSet
+		version string
+		expect  string
+	}{
+		{
+			name: "exact",
+			set: AddressSet{
+				"v1.0.0": HexToAddress("0x123"),
+			},
+			version: "v1.0.0",
+			expect:  "v1.0.0",
+		},
+		{
+			name: "largest-minor",
+			set: AddressSet{
+				"v1.2.0": HexToAddress("0x123"),
+				"v1.1.0": HexToAddress("0x234"),
+			},
+			version: "^1.0.0",
+			expect:  "v1.2.0",
+		},
+		{
+			name: "largest-patch",
+			set: AddressSet{
+				"v1.0.2": HexToAddress("0x123"),
+				"v1.0.1": HexToAddress("0x234"),
+			},
+			version: "^1.0.0",
+			expect:  "v1.0.2",
+		},
+		{
+			name: "x-patch",
+			set: AddressSet{
+				"v3.0.5": HexToAddress("0x123"),
+				"v3.0.2": HexToAddress("0x234"),
+			},
+			version: "v3.0.x",
+			expect:  "v3.0.5",
+		},
+		{
+			name: "x-minor",
+			set: AddressSet{
+				"v2.5.1": HexToAddress("0x456"),
+				"v2.5.0": HexToAddress("0x123"),
+				"v2.2.2": HexToAddress("0x234"),
+			},
+			version: "v2.x",
+			expect:  "v2.5.1",
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			resolved, err := resolve(test.set, test.version)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resolved.Version != test.expect {
+				t.Fatalf("wrong version: %s", resolved.Version)
+			}
+		})
 	}
 }

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -228,3 +228,26 @@ func TestResolve(t *testing.T) {
 		})
 	}
 }
+
+// TestAddressSet ensures that the AddressSet.Get method works with
+// both the "v" prefix and without the "v" prefix.
+func TestAddressSet(t *testing.T) {
+	set := AddressSet{
+		"v1.0.0": HexToAddress("0x123"),
+		"1.1.0":  HexToAddress("0x234"),
+	}
+
+	if set.Get("v1.0.0") != HexToAddress("0x123") {
+		t.Fatal("wrong address")
+	}
+	if set.Get("1.0.0") != HexToAddress("0x123") {
+		t.Fatal("wrong address")
+	}
+
+	if set.Get("v1.1.0") != HexToAddress("0x234") {
+		t.Fatal("wrong address")
+	}
+	if set.Get("1.1.0") != HexToAddress("0x234") {
+		t.Fatal("wrong address")
+	}
+}

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -1,11 +1,14 @@
 package superchain
 
-import "testing"
+import (
+	"path"
+	"testing"
+)
 
 func TestConfigs(t *testing.T) {
 	n := 0
 	for name, sch := range Superchains {
-		if name != sch.Config.Name {
+		if name != sch.Superchain {
 			t.Errorf("superchain %q has bad key", name)
 		}
 		n += len(sch.ChainIDs)
@@ -41,5 +44,43 @@ func TestGenesis(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to load genesis of chain %d: %v", id, err)
 		}
+	}
+}
+
+// TestImplementations ensures that the global Implementations
+// map is populated.
+func TestImplementations(t *testing.T) {
+	if len(Implementations) == 0 {
+		t.Fatal("no implementations found")
+	}
+}
+
+// TestContractImplementations tests specific contracts implementations are set
+// correctly.
+func TestContractImplementations(t *testing.T) {
+	impls, err := NewContractImplementations(path.Join("implementations", "implementations.yaml"))
+	if err != nil {
+		t.Fatalf("failed to load contract implementations: %v", err)
+	}
+	if impls.L1CrossDomainMessenger["1.6.0"] != HexToAddress("0xf4d5682dA3ad1820ea83E1cEE5Fd92a3A7BabC30") {
+		t.Fatal("wrong L1CrossDomainMessenger address")
+	}
+	if impls.L1ERC721Bridge["1.3.0"] != HexToAddress("0x8ADd7FB53A242e827373519d260EE3B8F7612Ba1") {
+		t.Fatal("wrong L1ERC721Bridge address")
+	}
+	if impls.L1StandardBridge["1.3.0"] != HexToAddress("0x9c540e769B9453d174EdB683a90D9170e6559F16") {
+		t.Fatal("wrong L1StandardBridge address")
+	}
+	if impls.L2OutputOracle["1.5.0"] != HexToAddress("0x7a811C9862ab54E677EEdA7e6F075aC86a1f551e") {
+		t.Fatal("wrong L2OutputOracle address")
+	}
+	if impls.OptimismMintableERC20Factory["1.4.0"] != HexToAddress("0x135B9097A0e1e56190251c62f111B676Fb4Ec494") {
+		t.Fatal("wrong OptimismMintableERC20 address")
+	}
+	if impls.OptimismPortal["1.9.0"] != HexToAddress("0x8Cfa294bD0c6F63cD65d492bdB754eAcf684D871") {
+		t.Fatal("wrong OptimismPortal address")
+	}
+	if impls.SystemConfig["1.7.0"] != HexToAddress("0x09323D05868393c7EBa8190BAc173f843b82030a") {
+		t.Fatal("wrong SystemConfig address")
 	}
 }

--- a/superchain/util.go
+++ b/superchain/util.go
@@ -23,6 +23,12 @@ func (b Address) String() string {
 	return encodeHex(b[:])
 }
 
+func HexToAddress(s string) Address {
+	var a Address
+	_ = a.UnmarshalText([]byte(s))
+	return a
+}
+
 type Hash [32]byte
 
 func has0xPrefix(text []byte) bool {


### PR DESCRIPTION
**Description**

Adds a concept of the contract implementations. yaml files that include the semantic version to address exist for each network as well as a global file for implementations that are deployed with create2. The network specific config is merged into the global config, so that contract addresses specific to a network will override the globals. This will be the canonical list of contract addresses for implementations going forward and will be used by the bundler tool to build upgrade transactions.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

