### PR TITLE
chore: change ci-builder version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           command: git diff --exit-code
   check-forge-fmt:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.35.0
     steps:
       - checkout
       - run:
@@ -62,7 +62,7 @@ jobs:
   check-security-configs:
     circleci_ip_ranges: true
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.35.0
     steps:
       - checkout
       - run:


### PR DESCRIPTION


Using this to smoke out any issues with rolling back the ci-builder image version.

---
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

A clear and concise description of the features you're adding in this pull request.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
