### PR TITLE
testing: Double check that there are no duplicated chain IDs

### DIFF
--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -37,10 +37,9 @@ func TestChainIds(t *testing.T) {
 					var chainConfig ChainConfig
 					if config.Name() == "superchain.yaml" {
 						continue
-					} else {
-						checkErr(t, yaml.Unmarshal(configBytes, &chainConfig))
-						storeIfUnique(chainConfig.ChainID)
 					}
+					checkErr(t, yaml.Unmarshal(configBytes, &chainConfig))
+					storeIfUnique(chainConfig.ChainID)
 				}
 			}
 		}


### PR DESCRIPTION
**Description**

Adds a test which checks for duplicate chain IDs in the config YAML files. 

**Tests**

I did a manual mutation test by creating a duplicate chain ID. The package fails to build and therefore the test suite will fail.. If I then break the below check in the package `init` function, the test I added fails. So it serves as a backstop. 

**Additional context**
There is already a mechanism in place which will cause the test suite to fail in the case of duplicated IDs:

https://github.com/ethereum-optimism/superchain-registry/blob/baa49d9c2242562a446254b74c7ebd2d2b5b14ee/superchain/superchain.go#L474-L479

The value of the additional test from this PR, then, is to:
* make this check more explicit and discoverable
* begin to establish a principle where validation is done in a test, rather than in the package `init` function (separation of concerns)
* protect against a regression where the `init` function gets changed in future


