### PR TITLE
validation: add checks for `L2OutputOracle` parameters

### DIFF
--- a/superchain/params.go
+++ b/superchain/params.go
@@ -30,3 +30,20 @@ var OPMainnetResourceConfig = ResourceConfig{
 	SystemTxMaxGas:              1000000,
 	MaximumBaseFee:              uint128Max,
 }
+
+type L2OOParams struct {
+	StartingBlockNumber       *big.Int
+	StartingTimestamp         *big.Int
+	SubmissionInterval        *big.Int
+	L2BlockTime               *big.Int
+	FinalizationPeriodSeconds *big.Int
+}
+
+// OPMainnetL2OOParams describes the L2OutputOracle parameters from OP Mainnet
+var OPMainnetL2OOParams = L2OOParams{
+	StartingBlockNumber:       big.NewInt(0),
+	StartingTimestamp:         big.NewInt(1690493568),
+	SubmissionInterval:        big.NewInt(120),
+	L2BlockTime:               big.NewInt(2),
+	FinalizationPeriodSeconds: big.NewInt(12),
+}

--- a/superchain/params.go
+++ b/superchain/params.go
@@ -32,15 +32,51 @@ var OPMainnetResourceConfig = ResourceConfig{
 }
 
 type L2OOParams struct {
-	StartingBlockNumber       *big.Int
-	StartingTimestamp         *big.Int
-	SubmissionInterval        *big.Int
-	L2BlockTime               *big.Int
-	FinalizationPeriodSeconds *big.Int
+	StartingBlockNumber       *big.Int // The number of the first L2 block.
+	StartingTimestamp         *big.Int // The timestamp of the first L2 block.
+	SubmissionInterval        *big.Int // Interval in blocks at which checkpoints must be submitted.
+	L2BlockTime               *big.Int // The time per L2 block, in seconds.
+	FinalizationPeriodSeconds *big.Int // The minimum time (in seconds) that must elapse before a withdrawal can be finalized.
 }
 
 // OPMainnetL2OOParams describes the L2OutputOracle parameters from OP Mainnet
 var OPMainnetL2OOParams = L2OOParams{
+	StartingBlockNumber:       big.NewInt(0),
+	StartingTimestamp:         big.NewInt(1690493568),
+	SubmissionInterval:        big.NewInt(120),
+	L2BlockTime:               big.NewInt(2),
+	FinalizationPeriodSeconds: big.NewInt(12),
+}
+
+// OPGoerliL2OOParams describes the L2OutputOracle parameters from OP Goerli
+var OPGoerliL2OOParams = L2OOParams{
+	StartingBlockNumber:       big.NewInt(4061224),
+	StartingTimestamp:         big.NewInt(1673550516),
+	SubmissionInterval:        big.NewInt(120),
+	L2BlockTime:               big.NewInt(2),
+	FinalizationPeriodSeconds: big.NewInt(12),
+}
+
+// OPGoerliDev0L2OOParams describes the L2OutputOracle parameters from OP Goerli
+var OPGoerliDev0L2OOParams = L2OOParams{
+	StartingBlockNumber:       big.NewInt(0),
+	StartingTimestamp:         big.NewInt(1690493568),
+	SubmissionInterval:        big.NewInt(120),
+	L2BlockTime:               big.NewInt(2),
+	FinalizationPeriodSeconds: big.NewInt(12),
+}
+
+// OPSepoliaL2OOParams describes the L2OutputOracle parameters from OP Goerli
+var OPSepoliaL2OOParams = L2OOParams{
+	StartingBlockNumber:       big.NewInt(0),
+	StartingTimestamp:         big.NewInt(1690493568),
+	SubmissionInterval:        big.NewInt(120),
+	L2BlockTime:               big.NewInt(2),
+	FinalizationPeriodSeconds: big.NewInt(12),
+}
+
+// OPSepoliaDev0L2OOParams describes the L2OutputOracle parameters from OP Goerli
+var OPSepoliaDev0L2OOParams = L2OOParams{
 	StartingBlockNumber:       big.NewInt(0),
 	StartingTimestamp:         big.NewInt(1690493568),
 	SubmissionInterval:        big.NewInt(120),

--- a/superchain/params.go
+++ b/superchain/params.go
@@ -32,8 +32,6 @@ var OPMainnetResourceConfig = ResourceConfig{
 }
 
 type L2OOParams struct {
-	StartingBlockNumber       *big.Int // The number of the first L2 block.
-	StartingTimestamp         *big.Int // The timestamp of the first L2 block.
 	SubmissionInterval        *big.Int // Interval in blocks at which checkpoints must be submitted.
 	L2BlockTime               *big.Int // The time per L2 block, in seconds.
 	FinalizationPeriodSeconds *big.Int // The minimum time (in seconds) that must elapse before a withdrawal can be finalized.
@@ -41,8 +39,6 @@ type L2OOParams struct {
 
 // OPMainnetL2OOParams describes the L2OutputOracle parameters from OP Mainnet
 var OPMainnetL2OOParams = L2OOParams{
-	StartingBlockNumber:       big.NewInt(0),
-	StartingTimestamp:         big.NewInt(1690493568),
 	SubmissionInterval:        big.NewInt(120),
 	L2BlockTime:               big.NewInt(2),
 	FinalizationPeriodSeconds: big.NewInt(12),
@@ -50,8 +46,6 @@ var OPMainnetL2OOParams = L2OOParams{
 
 // OPGoerliL2OOParams describes the L2OutputOracle parameters from OP Goerli
 var OPGoerliL2OOParams = L2OOParams{
-	StartingBlockNumber:       big.NewInt(4061224),
-	StartingTimestamp:         big.NewInt(1673550516),
 	SubmissionInterval:        big.NewInt(120),
 	L2BlockTime:               big.NewInt(2),
 	FinalizationPeriodSeconds: big.NewInt(12),
@@ -59,8 +53,6 @@ var OPGoerliL2OOParams = L2OOParams{
 
 // OPGoerliDev0L2OOParams describes the L2OutputOracle parameters from OP Goerli
 var OPGoerliDev0L2OOParams = L2OOParams{
-	StartingBlockNumber:       big.NewInt(0),
-	StartingTimestamp:         big.NewInt(1690493568),
 	SubmissionInterval:        big.NewInt(120),
 	L2BlockTime:               big.NewInt(2),
 	FinalizationPeriodSeconds: big.NewInt(12),
@@ -68,8 +60,6 @@ var OPGoerliDev0L2OOParams = L2OOParams{
 
 // OPSepoliaL2OOParams describes the L2OutputOracle parameters from OP Goerli
 var OPSepoliaL2OOParams = L2OOParams{
-	StartingBlockNumber:       big.NewInt(0),
-	StartingTimestamp:         big.NewInt(1690493568),
 	SubmissionInterval:        big.NewInt(120),
 	L2BlockTime:               big.NewInt(2),
 	FinalizationPeriodSeconds: big.NewInt(12),
@@ -77,8 +67,6 @@ var OPSepoliaL2OOParams = L2OOParams{
 
 // OPSepoliaDev0L2OOParams describes the L2OutputOracle parameters from OP Goerli
 var OPSepoliaDev0L2OOParams = L2OOParams{
-	StartingBlockNumber:       big.NewInt(0),
-	StartingTimestamp:         big.NewInt(1690493568),
 	SubmissionInterval:        big.NewInt(120),
 	L2BlockTime:               big.NewInt(2),
 	FinalizationPeriodSeconds: big.NewInt(12),

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -87,7 +87,7 @@ func (a AddressList) AddressFor(contractName string) (Address, error) {
 		address = a.L1ERC721BridgeProxy
 	case "L1StandardBridgeProxy":
 		address = a.L1StandardBridgeProxy
-	case "L2OutputOrcaleProxy":
+	case "L2OutputOracleProxy":
 		address = a.L2OutputOracleProxy
 	case "OptimismMintableERC20FactoryProxy":
 		address = a.OptimismMintableERC20FactoryProxy

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -247,7 +247,7 @@ func (c ContractVersions) VersionFor(contractName string) (string, error) {
 		version = c.L1ERC721Bridge
 	case "L1StandardBridge":
 		version = c.L1StandardBridge
-	case "L2OutputOrcale":
+	case "L2OutputOracle":
 		version = c.L2OutputOracle
 	case "OptimismMintableERC20Factory":
 		version = c.OptimismMintableERC20Factory

--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -1,0 +1,114 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	. "github.com/ethereum-optimism/superchain-registry/superchain"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+type l2OOParams struct {
+	startingBlockNumber       *big.Int
+	startingTimestamp         *big.Int
+	submissionInterval        *big.Int
+	l2BlockTime               *big.Int
+	finalizationPeriodSeconds *big.Int
+}
+
+func TestL2OOParams(t *testing.T) {
+
+	isExcluded := map[uint64]bool{
+		// 888:          true, // OP_Labs_chaosnet_0
+		// 997:          true, // OP_Labs_devnet_0
+		// 11155421:     true, // OP_Labs_Sepolia_devnet_0
+		// 11763071:     true, // Base_devnet_0
+		// 129831238013: true, // Conduit_devnet_0
+	}
+
+	checkL2OOParams := func(t *testing.T, chain *ChainConfig) {
+		rpcEndpoint := Superchains[chain.Superchain].Config.L1.PublicRPC
+
+		require.NotEmpty(t, rpcEndpoint)
+
+		client, err := ethclient.Dial(rpcEndpoint)
+		require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
+
+		contractAddress, err := Addresses[chain.ChainID].AddressFor("L2OutputOracleProxy")
+		require.NoError(t, err)
+
+		desiredParams := l2OOParams{}
+
+		actualParams, err := getl2OOParamsWithRetries(context.Background(), common.Address(contractAddress), client)
+		require.NoErrorf(t, err, "RPC endpoint %s", rpcEndpoint)
+
+		require.Equal(t, desiredParams, actualParams, "L2OutputOracle config params UNACCEPTABLE")
+
+		t.Logf("L2OutputOracle config params acceptable")
+
+	}
+
+	for chainID, chain := range OPChains {
+		if !isExcluded[chainID] {
+			t.Run(chain.Name+fmt.Sprintf(" (%d)", chainID), func(t *testing.T) { checkL2OOParams(t, chain) })
+		}
+	}
+}
+
+// getResourceMeteringwill gets each of the parameters from the L2OutputOracle at l2OOAddr,
+// retrying up to 10 times with exponential backoff.
+func getl2OOParamsWithRetries(ctx context.Context, l2OOAddr common.Address, client *ethclient.Client) (l2OOParams, error) {
+	const maxAttempts = 10
+	l2OO, err := bindings.NewL2OutputOracle(l2OOAddr, client)
+	if err != nil {
+		return l2OOParams{}, err
+	}
+
+	params := l2OOParams{}
+	params.startingBlockNumber, err = retry.Do(ctx, maxAttempts, retry.Exponential(),
+		func() (*big.Int, error) {
+			return l2OO.StartingBlockNumber(&bind.CallOpts{Context: ctx})
+		})
+	if err != nil {
+		return l2OOParams{}, fmt.Errorf("could not get startingBlockNumber: %w", err)
+	}
+	params.startingTimestamp, err = retry.Do(ctx, maxAttempts, retry.Exponential(),
+		func() (*big.Int, error) {
+			return l2OO.StartingTimestamp(&bind.CallOpts{Context: ctx})
+		})
+	if err != nil {
+		return l2OOParams{}, fmt.Errorf("could not get startingTimestamp: %w", err)
+	}
+	params.submissionInterval, err = retry.Do(ctx, maxAttempts, retry.Exponential(),
+		func() (*big.Int, error) {
+			return l2OO.SubmissionInterval(&bind.CallOpts{Context: ctx})
+		})
+	if err != nil {
+		return l2OOParams{}, fmt.Errorf("could not get submissionInterval: %w", err)
+	}
+	params.l2BlockTime, err = retry.Do(ctx, maxAttempts, retry.Exponential(),
+		func() (*big.Int, error) {
+			return l2OO.L2BlockTime(&bind.CallOpts{Context: ctx})
+		})
+	if err != nil {
+		return l2OOParams{}, fmt.Errorf("could not get l2Blocktime: %w", err)
+	}
+	params.finalizationPeriodSeconds, err = retry.Do(ctx, maxAttempts, retry.Exponential(),
+		func() (*big.Int, error) {
+			return l2OO.FinalizationPeriodSeconds(&bind.CallOpts{Context: ctx})
+		})
+	if err != nil {
+		return l2OOParams{}, fmt.Errorf("could not get finalizationPeriodSeconds: %w", err)
+	}
+
+	return params, nil
+}

--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -30,7 +30,7 @@ func TestL2OOParams(t *testing.T) {
 		34443:        true, // mainnet/mode                    (old version of L2OutputOracle, no submissionInterval method)
 		58008:        true, // sepolia/pgn                     (old version of L2OutputOracle, no submissionInterval method)
 		84531:        true, // goerli/base                     (old version of L2OutputOracle, no submissionInterval method)
-		84532:        true, // sepolia/base                    iIncorrect startingTimestamp)
+		84532:        true, // sepolia/base                    incorrect startingTimestamp)
 		7777777:      true, // mainnet/zora                    (old version of L2OutputOracle, no submissionInterval method)
 		11155421:     true, // sepolia-dev-0/oplabs-devnet-0   (old version of L2OutputOracle, no submissionInterval method)
 		11763071:     true, // goerli-dev-0/base-devnet-0      (old version of L2OutputOracle, no submissionInterval method)

--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -28,11 +28,39 @@ type l2OOParams struct {
 func TestL2OOParams(t *testing.T) {
 
 	isExcluded := map[uint64]bool{
-		// 888:          true, // OP_Labs_chaosnet_0
-		// 997:          true, // OP_Labs_devnet_0
-		// 11155421:     true, // OP_Labs_Sepolia_devnet_0
-		// 11763071:     true, // Base_devnet_0
-		// 129831238013: true, // Conduit_devnet_0
+		291:          true,
+		424:          true,
+		888:          true,
+		957:          true,
+		997:          true,
+		8453:         true,
+		34443:        true,
+		58008:        true,
+		84531:        true,
+		84532:        true,
+		7777777:      true,
+		11155421:     true, // sepolia-dev-0/oplabs-devnet-0
+		11763071:     true,
+		999999999:    true,
+		129831238013: true,
+	}
+
+	requireEqualParams := func(t *testing.T, desired, actual l2OOParams) {
+		require.Condition(t,
+			func() bool { return (desired.startingBlockNumber.Cmp(actual.startingBlockNumber) == 0) },
+			"Incorrect startingBlockNumber, wanted %s got %s", desired.startingBlockNumber, actual.startingBlockNumber)
+		require.Condition(t,
+			func() bool { return (desired.startingTimestamp.Cmp(actual.startingTimestamp) == 0) },
+			"Incorrect startingTimestamp, wanted %s got %s", desired.startingTimestamp, actual.startingTimestamp)
+		require.Condition(t,
+			func() bool { return (desired.submissionInterval.Cmp(actual.submissionInterval) == 0) },
+			"Incorrect submissionInterval, wanted %s got %s", desired.submissionInterval, actual.submissionInterval)
+		require.Condition(t,
+			func() bool { return (desired.l2BlockTime.Cmp(actual.l2BlockTime) == 0) },
+			"Incorrect l2BlockTime, wanted %s got %s", desired.l2BlockTime, actual.l2BlockTime)
+		require.Condition(t,
+			func() bool { return (desired.finalizationPeriodSeconds.Cmp(actual.finalizationPeriodSeconds) == 0) },
+			"Incorrect finalizationPeriodSeconds, wanted %s got %s", desired.finalizationPeriodSeconds, actual.finalizationPeriodSeconds)
 	}
 
 	checkL2OOParams := func(t *testing.T, chain *ChainConfig) {
@@ -46,12 +74,18 @@ func TestL2OOParams(t *testing.T) {
 		contractAddress, err := Addresses[chain.ChainID].AddressFor("L2OutputOracleProxy")
 		require.NoError(t, err)
 
-		desiredParams := l2OOParams{}
+		desiredParams := l2OOParams{
+			startingBlockNumber:       big.NewInt(0),
+			startingTimestamp:         big.NewInt(1690493568),
+			submissionInterval:        big.NewInt(120),
+			l2BlockTime:               big.NewInt(2),
+			finalizationPeriodSeconds: big.NewInt(12),
+		} // From OP Mainnet
 
 		actualParams, err := getl2OOParamsWithRetries(context.Background(), common.Address(contractAddress), client)
 		require.NoErrorf(t, err, "RPC endpoint %s", rpcEndpoint)
 
-		require.Equal(t, desiredParams, actualParams, "L2OutputOracle config params UNACCEPTABLE")
+		requireEqualParams(t, desiredParams, actualParams)
 
 		t.Logf("L2OutputOracle config params acceptable")
 

--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -20,24 +20,23 @@ import (
 func TestL2OOParams(t *testing.T) {
 
 	isExcluded := map[uint64]bool{
-		10: true, // mainnet/op (runs an old version of L2OutputOracle,
-		// which does not expose submissionInterval method)
-		291:          true,
-		424:          true,
-		888:          true,
-		957:          true,
-		997:          true,
-		8453:         true,
-		34443:        true,
-		58008:        true,
-		84531:        true,
-		84532:        true,
-		7777777:      true,
-		11155421:     true, // sepolia-dev-0/oplabs-devnet-0
-		11763071:     true,
-		11763072:     true, // sepolia-dev-0/base-devnet-0 incorrect startingTimestamp
-		999999999:    true,
-		129831238013: true,
+		10:           true, // mainnet/op                      (old version of L2OutputOracle, no submissionInterval method)
+		291:          true, // mainnet/orderly                 (old version of L2OutputOracle, no submissionInterval method)
+		424:          true, // mainnet/pgn                     (old version of L2OutputOracle, no submissionInterval method)
+		888:          true, // goerli-dev-0/op-labs-chaosnet-0 (incorrect startingBlockNumber)
+		957:          true, // mainnet/lyra                    (old version of L2OutputOracle, no submissionInterval method)
+		997:          true, // goerli-dev-0/op-labs-devnet-0   (old version of L2OutputOracle, no submissionInterval method)
+		8453:         true, // mainnet/base                    (old version of L2OutputOracle, no submissionInterval method)
+		34443:        true, // mainnet/mode                    (old version of L2OutputOracle, no submissionInterval method)
+		58008:        true, // sepolia/pgn                     (old version of L2OutputOracle, no submissionInterval method)
+		84531:        true, // goerli/base                     (old version of L2OutputOracle, no submissionInterval method)
+		84532:        true, // sepolia/base                    iIncorrect startingTimestamp)
+		7777777:      true, // mainnet/zora                    (old version of L2OutputOracle, no submissionInterval method)
+		11155421:     true, // sepolia-dev-0/oplabs-devnet-0   (old version of L2OutputOracle, no submissionInterval method)
+		11763071:     true, // goerli-dev-0/base-devnet-0      (old version of L2OutputOracle, no submissionInterval method)
+		11763072:     true, // sepolia-dev-0/base-devnet-0     (incorrect startingTimestamp)
+		999999999:    true, // sepolia/zora                    (old version of L2OutputOracle, no submissionInterval method)
+		129831238013: true, // goerli-dev-0/conduit-devnet-0   (old version of L2OutputOracle, no submissionInterval method)
 	}
 
 	checkEquality := func(a, b *big.Int) func() bool {

--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -103,6 +103,7 @@ func TestL2OOParams(t *testing.T) {
 // getResourceMeteringwill gets each of the parameters from the L2OutputOracle at l2OOAddr,
 // retrying up to 10 times with exponential backoff.
 func getl2OOParamsWithRetries(ctx context.Context, l2OOAddr common.Address, client *ethclient.Client) (L2OOParams, error) {
+	callOpts := &bind.CallOpts{Context: ctx}
 	const maxAttempts = 3
 	l2OO, err := bindings.NewL2OutputOracle(l2OOAddr, client)
 	if err != nil {
@@ -113,21 +114,21 @@ func getl2OOParamsWithRetries(ctx context.Context, l2OOAddr common.Address, clie
 
 	params.SubmissionInterval, err = retry.Do(ctx, maxAttempts, retry.Exponential(),
 		func() (*big.Int, error) {
-			return l2OO.SubmissionInterval(&bind.CallOpts{Context: ctx})
+			return l2OO.SubmissionInterval(callOpts)
 		})
 	if err != nil {
 		return L2OOParams{}, fmt.Errorf("could not get submissionInterval: %w", err)
 	}
 	params.L2BlockTime, err = retry.Do(ctx, maxAttempts, retry.Exponential(),
 		func() (*big.Int, error) {
-			return l2OO.L2BlockTime(&bind.CallOpts{Context: ctx})
+			return l2OO.L2BlockTime(callOpts)
 		})
 	if err != nil {
 		return L2OOParams{}, fmt.Errorf("could not get l2Blocktime: %w", err)
 	}
 	params.FinalizationPeriodSeconds, err = retry.Do(ctx, maxAttempts, retry.Exponential(),
 		func() (*big.Int, error) {
-			return l2OO.FinalizationPeriodSeconds(&bind.CallOpts{Context: ctx})
+			return l2OO.FinalizationPeriodSeconds(callOpts)
 		})
 	if err != nil {
 		return L2OOParams{}, fmt.Errorf("could not get finalizationPeriodSeconds: %w", err)

--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -45,22 +45,31 @@ func TestL2OOParams(t *testing.T) {
 		129831238013: true,
 	}
 
+	checkEquality := func(a, b *big.Int) func() bool {
+		return (func() bool { return (a.Cmp(b) == 0) })
+	}
+
+	incorrectMsg := func(name string, want, got *big.Int) string {
+		return fmt.Sprintf("Incorrect %s, wanted %d got %d", name, want, got)
+
+	}
+
 	requireEqualParams := func(t *testing.T, desired, actual l2OOParams) {
 		require.Condition(t,
-			func() bool { return (desired.startingBlockNumber.Cmp(actual.startingBlockNumber) == 0) },
-			"Incorrect startingBlockNumber, wanted %s got %s", desired.startingBlockNumber, actual.startingBlockNumber)
+			checkEquality(desired.startingBlockNumber, actual.startingBlockNumber),
+			incorrectMsg("startingBlockNumber", desired.startingBlockNumber, actual.startingBlockNumber))
 		require.Condition(t,
-			func() bool { return (desired.startingTimestamp.Cmp(actual.startingTimestamp) == 0) },
-			"Incorrect startingTimestamp, wanted %s got %s", desired.startingTimestamp, actual.startingTimestamp)
+			checkEquality(desired.startingTimestamp, actual.startingTimestamp),
+			incorrectMsg("startingTimestamp", desired.startingTimestamp, actual.startingTimestamp))
 		require.Condition(t,
-			func() bool { return (desired.submissionInterval.Cmp(actual.submissionInterval) == 0) },
-			"Incorrect submissionInterval, wanted %s got %s", desired.submissionInterval, actual.submissionInterval)
+			checkEquality(desired.submissionInterval, actual.submissionInterval),
+			incorrectMsg("submissionInterval", desired.submissionInterval, actual.submissionInterval))
 		require.Condition(t,
-			func() bool { return (desired.l2BlockTime.Cmp(actual.l2BlockTime) == 0) },
-			"Incorrect l2BlockTime, wanted %s got %s", desired.l2BlockTime, actual.l2BlockTime)
+			checkEquality(desired.l2BlockTime, actual.l2BlockTime),
+			incorrectMsg("l2BlockTime", desired.l2BlockTime, actual.l2BlockTime))
 		require.Condition(t,
-			func() bool { return (desired.finalizationPeriodSeconds.Cmp(actual.finalizationPeriodSeconds) == 0) },
-			"Incorrect finalizationPeriodSeconds, wanted %s got %s", desired.finalizationPeriodSeconds, actual.finalizationPeriodSeconds)
+			checkEquality(desired.finalizationPeriodSeconds, actual.finalizationPeriodSeconds),
+			incorrectMsg("finalizationPeriodSeconds", desired.finalizationPeriodSeconds, actual.finalizationPeriodSeconds))
 	}
 
 	checkL2OOParams := func(t *testing.T, chain *ChainConfig) {

--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -23,18 +23,15 @@ func TestL2OOParams(t *testing.T) {
 		10:           true, // mainnet/op                      (old version of L2OutputOracle, no submissionInterval method)
 		291:          true, // mainnet/orderly                 (old version of L2OutputOracle, no submissionInterval method)
 		424:          true, // mainnet/pgn                     (old version of L2OutputOracle, no submissionInterval method)
-		888:          true, // goerli-dev-0/op-labs-chaosnet-0 (incorrect startingBlockNumber)
 		957:          true, // mainnet/lyra                    (old version of L2OutputOracle, no submissionInterval method)
 		997:          true, // goerli-dev-0/op-labs-devnet-0   (old version of L2OutputOracle, no submissionInterval method)
 		8453:         true, // mainnet/base                    (old version of L2OutputOracle, no submissionInterval method)
 		34443:        true, // mainnet/mode                    (old version of L2OutputOracle, no submissionInterval method)
 		58008:        true, // sepolia/pgn                     (old version of L2OutputOracle, no submissionInterval method)
 		84531:        true, // goerli/base                     (old version of L2OutputOracle, no submissionInterval method)
-		84532:        true, // sepolia/base                    incorrect startingTimestamp)
 		7777777:      true, // mainnet/zora                    (old version of L2OutputOracle, no submissionInterval method)
 		11155421:     true, // sepolia-dev-0/oplabs-devnet-0   (old version of L2OutputOracle, no submissionInterval method)
 		11763071:     true, // goerli-dev-0/base-devnet-0      (old version of L2OutputOracle, no submissionInterval method)
-		11763072:     true, // sepolia-dev-0/base-devnet-0     (incorrect startingTimestamp)
 		999999999:    true, // sepolia/zora                    (old version of L2OutputOracle, no submissionInterval method)
 		129831238013: true, // goerli-dev-0/conduit-devnet-0   (old version of L2OutputOracle, no submissionInterval method)
 	}
@@ -49,12 +46,6 @@ func TestL2OOParams(t *testing.T) {
 	}
 
 	requireEqualParams := func(t *testing.T, desired, actual L2OOParams) {
-		require.Condition(t,
-			checkEquality(desired.StartingBlockNumber, actual.StartingBlockNumber),
-			incorrectMsg("startingBlockNumber", desired.StartingBlockNumber, actual.StartingBlockNumber))
-		require.Condition(t,
-			checkEquality(desired.StartingTimestamp, actual.StartingTimestamp),
-			incorrectMsg("startingTimestamp", desired.StartingTimestamp, actual.StartingTimestamp))
 		require.Condition(t,
 			checkEquality(desired.SubmissionInterval, actual.SubmissionInterval),
 			incorrectMsg("submissionInterval", desired.SubmissionInterval, actual.SubmissionInterval))
@@ -119,20 +110,7 @@ func getl2OOParamsWithRetries(ctx context.Context, l2OOAddr common.Address, clie
 	}
 
 	params := L2OOParams{}
-	params.StartingBlockNumber, err = retry.Do(ctx, maxAttempts, retry.Exponential(),
-		func() (*big.Int, error) {
-			return l2OO.StartingBlockNumber(&bind.CallOpts{Context: ctx})
-		})
-	if err != nil {
-		return L2OOParams{}, fmt.Errorf("could not get startingBlockNumber: %w", err)
-	}
-	params.StartingTimestamp, err = retry.Do(ctx, maxAttempts, retry.Exponential(),
-		func() (*big.Int, error) {
-			return l2OO.StartingTimestamp(&bind.CallOpts{Context: ctx})
-		})
-	if err != nil {
-		return L2OOParams{}, fmt.Errorf("could not get startingTimestamp: %w", err)
-	}
+
 	params.SubmissionInterval, err = retry.Do(ctx, maxAttempts, retry.Exponential(),
 		func() (*big.Int, error) {
 			return l2OO.SubmissionInterval(&bind.CallOpts{Context: ctx})

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -71,7 +71,7 @@ func TestContractVersions(t *testing.T) {
 			"L1CrossDomainMessenger",
 			"L1ERC721Bridge",
 			"L1StandardBridge",
-			"L2OutputOrcale",
+			"L2OutputOracle",
 			"OptimismMintableERC20Factory",
 			"OptimismPortal",
 			"SystemConfig",


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* adds (exported) expectations / ground truths to the `superchain` module resolve by superchain target
* Adds a test to query parameters from the `L2OutputOracle` contract for each chain and check them against expectations


**Metadata**

- Towards https://github.com/ethereum-optimism/client-pod/issues/486 (task 3)
