### PR TITLE
superchain: test bytecodes loading/hashes & bump to Go 1.20

### DIFF
--- a/superchain/go.mod
+++ b/superchain/go.mod
@@ -1,9 +1,12 @@
 module github.com/ethereum-optimism/superchain-registry/superchain
 
-go 1.19
+go 1.20
 
 require (
+	golang.org/x/crypto v0.13.0
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/mod v0.12.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+require golang.org/x/sys v0.12.0 // indirect

--- a/superchain/go.sum
+++ b/superchain/go.sum
@@ -1,7 +1,11 @@
+golang.org/x/crypto v0.13.0 h1:mvySKfSWJ+UKUii46M40LOvyWfN0s2U+46/jDd0e6Ck=
+golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/superchain/util.go
+++ b/superchain/util.go
@@ -4,6 +4,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+
+	"golang.org/x/crypto/sha3"
 )
 
 // Util-types for hex-encoding/decoding.
@@ -109,4 +111,10 @@ func (b HexBig) String() string {
 
 func (b *HexBig) UnmarshalText(text []byte) error {
 	return (*big.Int)(b).UnmarshalText(text)
+}
+
+func keccak256(v []byte) Hash {
+	st := sha3.NewLegacyKeccak256()
+	st.Write(v)
+	return *(*[32]byte)(st.Sum(nil))
 }


### PR DESCRIPTION
**Description**

- Bump to Go 1.20
- Add `golang.org/x/crypto` dependency to do keccak256 hashes for tests
- Test that all bytecodes correctly load and hash to the expected hash

