### PR TITLE
Activate Canyon on Sepolia & Goerli testnets

### DIFF
--- a/superchain/configs/goerli/superchain.yaml
+++ b/superchain/configs/goerli/superchain.yaml
@@ -5,3 +5,4 @@ l1:
   explorer: https://goerli.etherscan.io
 
 protocol_versions_addr: "0x0C24F5098774aA366827D667494e9F889f7cFc08"
+canyon_time: 1699981200

--- a/superchain/configs/sepolia/superchain.yaml
+++ b/superchain/configs/sepolia/superchain.yaml
@@ -5,3 +5,4 @@ l1:
   explorer: https://sepolia.etherscan.io
 
 protocol_versions_addr: "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
+canyon_time: 1699981200


### PR DESCRIPTION
**Description**

Unix timestamp is 1699981200 which is Tue Nov 14 09:00:00 PST 2023 or Tue Nov 14 17:00:00 UTC 2023.

