### PR TITLE
superchain: make delta hardfork configurable & schedule devnet upgrade

### DIFF
--- a/superchain/configs/goerli-dev-0/superchain.yaml
+++ b/superchain/configs/goerli-dev-0/superchain.yaml
@@ -5,4 +5,5 @@ l1:
   explorer: https://goerli.etherscan.io
 
 protocol_versions_addr: "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
-canyon_time: 1698436800
+canyon_time: 1698436800 # October 27, 2023 8:00:00 PM UTC
+delta_time: 1701993600 # December 8, 2023 12:00:00 AM UTC, i.e. midnight Dec 7 to Dec 8

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -369,7 +369,10 @@ type SuperchainConfig struct {
 	ProtocolVersionsAddr *Address `yaml:"protocol_versions_addr,omitempty"`
 
 	// Hardfork Configuration
-	CanyonTime *uint64 `yaml:"canyon_time,omitempty"`
+	CanyonTime  *uint64 `yaml:"canyon_time,omitempty"`
+	DeltaTime   *uint64 `yaml:"delta_time,omitempty"`
+	EclipseTime *uint64 `yaml:"eclipse_time,omitempty"`
+	FjordTime   *uint64 `yaml:"fjord_time,omitempty"`
 }
 
 type Superchain struct {


### PR DESCRIPTION
**Description**

This makes the Delta hardfork configurable.

This hardfork is in development, and will later be scheduled for superchain-devnet activation for testing.
