### PR TITLE
chore: update `goerli-dev-0` `semver.yaml` file

### DIFF
--- a/superchain/configs/goerli-dev-0/semver.yaml
+++ b/superchain/configs/goerli-dev-0/semver.yaml
@@ -1,7 +1,7 @@
-l1_cross_domain_messenger: 1.7.0
-l1_erc721_bridge: 1.4.0
-l1_standard_bridge: 1.4.0
-l2_output_oracle: 1.6.0
-optimism_mintable_erc20_factory: 1.6.0
-optimism_portal: 1.10.0
-system_config: 1.10.0
+l1_cross_domain_messenger: 1.1.0
+l1_erc721_bridge: 1.1.0
+l1_standard_bridge: 1.1.0
+l2_output_oracle: 1.2.0
+optimism_mintable_erc20_factory: 1.1.0
+optimism_portal: 1.2.0
+system_config: 1.0.1


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Follows on from #63, which didn't include this superchain due to a problem with `op-version-check`. I used a patched version of `op-version-check` from here https://github.com/ethereum-optimism/optimism/pull/9203, and ran it against `goerli-dev-0/op-labs-devnet-0` to get these versions.

**Tests**

**Additional context**

Towards https://github.com/ethereum-optimism/client-pod/issues/485 
