### PR TITLE
configs: Add ProtocolVersions address to Goerli superchain

### DIFF
--- a/superchain/configs/goerli/superchain.yaml
+++ b/superchain/configs/goerli/superchain.yaml
@@ -4,4 +4,4 @@ l1:
   public_rpc: https://ethereum-goerli-rpc.allthatnode.com
   explorer: https://goerli.etherscan.io
 
-protocol_versions_addr: null # todo
+protocol_versions_addr: "0x0C24F5098774aA366827D667494e9F889f7cFc08"


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds `ProtocolVersions` proxy address to Goerli superchain config. Deployment added to monorepo in https://github.com/ethereum-optimism/optimism/pull/7345
