### PR TITLE
implementations: add mainnet deployment

### DIFF
--- a/superchain/implementations/networks/mainnet.yaml
+++ b/superchain/implementations/networks/mainnet.yaml
@@ -2,6 +2,7 @@ l1_cross_domain_messenger:
 l1_erc721_bridge:
 l1_standard_bridge:
 l2_output_oracle:
+  1.6.0: 0xB48B1827BC7218b1aB7B000b4f0416DF8F14B16A
 optimism_mintable_erc20_factory:
 optimism_portal:
 system_config:


### PR DESCRIPTION
**Description**

The `L2OutputOracle` has constructor arguments that cause the create2 address to be different than the other networks. The other addresses are the same and are all verified on etherscan.

See https://github.com/ethereum-optimism/optimism/pull/7607 for the artifacts.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

