### PR TITLE
bump ci builder to 0.40.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           command: git diff --exit-code
   check-forge-fmt:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.35.0
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.40.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
   check-security-configs:
     circleci_ip_ranges: true
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.35.0
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.40.0
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This proposes to bump `ci-builder` to `0.40.0`, which has the latest forge, and should fix the illegal instruction we were seeing yesterday.