### PR TITLE
mainnet: Set Ecotone activation time

### DIFF
--- a/superchain/configs/mainnet/superchain.yaml
+++ b/superchain/configs/mainnet/superchain.yaml
@@ -7,3 +7,4 @@ l1:
 protocol_versions_addr: "0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935"
 canyon_time: 1704992401 # Thu Jan 11 17:00:01 UTC 2024
 delta_time: 1708560000  # Thu Feb 22 00:00:00 UTC 2024
+ecotone_time: 1710781201 # Mon Mar 18 17:00:01 UTC 2024


### PR DESCRIPTION
unix timestamp: 1710781201
Mon Mar 18 17:00:01 UTC 2024

Fixes https://github.com/ethereum-optimism/protocol-quest/issues/80