### PR TITLE
goerli-dev-0: Set ecotone activation time

### DIFF
--- a/superchain/configs/goerli-dev-0/superchain.yaml
+++ b/superchain/configs/goerli-dev-0/superchain.yaml
@@ -7,3 +7,4 @@ l1:
 protocol_versions_addr: "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
 canyon_time: 1698436800 # October 27, 2023 8:00:00 PM UTC
 delta_time: 1701993600 # December 8, 2023 12:00:00 AM UTC, i.e. midnight Dec 7 to Dec 8
+ecotone_time: 1706126400 # Wed Jan 24 20:00:00 UTC 2024


### PR DESCRIPTION
**Description**

unix time: 1706126400
Wed Jan 24 20:00:00 UTC 2024

**Tests**

n/a

**Additional context**

devnet activation tomorrow

**Metadata**

- Fixes https://github.com/ethereum-optimism/protocol-quest/issues/104
