### PR TITLE
validation: check `SuperchainConfig` version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ system_config: 1.3.0
 
 # superchain-wide contracts
 protocol_versions: 1.0.0
+superchain_config: 
 ```
 
 ### `implementations`

--- a/superchain/configs/goerli/semver.yaml
+++ b/superchain/configs/goerli/semver.yaml
@@ -8,4 +8,4 @@ system_config: 1.10.0
 
 # superchain-wide contracts
 protocol_versions: 0.1.0
-supechain_config:
+superchain_config:

--- a/superchain/configs/goerli/semver.yaml
+++ b/superchain/configs/goerli/semver.yaml
@@ -8,3 +8,4 @@ system_config: 1.10.0
 
 # superchain-wide contracts
 protocol_versions: 0.1.0
+supechain_config:

--- a/superchain/configs/sepolia-dev-0/semver.yaml
+++ b/superchain/configs/sepolia-dev-0/semver.yaml
@@ -8,3 +8,4 @@ system_config: 1.7.0
 
 # superchain-wide contracts
 protocol_versions: 1.0.0
+superchain_config: 1.0.0

--- a/superchain/configs/sepolia/semver.yaml
+++ b/superchain/configs/sepolia/semver.yaml
@@ -8,3 +8,4 @@ system_config: 1.12.0
 
 # superchain-wide contracts
 protocol_versions: 1.0.0
+superchain_config: 1.1.0

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -235,6 +235,7 @@ type ContractVersions struct {
 	SystemConfig                 string `yaml:"system_config"`
 	// Superchain-wide contracts:
 	ProtocolVersions string `yaml:"protocol_versions"`
+	SuperchainConfig string `yaml:"superchain_config,omitempty"`
 }
 
 // VersionFor returns the version for the supplied contract name, if it exits
@@ -258,6 +259,8 @@ func (c ContractVersions) VersionFor(contractName string) (string, error) {
 		version = c.SystemConfig
 	case "ProtocolVersions":
 		version = c.ProtocolVersions
+	case "SuperchainConfig":
+		version = c.SuperchainConfig
 	default:
 		return "", errors.New("no such contract name")
 	}

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -281,7 +281,7 @@ func (c ContractVersions) Check() error {
 			return fmt.Errorf("invalid type for field %s", val.Type().Field(i).Name)
 		}
 		if str == "" {
-			return fmt.Errorf("empty version for field %s", val.Type().Field(i).Name)
+			continue // we allow empty strings and rely on tests to assert (or except) a nonempty version
 		}
 		str = canonicalizeSemver(str)
 		if !semver.IsValid(str) {
@@ -590,9 +590,6 @@ func newContractVersions(superchain string) (ContractVersions, error) {
 	}
 	if err := yaml.Unmarshal(semvers, &versions); err != nil {
 		return versions, fmt.Errorf("failed to unmarshal semver.yaml: %w", err)
-	}
-	if err := versions.Check(); err != nil {
-		return versions, fmt.Errorf("semver.yaml is invalid: %w", err)
 	}
 	return versions, nil
 }

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -271,8 +271,8 @@ func (c ContractVersions) VersionFor(contractName string) (string, error) {
 }
 
 // Check will sanity check the validity of the semantic version strings
-// in the ContractVersions struct.
-func (c ContractVersions) Check() error {
+// in the ContractVersions struct. If allowEmptyVersions is true, empty version errors will be ignored.
+func (c ContractVersions) Check(allowEmptyVersions bool) error {
 	val := reflect.ValueOf(c)
 	for i := 0; i < val.NumField(); i++ {
 		field := val.Field(i)
@@ -281,7 +281,10 @@ func (c ContractVersions) Check() error {
 			return fmt.Errorf("invalid type for field %s", val.Type().Field(i).Name)
 		}
 		if str == "" {
-			continue // we allow empty strings and rely on tests to assert (or except) a nonempty version
+			if allowEmptyVersions {
+				continue // we allow empty strings and rely on tests to assert (or except) a nonempty version
+			}
+			return fmt.Errorf("empty version for field %s", val.Type().Field(i).Name)
 		}
 		str = canonicalizeSemver(str)
 		if !semver.IsValid(str) {

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -155,7 +155,7 @@ func TestContractImplementations(t *testing.T) {
 // is not read correctly.
 func TestContractVersionsCheck(t *testing.T) {
 	for _, versions := range SuperchainSemver {
-		if err := versions.Check(false); err != nil {
+		if err := versions.Check(true); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -155,7 +155,7 @@ func TestContractImplementations(t *testing.T) {
 // is not read correctly.
 func TestContractVersionsCheck(t *testing.T) {
 	for _, versions := range SuperchainSemver {
-		if err := versions.Check(); err != nil {
+		if err := versions.Check(false); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -32,6 +32,10 @@ func TestSuperchainWideContractVersions(t *testing.T) {
 		desiredSemver, err := SuperchainSemver[superchain.Superchain].VersionFor("ProtocolVersions")
 		require.NoError(t, err)
 		checkSemverForContract(t, "ProtocolVersions", superchain.Config.ProtocolVersionsAddr, client, desiredSemver)
+
+		desiredSemver, err = SuperchainSemver[superchain.Superchain].VersionFor("SuperchainConfig")
+		require.NoError(t, err)
+		checkSemverForContract(t, "SuperchainConfig", superchain.Config.SuperchainConfigAddr, client, desiredSemver)
 	}
 
 	for superchainName, superchain := range Superchains {

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -23,6 +23,7 @@ var isSemverAcceptable = func(desired, actual string) bool {
 func TestSuperchainWideContractVersions(t *testing.T) {
 
 	checkSuperchainTargetSatisfiesSemver := func(t *testing.T, superchain *Superchain) {
+
 		rpcEndpoint := superchain.Config.L1.PublicRPC
 		require.NotEmpty(t, rpcEndpoint)
 
@@ -32,6 +33,17 @@ func TestSuperchainWideContractVersions(t *testing.T) {
 		desiredSemver, err := SuperchainSemver[superchain.Superchain].VersionFor("ProtocolVersions")
 		require.NoError(t, err)
 		checkSemverForContract(t, "ProtocolVersions", superchain.Config.ProtocolVersionsAddr, client, desiredSemver)
+
+		isExcludedFromSuperchainConfigCheck := map[string]bool{
+			"Goerli":       true, // no version specified
+			"Goerli Dev 0": true, // no version specified
+			"Mainnet":      true, // no version specified
+		}
+
+		if isExcludedFromSuperchainConfigCheck[superchain.Config.Name] {
+			t.Logf("%s excluded from SuperChainConfig version check", superchain.Config.Name)
+			return
+		}
 
 		desiredSemver, err = SuperchainSemver[superchain.Superchain].VersionFor("SuperchainConfig")
 		require.NoError(t, err)


### PR DESCRIPTION
This is a superchain-wide contract.

Some targets do not have it deployed or do not specify an address. Therefore we cannot specify anything in the semver.yaml file. Therefore the semver.yaml would fail a sanity check which currently enforces that no field is empty.

My usual approach of skipping certain superchains / chains in the test won't work here without some deeper changes, because there failing check runs when the package is built/imported. 

Options: 
1. ~Store the `SuperchainConfig` version in a different place and allow it to be null/empty~
2. Relax the requirements that specified versions cannot be empty. We can allow empty versions at init time, and check them at validation time. 
3. ~Use a magic value instead of `""` for unspecified chains~

Closes https://github.com/ethereum-optimism/client-pod/issues/485


