### PR TITLE
op-labs-devnet-0: fix extra addresses

### DIFF
--- a/superchain/extra/addresses/goerli-dev-0/op-labs-devnet-0.json
+++ b/superchain/extra/addresses/goerli-dev-0/op-labs-devnet-0.json
@@ -1,10 +1,10 @@
 {
-  "AddressManager": "0x134a277D48C96CaeC0dBBD3893A05F6d1FBbCd4C",
-  "L1CrossDomainMessengerProxy": "0x71A046D793C71af209960DCb8bD5388d2c5D2a78",
-  "L1ERC721BridgeProxy": "0x60e0f047FfA2Fad2AF197c9CDb404bDF47277Ed4",
-  "L1StandardBridgeProxy": "0x791590936abB3531c9d54CD10CEC4B14415B0Ba7",
-  "L2OutputOracleProxy": "0xA57B9f15AA204b9D68DF58849b02Df16c80C0999",
-  "OptimismMintableERC20FactoryProxy": "0x2998dDaF6AaA00Fa8A7104214688d29Bc749B78F",
-  "OptimismPortalProxy": "0x83a242F8481D4F8a605Aa82BA9D42BA574054258",
-  "ProxyAdmin": "0x3A36fDcA4304040690d9387B4b84666B3626E281"
+  "AddressManager": "0xf3a31b72d030e1916afeb3abba90e7e104818b9b",
+  "L1CrossDomainMessengerProxy": "0x12371d047382bb3a4b1891e8474ddaee983d08ec",
+  "L1ERC721BridgeProxy": "0xab598ffd07bdf497fce58e36138573ccba6b7a8b",
+  "L1StandardBridgeProxy": "0x0178b1f72eb1e61e1847f8fd36c791822623fb42",
+  "L2OutputOracleProxy": "0xddb2e0c86ae08f1249d528f1a810cebd1b4c4d72",
+  "OptimismMintableERC20FactoryProxy": "0x00b75ed2e46c4c29bc363a75a6d97791018b3903",
+  "OptimismPortalProxy": "0xc6170e048b7daef6d0b6cbbad9aca0e5370ddbbc",
+  "ProxyAdmin": "0xD98bD7a1F2384D890d0D6153Cb6F813ab6cCFcCF"
 }


### PR DESCRIPTION
**Description**

The devnet was rerolled end May, but the deployment artifacts in the monorepo were outdated. This corrects the addresses to match the current set of Goerli L1 contracts used by the devnet.

