### PR TITLE
Rename "Eclipse" to "Ecotone"

### DIFF
--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -372,7 +372,7 @@ type SuperchainConfig struct {
 	// Hardfork Configuration
 	CanyonTime  *uint64 `yaml:"canyon_time,omitempty"`
 	DeltaTime   *uint64 `yaml:"delta_time,omitempty"`
-	EclipseTime *uint64 `yaml:"eclipse_time,omitempty"`
+	EcotoneTime *uint64 `yaml:"ecotone_time,omitempty"`
 	FjordTime   *uint64 `yaml:"fjord_time,omitempty"`
 }
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR simply renames `eclipse` to `ecotone`.

**Additional context**
https://github.com/ethereum-optimism/optimism/issues/8701
