### PR TITLE
ci: add nightly workflow for `golang-test` and `check-security-configs` jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
       - notify-failures-on-main
 
 workflows:
-  nightly:
+  hourly:
     jobs:
       - golang-test:
           context:
@@ -124,7 +124,7 @@ workflows:
             - slack
     triggers:
       - schedule: 
-          cron: "0 0 * * *"
+          cron: "0 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,26 @@ version: 2.1
 
 orbs:
   go: circleci/go@1.8.0
+  slack: circleci/slack@4.10.1
 
+commands:
+  notify-failures-on-main:
+    description: "Notify Slack"
+    parameters:
+      channel:
+        type: string
+        default: C03N11M0BBN
+    steps:
+      - slack/notify:
+          channel: << parameters.channel >>
+          event: fail
+          template: basic_fail_1
+          branch_pattern: main
+      - slack/notify: # DELETEME for temporary testing only
+          channel: << parameters.channel >>
+          event: pass 
+          template: basic_fail_1
+          branch_pattern: gk/nightly-ci-run
 jobs:
   golang-lint:
     executor:
@@ -42,6 +61,7 @@ jobs:
           name: run validation module tests
           command: go test ./... -v
           working_directory: validation
+      - notify-failures-on-main
   publish-bot:
     environment:
       NODE_AUTH_TOKEN: $NPM_TOKEN  # Use NPM_TOKEN as the auth token
@@ -96,6 +116,7 @@ jobs:
               --fork-url="https://ci-sepolia-l1.optimism.io" --compute-units-per-second=320
             forge script CheckSecurityConfigs \
               --fork-url="https://ci-goerli-l1.optimism.io" --compute-units-per-second=320
+      - notify-failures-on-main
 
 workflows:
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,6 @@ commands:
           event: fail
           template: basic_fail_1
           branch_pattern: main
-      - slack/notify: # DELETEME for temporary testing only
-          channel: << parameters.channel >>
-          event: pass 
-          template: basic_fail_1
-          branch_pattern: gk/nightly-ci-run
 jobs:
   golang-lint:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,17 @@ jobs:
               --fork-url="https://ci-goerli-l1.optimism.io" --compute-units-per-second=320
 
 workflows:
+  nightly:
+    jobs:
+      - golang-test
+      - check-security-configs
+    triggers:
+      - schedule: 
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
   main:
     jobs:
       - golang-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,22 +5,18 @@ orbs:
 
 jobs:
   golang-lint:
-    working_directory: ~/superchain-registry/
     executor:
       name: go/default  # is based on cimg/go
       tag: '1.21'
     steps:
-      - checkout:
-          path: ~/superchain-registry
+      - checkout
       - run:  golangci-lint run superchain validation
   golang-modules-tidy:
-    working_directory: ~/superchain-registry
     executor:
       name: go/default  # is based on cimg/go
       tag: '1.21'
     steps:
-      - checkout:
-          path: ~/superchain-registry
+      - checkout
       - run:
           name: tidy superchain module
           command: go mod tidy
@@ -33,13 +29,11 @@ jobs:
           name: check git tree is clean
           command: git diff --exit-code 
   golang-test:
-    working_directory: ~/superchain-registry
     executor:
       name: go/default  # is based on cimg/go
       tag: '1.21'
     steps:
-      - checkout:
-          path: ~/superchain-registry
+      - checkout
       - run:
           name: run superchain module tests
           command: go test ./... -v
@@ -53,10 +47,8 @@ jobs:
       NODE_AUTH_TOKEN: $NPM_TOKEN  # Use NPM_TOKEN as the auth token
     docker:
       - image: cimg/node:18  # Use Node.js 18
-    working_directory: ~/superchain-registry/
     steps:
-      - checkout:  # Checkout the code
-          path: ~/superchain-registry
+      - checkout
       - run:
           name: Set deployment token
           command: npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
@@ -68,10 +60,8 @@ jobs:
   check-codegen:
     docker:
       - image: cimg/node:18.18.2
-    working_directory: ~/superchain-registry/
     steps:
-      - checkout:
-          path: ~/superchain-registry
+      - checkout
       - run:
           name: Run codegen
           command: pnpm codegen

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,8 +121,12 @@ jobs:
 workflows:
   nightly:
     jobs:
-      - golang-test
-      - check-security-configs
+      - golang-test:
+          context:
+            - slack
+      - check-security-configs:
+          context:
+            - slack
     triggers:
       - schedule: 
           cron: "0 0 * * *"
@@ -134,7 +138,11 @@ workflows:
     jobs:
       - golang-lint
       - golang-modules-tidy
-      - golang-test
+      - golang-test:
+          context:
+            - slack
       - check-codegen
       - check-forge-fmt
-      - check-security-configs
+      - check-security-configs:
+          context:
+            - slack


### PR DESCRIPTION
- Fixes #89

I'm also running the `golang-tests` job nightly in addition to the `check-security-configs` job. Either of these can break due to changes external to the repo, so we will get notified within 24hrs if that happens.

I've manually verified the slack integration is working. 

