### PR TITLE
test: add TestResourceConfig

### DIFF
--- a/superchain/params.go
+++ b/superchain/params.go
@@ -1,0 +1,32 @@
+package superchain
+
+import (
+	"math/big"
+)
+
+var uint128Max, ok = big.NewInt(0).SetString("ffffffffffffffffffffffffffffffff", 16)
+
+func init() {
+	if !ok {
+		panic("cannot construct uint128Max")
+	}
+}
+
+type ResourceConfig struct {
+	MaxResourceLimit            uint32
+	ElasticityMultiplier        uint8
+	BaseFeeMaxChangeDenominator uint8
+	MinimumBaseFee              uint32
+	SystemTxMaxGas              uint32
+	MaximumBaseFee              *big.Int
+}
+
+// OPMainnetResourceConfig describes the resource metering configuration from OP Mainnet
+var OPMainnetResourceConfig = ResourceConfig{
+	MaxResourceLimit:            20000000,
+	ElasticityMultiplier:        10,
+	BaseFeeMaxChangeDenominator: 8,
+	MinimumBaseFee:              1000000000,
+	SystemTxMaxGas:              1000000,
+	MaximumBaseFee:              uint128Max,
+}

--- a/validation/resource-config_test.go
+++ b/validation/resource-config_test.go
@@ -3,7 +3,6 @@ package validation
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
@@ -37,23 +36,10 @@ func TestResourceConfig(t *testing.T) {
 		contractAddress, err := Addresses[chain.ChainID].AddressFor("SystemConfigProxy")
 		require.NoError(t, err)
 
-		uint128Max, ok := new(big.Int).SetString("ffffffffffffffffffffffffffffffff", 16)
-		if !ok {
-			panic("cannot construct uint128Max")
-		}
-		desiredResourceConfig := bindings.ResourceMeteringResourceConfig{
-			MaxResourceLimit:            20000000,
-			ElasticityMultiplier:        10,
-			BaseFeeMaxChangeDenominator: 8,
-			MinimumBaseFee:              1000000000,
-			SystemTxMaxGas:              1000000,
-			MaximumBaseFee:              uint128Max,
-		} // from OP Mainnet
-
 		actualResourceConfig, err := getResourceConfigWithRetries(context.Background(), common.Address(contractAddress), client)
 		require.NoErrorf(t, err, "RPC endpoint %s: %s", rpcEndpoint)
 
-		require.Equal(t, desiredResourceConfig, actualResourceConfig, "resource config unacceptable")
+		require.Equal(t, bindings.ResourceMeteringResourceConfig(OPMainnetResourceConfig), actualResourceConfig, "resource config unacceptable")
 
 		t.Logf("resource metering acceptable")
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds a test to:
* pull resource config from each chain's `SystemConfig` contract, if that address has been specified (test fails if not)
* check these parameters against a "ground truth"

**Metadata**

- Towards https://github.com/ethereum-optimism/client-pod/issues/486 (Task 2)
