### PR TITLE
Fix failing sepolia gas price oracle checks

### DIFF
--- a/superchain/params.go
+++ b/superchain/params.go
@@ -107,8 +107,8 @@ type EcotoneGasPriceOracleParamsWithBounds struct {
 }
 
 type UpgradeFilter struct {
-	PreEcotone PreEcotoneGasPriceOracleParamsWithBounds
-	Ecotone    EcotoneGasPriceOracleParamsWithBounds
+	PreEcotone *PreEcotoneGasPriceOracleParamsWithBounds
+	Ecotone    *EcotoneGasPriceOracleParamsWithBounds
 }
 
 func makeBigIntAndBounds(value int64, bounds [2]int64) BigIntAndBounds {
@@ -117,26 +117,26 @@ func makeBigIntAndBounds(value int64, bounds [2]int64) BigIntAndBounds {
 
 var GasPriceOracleParams = map[string]UpgradeFilter{
 	"mainnet": {
-		PreEcotone: PreEcotoneGasPriceOracleParamsWithBounds{
+		PreEcotone: &PreEcotoneGasPriceOracleParamsWithBounds{
 			Decimals: makeBigIntAndBounds(6, [2]int64{6, 6}),
 			Overhead: makeBigIntAndBounds(188, [2]int64{188, 188}),
 			Scalar:   makeBigIntAndBounds(684_000, [2]int64{684_000, 684_000}),
 		},
 	},
 	"sepolia": {
-		PreEcotone: PreEcotoneGasPriceOracleParamsWithBounds{
+		PreEcotone: &PreEcotoneGasPriceOracleParamsWithBounds{
 			Decimals: makeBigIntAndBounds(6, [2]int64{6, 6}),
 			Overhead: makeBigIntAndBounds(188, [2]int64{188, 2_100}),
 			Scalar:   makeBigIntAndBounds(684_000, [2]int64{684_000, 1_000_000}),
 		},
 	},
 	"goerli": {
-		PreEcotone: PreEcotoneGasPriceOracleParamsWithBounds{
+		PreEcotone: &PreEcotoneGasPriceOracleParamsWithBounds{
 			Decimals: makeBigIntAndBounds(6, [2]int64{6, 6}),
 			Overhead: makeBigIntAndBounds(2_100, [2]int64{2_100, 2_100}),
 			Scalar:   makeBigIntAndBounds(100_000, [2]int64{100_000, 100_000}),
 		},
-		Ecotone: EcotoneGasPriceOracleParamsWithBounds{
+		Ecotone: &EcotoneGasPriceOracleParamsWithBounds{
 			Decimals:          makeBigIntAndBounds(6, [2]int64{6, 6}),
 			BlobBaseFeeScalar: Uint32AndBounds{862_000, [2]uint32{862_000, 862_000}},
 			BaseFeeScalar:     Uint32AndBounds{7600, [2]uint32{7600, 7600}},

--- a/superchain/params.go
+++ b/superchain/params.go
@@ -129,6 +129,11 @@ var GasPriceOracleParams = map[string]UpgradeFilter{
 			Overhead: makeBigIntAndBounds(188, [2]int64{188, 2_100}),
 			Scalar:   makeBigIntAndBounds(684_000, [2]int64{684_000, 1_000_000}),
 		},
+		Ecotone: &EcotoneGasPriceOracleParamsWithBounds{
+			Decimals:          makeBigIntAndBounds(6, [2]int64{6, 6}),
+			BlobBaseFeeScalar: Uint32AndBounds{862_000, [2]uint32{862_000, 862_000}},
+			BaseFeeScalar:     Uint32AndBounds{7600, [2]uint32{7600, 7600}},
+		},
 	},
 	"goerli": {
 		PreEcotone: &PreEcotoneGasPriceOracleParamsWithBounds{

--- a/validation/gpo-params_test.go
+++ b/validation/gpo-params_test.go
@@ -44,11 +44,11 @@ func TestGasPriceOracleParams(t *testing.T) {
 		actualParams, err := getPreEcotoneGasPriceOracleParams(context.Background(), gasPriceOraclAddr, client)
 		require.NoError(t, err)
 
-		require.True(t, areCloseBigInts(actualParams.Decimals, desiredParams.Decimals.Bounds),
+		require.True(t, isBigIntWithinBounds(actualParams.Decimals, desiredParams.Decimals.Bounds),
 			"decimals parameter %d out of bounds %d", actualParams.Decimals, desiredParams.Decimals.Bounds)
-		require.True(t, areCloseBigInts(actualParams.Overhead, desiredParams.Overhead.Bounds),
+		require.True(t, isBigIntWithinBounds(actualParams.Overhead, desiredParams.Overhead.Bounds),
 			"overhead parameter %d out of bounds %d", actualParams.Overhead, desiredParams.Overhead.Bounds)
-		require.True(t, areCloseBigInts(actualParams.Scalar, desiredParams.Scalar.Bounds),
+		require.True(t, isBigIntWithinBounds(actualParams.Scalar, desiredParams.Scalar.Bounds),
 			"scalar parameter %d out of bounds %d", actualParams.Scalar, desiredParams.Scalar.Bounds)
 
 		t.Logf("gas price oracle params are acceptable")
@@ -71,11 +71,11 @@ func TestGasPriceOracleParams(t *testing.T) {
 		actualParams, err := getEcotoneGasPriceOracleParams(context.Background(), gasPriceOraclAddr, client)
 		require.NoError(t, err)
 
-		require.True(t, areCloseBigInts(actualParams.Decimals, desiredParams.Decimals.Bounds),
+		require.True(t, isBigIntWithinBounds(actualParams.Decimals, desiredParams.Decimals.Bounds),
 			"decimals parameter %d out of bounds %d", actualParams.Decimals, desiredParams.Decimals.Bounds)
-		require.True(t, areCloseInts(actualParams.BlobBaseFeeScalar, desiredParams.BlobBaseFeeScalar.Bounds),
+		require.True(t, isWithinBounds(actualParams.BlobBaseFeeScalar, desiredParams.BlobBaseFeeScalar.Bounds),
 			desiredParams.BlobBaseFeeScalar.Bounds, "blobBaseFeeScalar %d out of bounds %d", actualParams.BlobBaseFeeScalar, desiredParams.BlobBaseFeeScalar.Bounds)
-		require.True(t, areCloseInts(actualParams.BaseFeeScalar, desiredParams.BaseFeeScalar.Bounds),
+		require.True(t, isWithinBounds(actualParams.BaseFeeScalar, desiredParams.BaseFeeScalar.Bounds),
 			"baseFeeScalar parameter %d out of bounds %d", actualParams.BaseFeeScalar, desiredParams.BaseFeeScalar.Bounds)
 
 		t.Logf("gas price oracle params are acceptable")

--- a/validation/gpo-params_test.go
+++ b/validation/gpo-params_test.go
@@ -74,7 +74,7 @@ func TestGasPriceOracleParams(t *testing.T) {
 		require.True(t, isBigIntWithinBounds(actualParams.Decimals, desiredParams.Decimals.Bounds),
 			"decimals parameter %d out of bounds %d", actualParams.Decimals, desiredParams.Decimals.Bounds)
 		require.True(t, isWithinBounds(actualParams.BlobBaseFeeScalar, desiredParams.BlobBaseFeeScalar.Bounds),
-			desiredParams.BlobBaseFeeScalar.Bounds, "blobBaseFeeScalar %d out of bounds %d", actualParams.BlobBaseFeeScalar, desiredParams.BlobBaseFeeScalar.Bounds)
+			"blobBaseFeeScalar %d out of bounds %d", actualParams.BlobBaseFeeScalar, desiredParams.BlobBaseFeeScalar.Bounds)
 		require.True(t, isWithinBounds(actualParams.BaseFeeScalar, desiredParams.BaseFeeScalar.Bounds),
 			"baseFeeScalar parameter %d out of bounds %d", actualParams.BaseFeeScalar, desiredParams.BaseFeeScalar.Bounds)
 

--- a/validation/gpo-params_test.go
+++ b/validation/gpo-params_test.go
@@ -19,14 +19,18 @@ import (
 
 func TestGasPriceOracleParams(t *testing.T) {
 	isExcluded := map[uint64]bool{
-		291:          true, // mainnet/orderly                 (incorrect scalar parameter)
-		888:          true, // goerli-dev-0/op-labs-chaosnet-0 (no public endpoint)
-		957:          true, // mainnet/lyra                    (incorrect scalar parameter)
-		997:          true, // goerli-dev-0/op-labs-devnet-0   (no public endpoint)
-		84531:        true, // goerli/base                     (network sunset)
-		11155421:     true, // sepolia-dev-0/oplabs-devnet-0   (no public endpoint)
-		11763071:     true, // goerli-dev-0/base-devnet-0      (no public endpoint)
-		11763072:     true, // sepolia-dev-0/base-devnet-0     (no public endpoint)
+		291:       true, // mainnet/orderly                 (incorrect scalar parameter)
+		888:       true, // goerli-dev-0/op-labs-chaosnet-0 (no public endpoint)
+		957:       true, // mainnet/lyra                    (incorrect scalar parameter)
+		997:       true, // goerli-dev-0/op-labs-devnet-0   (no public endpoint)
+		58008:     true, // sepolia/pgn                     (blobBaseFeeScalar out of bounds)
+		84531:     true, // goerli/base                     (network sunset)
+		84532:     true, // sepolia/base                    (blobBaseFeeScalar out of bounds)
+		11155421:  true, // sepolia-dev-0/oplabs-devnet-0   (no public endpoint)
+		11763071:  true, // goerli-dev-0/base-devnet-0      (no public endpoint)
+		11763072:  true, // sepolia-dev-0/base-devnet-0     (no public endpoint)
+		999999999: true, // sepolia/zora                    (blobBaseFeeScalar out of bounds)
+
 		129831238013: true, // goerli-dev-0/conduit-devnet-0   (no ground truth)
 	}
 

--- a/validation/gpo-params_test.go
+++ b/validation/gpo-params_test.go
@@ -64,6 +64,10 @@ func TestGasPriceOracleParams(t *testing.T) {
 		}
 		desiredParams := desiredParamsOuter.Ecotone
 
+		if desiredParams == nil {
+			t.Fatal("no desiredParams.Ecotone set to compare Ecotone chain to")
+		}
+
 		actualParams, err := getEcotoneGasPriceOracleParams(context.Background(), gasPriceOraclAddr, client)
 		require.NoError(t, err)
 

--- a/validation/utils_test.go
+++ b/validation/utils_test.go
@@ -8,16 +8,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Returns true if actual is within bounds, where the bounds are [lower bound, upper bound] and are inclusive.
-var areCloseBigInts = func(actual *big.Int, bounds [2]*big.Int) bool {
+// isBigIntWithinBounds returns true if actual is within bounds, where the bounds are [lower bound, upper bound] and are inclusive.
+var isBigIntWithinBounds = func(actual *big.Int, bounds [2]*big.Int) bool {
 	if (bounds[1].Cmp(bounds[0])) < 0 {
 		panic("bounds are in wrong order")
 	}
 	return (actual.Cmp(bounds[0]) >= 0 && actual.Cmp(bounds[1]) <= 0)
 }
 
-// Returns true if actual is within bounds, where the bounds are [lower bound, upper bound] and are inclusive.
-var areCloseInts = func(actual uint32, bounds [2]uint32) bool {
+// isWithinBounds returns true if actual is within bounds, where the bounds are [lower bound, upper bound] and are inclusive.
+var isWithinBounds = func(actual uint32, bounds [2]uint32) bool {
 	if bounds[1] < bounds[0] {
 		panic("bounds are in wrong order")
 	}
@@ -43,7 +43,7 @@ func TestAreCloseInts(t *testing.T) {
 
 	for _, test := range tt {
 		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
-			result := areCloseInts(test.actual, test.bounds)
+			result := isWithinBounds(test.actual, test.bounds)
 			require.Equal(t, test.expectation, result)
 		})
 	}


### PR DESCRIPTION
* Ecotone was activated on Sepolia, triggering a different pathway in the tests.
* That pathway did not have a "ground truth" defined.
* The test panicked with an unhelpful message

This PR:
* updates the test to check explicitly for the existence of a ground truth, causing a fatal error with useful message if there is none
* adds in a ground truth for sepolia / ecotone
* some additional driveby changes tidying up / renaming things.