### PR TITLE
Add superchain_config_addr to sepolia

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ l1:
   explorer: https://goerli.etherscan.io
 
 protocol_versions_addr: null # todo
+superchain_config_addr: null # todo
 EOF
 ```
 Superchain-wide configuration, like the `ProtocolVersions` contract address, should be configured here when available.
@@ -127,7 +128,7 @@ The format is a gzipped JSON `genesis.json` file, with either:
   but with `codeHash` (bytes32, `keccak256` hash of contract code) attribute per account,
   instead of the `code` attribute seen in standard Ethereum genesis definitions.
 - a `stateHash` attribute: to omit a large state (e.g. for networks with a re-genesis or migration history).
-  Nodes can load the genesis block header, and state-sync to complete the node initialization. 
+  Nodes can load the genesis block header, and state-sync to complete the node initialization.
 
 ```bash
 # create extra genesis data

--- a/superchain/configs/sepolia/superchain.yaml
+++ b/superchain/configs/sepolia/superchain.yaml
@@ -5,5 +5,6 @@ l1:
   explorer: https://sepolia.etherscan.io
 
 protocol_versions_addr: "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
+superchain_config_addr: "0xc2be75506d5724086deb7245bd260cc9753911be"
 canyon_time: 1699981200 # Tue Nov 14 17:00:00 UTC 2023
 delta_time: 1703203200  # Fri Dec 22 00:00:00 UTC 2023

--- a/superchain/configs/sepolia/superchain.yaml
+++ b/superchain/configs/sepolia/superchain.yaml
@@ -5,6 +5,6 @@ l1:
   explorer: https://sepolia.etherscan.io
 
 protocol_versions_addr: "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
-superchain_config_addr: "0xc2be75506d5724086deb7245bd260cc9753911be"
+superchain_config_addr: "0xC2Be75506d5724086DEB7245bd260Cc9753911Be"
 canyon_time: 1699981200 # Tue Nov 14 17:00:00 UTC 2023
 delta_time: 1703203200  # Fri Dec 22 00:00:00 UTC 2023

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -367,6 +367,7 @@ type SuperchainConfig struct {
 	L1   SuperchainL1Info `yaml:"l1"`
 
 	ProtocolVersionsAddr *Address `yaml:"protocol_versions_addr,omitempty"`
+	SuperchainConfigAddr *Address `yaml:"superchain_config_addr,omitempty"`
 
 	// Hardfork Configuration
 	CanyonTime  *uint64 `yaml:"canyon_time,omitempty"`


### PR DESCRIPTION
Adds the address of the new SuperchainConfig contract to the sepolia superchain.yaml. 

I've followed the lead of the `ProtocolVersions` contract, as it similarly is a singleton per superchain target.