### PR TITLE
chore: Add .circleci to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@
 
 # Configs / build system
 /.github @protolambda
+/.circleci @protolambda
 
 # Go bindings
 /superchain.go @protolambda


### PR DESCRIPTION
I was copying over configs to a new repo and noticed this was missing
