### PR TITLE
Make forge script rpc limit explicit.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,10 @@ jobs:
           name: check security configs
           command: |
             forge build
-            forge script CheckSecurityConfigs --fork-url="https://ci-mainnet-l1.optimism.io"
+            # Note: If RPC is being rate-limited, consider reducing
+            # --compute-units-per-second or using --fork-retries and
+            # --fork-retry-backoff to stay under the limit.
+            forge script CheckSecurityConfigs --fork-url="https://ci-mainnet-l1.optimism.io" --compute-units-per-second=320
 
 workflows:
   main:


### PR DESCRIPTION
We ran into our RPC limit in https://github.com/ethereum-optimism/superchain-registry/pull/44. Devinfra team bumped it. But I'm also adding additional options to the CI configuration so next time we have the flags ready to be tweaked.