### PR TITLE
Feat/add contracts address manager proxy admin

### DIFF
--- a/superchain/semver.yaml
+++ b/superchain/semver.yaml
@@ -1,3 +1,4 @@
+address_manager: 0.0.0
 l1_cross_domain_messenger: 1.7.0
 l1_erc721_bridge: 1.4.0
 l1_standard_bridge: 1.4.0
@@ -5,3 +6,4 @@ l2_output_oracle: 1.6.0
 optimism_mintable_erc20_factory: 1.6.0
 optimism_portal: 1.10.0
 system_config: 1.10.0
+proxy_admin: 0.0.0

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -192,6 +192,7 @@ func resolve(set AddressSet, version string) (VersionedContract, error) {
 // in the superchain. This currently only supports L1 contracts but could
 // represent L2 predeploys in the future.
 type ContractVersions struct {
+	AddressManager               string `yaml:"address_manager"`
 	L1CrossDomainMessenger       string `yaml:"l1_cross_domain_messenger"`
 	L1ERC721Bridge               string `yaml:"l1_erc721_bridge"`
 	L1StandardBridge             string `yaml:"l1_standard_bridge"`
@@ -199,6 +200,7 @@ type ContractVersions struct {
 	OptimismMintableERC20Factory string `yaml:"optimism_mintable_erc20_factory"`
 	OptimismPortal               string `yaml:"optimism_portal"`
 	SystemConfig                 string `yaml:"system_config"`
+	ProxyAdmin                   string `yaml:"proxy_admin"`
 }
 
 // Check will sanity check the validity of the semantic version strings


### PR DESCRIPTION
addresses https://github.com/ethereum-optimism/optimism/pull/8859#issuecomment-1881663953

**important**: it considers contracts without semver as contracts with a semver version of `0.0.0`, because it sets `0.0.0` as the placeholder for the two new contracts added to `ContractVersions` (`AddressManager` & `ProxyAdmin`).