### PR TITLE
feat: add `ProtocolVersions` to list of contract addresses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ EOF
 Superchain-wide configuration, like the `ProtocolVersions` contract address, should be configured here when available.
 
 ### Approved contract versions
-Each superchain target should have a `semver.yaml` file in the same directory declaing the approved contract semantic versions for that superchain, e.g: 
+Each superchain target should have a `semver.yaml` file in the same directory declaring the approved contract semantic versions for that superchain, e.g: 
 ```yaml
 l1_cross_domain_messenger: 1.4.0
 l1_erc721_bridge: 1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,21 @@ EOF
 ```
 Superchain-wide configuration, like the `ProtocolVersions` contract address, should be configured here when available.
 
+### Approved contract versions
+Each superchain target should have a `semver.yaml` file in the same directory declaing the approved contract semantic versions for that superchain, e.g: 
+```yaml
+l1_cross_domain_messenger: 1.4.0
+l1_erc721_bridge: 1.0.0
+l1_standard_bridge: 1.1.0
+l2_output_oracle: 1.3.0
+optimism_mintable_erc20_factory: 1.1.0
+optimism_portal: 1.6.0
+system_config: 1.3.0
+
+# superchain-wide contracts
+protocol_versions: 1.0.0
+```
+
 ### `implementations`
 
 Per superchain a set of canonical implementation deployments, per semver version, is tracked.

--- a/superchain/configs/goerli-dev-0/semver.yaml
+++ b/superchain/configs/goerli-dev-0/semver.yaml
@@ -7,4 +7,4 @@ optimism_portal: 1.2.0
 system_config: 1.0.1
 
 # superchain-wide contracts
-protocol_versions:
+protocol_versions: 0.1.0

--- a/superchain/configs/goerli-dev-0/semver.yaml
+++ b/superchain/configs/goerli-dev-0/semver.yaml
@@ -5,3 +5,6 @@ l2_output_oracle: 1.2.0
 optimism_mintable_erc20_factory: 1.1.0
 optimism_portal: 1.2.0
 system_config: 1.0.1
+
+# superchain-wide contracts
+protocol_versions:

--- a/superchain/configs/goerli/semver.yaml
+++ b/superchain/configs/goerli/semver.yaml
@@ -7,4 +7,4 @@ optimism_portal: 1.10.0
 system_config: 1.10.0
 
 # superchain-wide contracts
-protocol_versions:
+protocol_versions: 0.1.0

--- a/superchain/configs/goerli/semver.yaml
+++ b/superchain/configs/goerli/semver.yaml
@@ -5,3 +5,6 @@ l2_output_oracle: 1.6.0
 optimism_mintable_erc20_factory: 1.6.0
 optimism_portal: 1.10.0
 system_config: 1.10.0
+
+# superchain-wide contracts
+protocol_versions:

--- a/superchain/configs/mainnet/semver.yaml
+++ b/superchain/configs/mainnet/semver.yaml
@@ -5,3 +5,6 @@ l2_output_oracle: 1.3.0
 optimism_mintable_erc20_factory: 1.1.0
 optimism_portal: 1.6.0
 system_config: 1.3.0
+
+# superchain-wide contracts
+protocol_versions: 1.0.0

--- a/superchain/configs/sepolia-dev-0/semver.yaml
+++ b/superchain/configs/sepolia-dev-0/semver.yaml
@@ -7,4 +7,4 @@ optimism_portal: 1.9.0
 system_config: 1.7.0
 
 # superchain-wide contracts
-protocol_versions:
+protocol_versions: 1.0.0

--- a/superchain/configs/sepolia-dev-0/semver.yaml
+++ b/superchain/configs/sepolia-dev-0/semver.yaml
@@ -5,3 +5,6 @@ l2_output_oracle: 1.5.0
 optimism_mintable_erc20_factory: 1.4.0
 optimism_portal: 1.9.0
 system_config: 1.7.0
+
+# superchain-wide contracts
+protocol_versions:

--- a/superchain/configs/sepolia/semver.yaml
+++ b/superchain/configs/sepolia/semver.yaml
@@ -5,3 +5,6 @@ l2_output_oracle: 1.8.0
 optimism_mintable_erc20_factory: 1.9.0
 optimism_portal: 2.5.0
 system_config: 1.12.0
+
+# superchain-wide contracts
+protocol_versions:

--- a/superchain/configs/sepolia/semver.yaml
+++ b/superchain/configs/sepolia/semver.yaml
@@ -7,4 +7,4 @@ optimism_portal: 2.5.0
 system_config: 1.12.0
 
 # superchain-wide contracts
-protocol_versions:
+protocol_versions: 1.0.0

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -255,6 +255,8 @@ func (c ContractVersions) VersionFor(contractName string) (string, error) {
 		version = c.OptimismPortal
 	case "SystemConfig":
 		version = c.SystemConfig
+	case "ProtocolVersions":
+		version = c.ProtocolVersions
 	default:
 		return "", errors.New("no such contract name")
 	}

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -232,6 +232,8 @@ type ContractVersions struct {
 	OptimismMintableERC20Factory string `yaml:"optimism_mintable_erc20_factory"`
 	OptimismPortal               string `yaml:"optimism_portal"`
 	SystemConfig                 string `yaml:"system_config"`
+	// Superchain-wide contracts:
+	ProtocolVersions string `yaml:"protocol_versions"`
 }
 
 // VersionFor returns the version for the supplied contract name, if it exits

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -16,6 +16,12 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
+func TestSuperchainWideContractVersions(t *testing.T) {
+	t.Log("TODO: factor out version checking from sibling test")
+	t.Log("TODO: loop over superchains")
+	t.Log("TODO: getVersion and check against semver.yaml")
+}
+
 // TestContractVersions will check that
 //   - for each chain in OPChain
 //   - for each declared contract "Foo" : version entry in the corresponding superchain's semver.yaml

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -20,13 +20,6 @@ var isSemverAcceptable = func(desired, actual string) bool {
 	return desired == actual
 }
 
-// TestSuperchainWideContractVersions will check that
-//   - for each superchain
-//   - for each declared superchain-wide contract "Foo" : version entry in the corresponding superchain's semver.yaml
-//   - the superchain has a contract Foo deployed (at an address declared in superchain.yaml) at the same version
-//
-// Actual semvers are
-// read from the L1 chain RPC provider for the superchain in question.
 func TestSuperchainWideContractVersions(t *testing.T) {
 	for name, superchain := range Superchains {
 		rpcEndpoint := superchain.Config.L1.PublicRPC
@@ -59,13 +52,6 @@ func TestSuperchainWideContractVersions(t *testing.T) {
 	}
 }
 
-// TestContractVersions will check that
-//   - for each chain in OPChain
-//   - for each declared chain-specific contract "Foo" : version entry in the corresponding superchain's semver.yaml
-//   - the chain has a contract FooProxy deployed at the same version
-//
-// Actual semvers are
-// read from the L1 chain RPC provider for the chain in question.
 func TestContractVersions(t *testing.T) {
 	isExcluded := map[uint64]bool{
 		291:          true,

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -39,20 +39,10 @@ func TestSuperchainWideContractVersions(t *testing.T) {
 			client, err := ethclient.Dial(rpcEndpoint)
 			require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
 
-			contractNames := []string{
-				"ProtocolVersions",
-			}
+			desiredSemver, err := SuperchainSemver[superchainName].VersionFor("ProtocolVersions")
+			require.NoError(t, err)
+			checkSemverForContract(t, "ProtocolVersions", superchain.Config.ProtocolVersionsAddr, client, desiredSemver)
 
-			for _, contractName := range contractNames {
-				var contractAddress *Address
-				switch contractName {
-				case "ProtocolVersions":
-					contractAddress = superchain.Config.ProtocolVersionsAddr
-				}
-				desiredSemver, err := SuperchainSemver[superchainName].VersionFor(contractName)
-				require.NoError(t, err)
-				checkSemverForContract(t, contractName, contractAddress, client, desiredSemver)
-			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* Adds another `contract name: version` entry to the list of declared contract versions (per superchain)
* Adds a test which verifies that the superchain-wide contract `protocol_versions` (address declared in `superchain.yaml`) has the version declared above.

The value of this check is that:

1. The package now exposes the `ProtocolVersions` version under `SuperchainSemver` (along with existing contract versions). 
2. any new superchain being added to the repo will be checked to ensure that the following lines are consistent:

https://github.com/ethereum-optimism/superchain-registry/blob/afa2460347b5278ea2e1b642e915879f57cbfddf/superchain/configs/mainnet/superchain.yaml#L7

https://github.com/ethereum-optimism/superchain-registry/blob/b5cde4101cd1952a04636ea9d1a63771071bb703/superchain/configs/mainnet/semver.yaml#L10

**Additional context**

* I pulled the versions for existing superchains from etherscan
* I have written the test in a way which anticipates more superchain wide contracts being added in future (e.g. `SuperchainConfig`

**Metadata**

- Towards https://github.com/ethereum-optimism/client-pod/issues/485
