### PR TITLE
mainnet: update Ecotone activation date to Mar 14

### DIFF
--- a/superchain/configs/mainnet/superchain.yaml
+++ b/superchain/configs/mainnet/superchain.yaml
@@ -5,6 +5,7 @@ l1:
   explorer: https://etherscan.io
 
 protocol_versions_addr: "0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935"
-canyon_time: 1704992401 # Thu Jan 11 17:00:01 UTC 2024
-delta_time: 1708560000  # Thu Feb 22 00:00:00 UTC 2024
-ecotone_time: 1710781201 # Mon Mar 18 17:00:01 UTC 2024
+
+canyon_time: 1704992401  # Thu Jan 11 17:00:01 UTC 2024
+delta_time: 1708560000   # Thu Feb 22 00:00:00 UTC 2024
+ecotone_time: 1710374401 # Thu Mar 14 00:00:01 UTC 2024


### PR DESCRIPTION
unix timestamp: 1710374401
Thu Mar 14 00:00:01 UTC 2024

per the [updated gov proposal](https://gov.optimism.io/t/upgrade-proposal-5-ecotone-network-upgrade/7669)
