### PR TITLE
Add per-chain hardfork time overrides

### DIFF
--- a/superchain/configs/goerli-dev-0/base-devnet-0.yaml
+++ b/superchain/configs/goerli-dev-0/base-devnet-0.yaml
@@ -14,3 +14,5 @@ genesis:
     hash: "0x5216ec29e8cc4fc890c31cc70c72be3c61dd9a43cfffb63385be17a56eae4c68"
     number: 0
   l2_time: 1684327104
+
+regolith_time: 1682101800 # Apr 21, 2023 @ 6:30:00 pm UTC

--- a/superchain/configs/goerli-dev-0/base-devnet-0.yaml
+++ b/superchain/configs/goerli-dev-0/base-devnet-0.yaml
@@ -15,4 +15,3 @@ genesis:
     number: 0
   l2_time: 1684327104 # Wed 17 May 2023 12:38:24 UTC
 
-regolith_time: 1682101800 # Fri 21 Apr 2023 18:30:00 UTC

--- a/superchain/configs/goerli-dev-0/base-devnet-0.yaml
+++ b/superchain/configs/goerli-dev-0/base-devnet-0.yaml
@@ -13,6 +13,6 @@ genesis:
   l2:
     hash: "0x5216ec29e8cc4fc890c31cc70c72be3c61dd9a43cfffb63385be17a56eae4c68"
     number: 0
-  l2_time: 1684327104
+  l2_time: 1684327104 # Wed 17 May 2023 12:38:24 UTC
 
-regolith_time: 1682101800 # Apr 21, 2023 @ 6:30:00 pm UTC
+regolith_time: 1682101800 # Fri 21 Apr 2023 18:30:00 UTC

--- a/superchain/configs/goerli-dev-0/conduit-devnet-0.yaml
+++ b/superchain/configs/goerli-dev-0/conduit-devnet-0.yaml
@@ -13,4 +13,4 @@ genesis:
   l2:
     hash: "0xf8eabf71fbb403e778c0efa7f07ceea5dc70a5c53c35693b4adf87500dd845e0"
     number: 0
-  l2_time: 1697750040
+  l2_time: 1697750040 # Thu 19 Oct 2023 21:14:00 UTC

--- a/superchain/configs/goerli-dev-0/op-labs-chaosnet-0.yaml
+++ b/superchain/configs/goerli-dev-0/op-labs-chaosnet-0.yaml
@@ -14,3 +14,5 @@ genesis:
     hash: "0x92e26b8a6b0e0939d8e50844deec6890c8b7925f39c921e91944dcb9a87217f8"
     number: 0
   l2_time: 1677688044
+
+regolith_time: 1692156862	# August 16, 2023 @ 3:34:22 am UTC

--- a/superchain/configs/goerli-dev-0/op-labs-chaosnet-0.yaml
+++ b/superchain/configs/goerli-dev-0/op-labs-chaosnet-0.yaml
@@ -14,5 +14,3 @@ genesis:
     hash: "0x92e26b8a6b0e0939d8e50844deec6890c8b7925f39c921e91944dcb9a87217f8"
     number: 0
   l2_time: 1677688044 # Wed  1 Mar 2023 16:27:24 UTC
-
-regolith_time: 1692156862	# August 16, 2023 @ 3:34:22 am UTC

--- a/superchain/configs/goerli-dev-0/op-labs-chaosnet-0.yaml
+++ b/superchain/configs/goerli-dev-0/op-labs-chaosnet-0.yaml
@@ -13,6 +13,6 @@ genesis:
   l2:
     hash: "0x92e26b8a6b0e0939d8e50844deec6890c8b7925f39c921e91944dcb9a87217f8"
     number: 0
-  l2_time: 1677688044
+  l2_time: 1677688044 # Wed  1 Mar 2023 16:27:24 UTC
 
 regolith_time: 1692156862	# August 16, 2023 @ 3:34:22 am UTC

--- a/superchain/configs/goerli-dev-0/op-labs-devnet-0.yaml
+++ b/superchain/configs/goerli-dev-0/op-labs-devnet-0.yaml
@@ -13,6 +13,6 @@ genesis:
   l2:
     hash: "0x742e03d9c8fe4dfd96f8e2d53d3815ec5537cbe3d88ad28cbb75c17ff2672867"
     number: 0
-  l2_time: 1677973680
+  l2_time: 1677973680 # Sat  4 Mar 2023 23:48:00 UTC
 
 regolith_time: 1677984480 # March 5, 2023 @ 2:48:00 am UTC

--- a/superchain/configs/goerli-dev-0/op-labs-devnet-0.yaml
+++ b/superchain/configs/goerli-dev-0/op-labs-devnet-0.yaml
@@ -14,3 +14,5 @@ genesis:
     hash: "0x742e03d9c8fe4dfd96f8e2d53d3815ec5537cbe3d88ad28cbb75c17ff2672867"
     number: 0
   l2_time: 1677973680
+
+regolith_time: 1677984480 # March 5, 2023 @ 2:48:00 am UTC

--- a/superchain/configs/goerli-dev-0/op-labs-devnet-0.yaml
+++ b/superchain/configs/goerli-dev-0/op-labs-devnet-0.yaml
@@ -14,5 +14,3 @@ genesis:
     hash: "0x742e03d9c8fe4dfd96f8e2d53d3815ec5537cbe3d88ad28cbb75c17ff2672867"
     number: 0
   l2_time: 1677973680 # Sat  4 Mar 2023 23:48:00 UTC
-
-regolith_time: 1677984480 # March 5, 2023 @ 2:48:00 am UTC

--- a/superchain/configs/goerli-dev-0/superchain.yaml
+++ b/superchain/configs/goerli-dev-0/superchain.yaml
@@ -6,7 +6,7 @@ l1:
 
 protocol_versions_addr: "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
 
-regolith_time: 0 # genesis, overriden by individual chains
-canyon_time: 1698436800 # October 27, 2023 8:00:00 PM UTC
-delta_time: 1701993600 # December 8, 2023 12:00:00 AM UTC, i.e. midnight Dec 7 to Dec 8
-ecotone_time: 1706126400 # Wed Jan 24 20:00:00 UTC 2024
+regolith_time: 0         # Thu  1 Jan 1970 00:00:00 UTC genesis, overriden by individual chains
+canyon_time: 1698436800  # Fri 27 Oct 2023 20:00:00 UTC
+delta_time: 1701993600   # Fri  8 Dec 2023 00:00:00 UTC
+ecotone_time: 1706126400 # Wed 24 Jan 2024 20:00:00 UTC

--- a/superchain/configs/goerli-dev-0/superchain.yaml
+++ b/superchain/configs/goerli-dev-0/superchain.yaml
@@ -6,7 +6,6 @@ l1:
 
 protocol_versions_addr: "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
 
-regolith_time: 0         # Thu  1 Jan 1970 00:00:00 UTC genesis, overriden by individual chains
 canyon_time: 1698436800  # Fri 27 Oct 2023 20:00:00 UTC
 delta_time: 1701993600   # Fri  8 Dec 2023 00:00:00 UTC
 ecotone_time: 1706126400 # Wed 24 Jan 2024 20:00:00 UTC

--- a/superchain/configs/goerli-dev-0/superchain.yaml
+++ b/superchain/configs/goerli-dev-0/superchain.yaml
@@ -5,6 +5,8 @@ l1:
   explorer: https://goerli.etherscan.io
 
 protocol_versions_addr: "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
+
+regolith_time: 0 # genesis, overriden by individual chains
 canyon_time: 1698436800 # October 27, 2023 8:00:00 PM UTC
 delta_time: 1701993600 # December 8, 2023 12:00:00 AM UTC, i.e. midnight Dec 7 to Dec 8
 ecotone_time: 1706126400 # Wed Jan 24 20:00:00 UTC 2024

--- a/superchain/configs/goerli/base.yaml
+++ b/superchain/configs/goerli/base.yaml
@@ -15,3 +15,5 @@ genesis:
     hash: "0xa3ab140f15ea7f7443a4702da64c10314eb04d488e72974e02e2d728096b4f76"
     number: 0
   l2_time: 1675193616
+
+regolith_time: 1683219600 # May 4, 2023 @ 5:00:00 pm UTC

--- a/superchain/configs/goerli/base.yaml
+++ b/superchain/configs/goerli/base.yaml
@@ -15,5 +15,3 @@ genesis:
     hash: "0xa3ab140f15ea7f7443a4702da64c10314eb04d488e72974e02e2d728096b4f76"
     number: 0
   l2_time: 1675193616 # Tue 31 Jan 2023 19:33:36 UTC
-
-regolith_time: 1683219600 # Thu  4 May 2023 17:00:00 UTC

--- a/superchain/configs/goerli/base.yaml
+++ b/superchain/configs/goerli/base.yaml
@@ -14,6 +14,6 @@ genesis:
   l2:
     hash: "0xa3ab140f15ea7f7443a4702da64c10314eb04d488e72974e02e2d728096b4f76"
     number: 0
-  l2_time: 1675193616
+  l2_time: 1675193616 # Tue 31 Jan 2023 19:33:36 UTC
 
-regolith_time: 1683219600 # May 4, 2023 @ 5:00:00 pm UTC
+regolith_time: 1683219600 # Thu  4 May 2023 17:00:00 UTC

--- a/superchain/configs/goerli/op.yaml
+++ b/superchain/configs/goerli/op.yaml
@@ -14,6 +14,6 @@ genesis:
   l2:
     hash: "0x0f783549ea4313b784eadd9b8e8a69913b368b7366363ea814d7707ac505175f"
     number: 4061224
-  l2_time: 1673550516
+  l2_time: 1673550516 # Thu 12 Jan 2023 19:08:36 UTC
 
-regolith_time: 1679079600 # March 17, 2023 @ 7:00:00 pm UTC
+regolith_time: 1679079600 # Fri 17 Mar 2023 19:00:00 UTC

--- a/superchain/configs/goerli/op.yaml
+++ b/superchain/configs/goerli/op.yaml
@@ -15,5 +15,3 @@ genesis:
     hash: "0x0f783549ea4313b784eadd9b8e8a69913b368b7366363ea814d7707ac505175f"
     number: 4061224
   l2_time: 1673550516 # Thu 12 Jan 2023 19:08:36 UTC
-
-regolith_time: 1679079600 # Fri 17 Mar 2023 19:00:00 UTC

--- a/superchain/configs/goerli/op.yaml
+++ b/superchain/configs/goerli/op.yaml
@@ -15,3 +15,5 @@ genesis:
     hash: "0x0f783549ea4313b784eadd9b8e8a69913b368b7366363ea814d7707ac505175f"
     number: 4061224
   l2_time: 1673550516
+
+regolith_time: 1679079600 # March 17, 2023 @ 7:00:00 pm UTC

--- a/superchain/configs/goerli/superchain.yaml
+++ b/superchain/configs/goerli/superchain.yaml
@@ -6,7 +6,7 @@ l1:
 
 protocol_versions_addr: "0x0C24F5098774aA366827D667494e9F889f7cFc08"
 
-regolith_time: 0 # genesis, overriden by individual chains
-canyon_time: 1699981200 # Tue Nov 14 17:00:00 UTC 2023
-delta_time: 1703116800  # Thu Dec 21 00:00:00 UTC 2023
-ecotone_time: 1707238800 # Tue Feb 6 17:00:00 UTC 2024
+regolith_time: 0         # Thu  1 Jan 1970 00:00:00 UTC genesis, overriden by individual chains
+canyon_time: 1699981200  # Tue 14 Nov 2023 17:00:00 UTC
+delta_time: 1703116800   # Thu 21 Dec 2023 00:00:00 UTC
+ecotone_time: 1707238800 # Tue  6 Feb 2024 17:00:00 UTC

--- a/superchain/configs/goerli/superchain.yaml
+++ b/superchain/configs/goerli/superchain.yaml
@@ -6,7 +6,6 @@ l1:
 
 protocol_versions_addr: "0x0C24F5098774aA366827D667494e9F889f7cFc08"
 
-regolith_time: 0         # Thu  1 Jan 1970 00:00:00 UTC genesis, overriden by individual chains
 canyon_time: 1699981200  # Tue 14 Nov 2023 17:00:00 UTC
 delta_time: 1703116800   # Thu 21 Dec 2023 00:00:00 UTC
 ecotone_time: 1707238800 # Tue  6 Feb 2024 17:00:00 UTC

--- a/superchain/configs/goerli/superchain.yaml
+++ b/superchain/configs/goerli/superchain.yaml
@@ -5,6 +5,8 @@ l1:
   explorer: https://goerli.etherscan.io
 
 protocol_versions_addr: "0x0C24F5098774aA366827D667494e9F889f7cFc08"
+
+regolith_time: 0 # genesis, overriden by individual chains
 canyon_time: 1699981200 # Tue Nov 14 17:00:00 UTC 2023
 delta_time: 1703116800  # Thu Dec 21 00:00:00 UTC 2023
-ecotone_time: 1707238800 # Tue Feb  6 17:00:00 UTC 2024
+ecotone_time: 1707238800 # Tue Feb 6 17:00:00 UTC 2024

--- a/superchain/configs/mainnet/base.yaml
+++ b/superchain/configs/mainnet/base.yaml
@@ -14,4 +14,4 @@ genesis:
   l2:
     hash: "0xf712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd"
     number: 0
-  l2_time: 1686789347
+  l2_time: 1686789347 # Thu 15 Jun 2023 00:35:47 UTC

--- a/superchain/configs/mainnet/lyra.yaml
+++ b/superchain/configs/mainnet/lyra.yaml
@@ -14,4 +14,4 @@ genesis:
   l2:
     hash: "0x047f535b3da7ad4f96d353b5a439740b7591413daee0e2f27dd3aabb24581af2"
     number: 0
-  l2_time: 1700021615
+  l2_time: 1700021615 # Wed 15 Nov 2023 04:13:35 UTC

--- a/superchain/configs/mainnet/mode.yaml
+++ b/superchain/configs/mainnet/mode.yaml
@@ -14,4 +14,4 @@ genesis:
   l2:
     hash: "0xb0f682e12fc555fd5ce8fce51a59a67d66a5b46be28611a168260a549dac8a9b"
     number: 0
-  l2_time: 1700167583
+  l2_time: 1700167583 # Thu 16 Nov 2023 20:46:23 UTC

--- a/superchain/configs/mainnet/op.yaml
+++ b/superchain/configs/mainnet/op.yaml
@@ -14,4 +14,4 @@ genesis:
   l2:
     hash: "0xdbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3"
     number: 105235063
-  l2_time: 1686068903
+  l2_time: 1686068903 # Tue  6 Jun 2023 16:28:23 UTC

--- a/superchain/configs/mainnet/orderly.yaml
+++ b/superchain/configs/mainnet/orderly.yaml
@@ -14,4 +14,4 @@ genesis:
   l2:
     hash: "0xe53c94ddd42714239429bd132ba2fa080c7e5cc7dca816ec6e482ec0418e6d7f"
     number: 0
-  l2_time: 1696608227
+  l2_time: 1696608227 # Fri  6 Oct 2023 16:03:47 UTC

--- a/superchain/configs/mainnet/pgn.yaml
+++ b/superchain/configs/mainnet/pgn.yaml
@@ -14,4 +14,4 @@ genesis:
   l2:
     hash: "0x39c02e153c193000f2d2907de42cc49f48329163f71d7f9c3fd0e15f41b529db"
     number: 0
-  l2_time: 1689106727
+  l2_time: 1689106727 # Tue 11 Jul 2023 20:18:47 UTC

--- a/superchain/configs/mainnet/superchain.yaml
+++ b/superchain/configs/mainnet/superchain.yaml
@@ -6,7 +6,6 @@ l1:
 
 protocol_versions_addr: "0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935"
 
-regolith_time: 0         # Thu  1 Jan 1970 00:00:00 UTC
 canyon_time: 1704992401  # Thu 11 Jan 2024 17:00:01 UTC
 delta_time: 1708560000   # Thu 22 Feb 2024 00:00:00 UTC
 ecotone_time: 1710374401 # Thu 14 Mar 2024 00:00:01 UTC

--- a/superchain/configs/mainnet/superchain.yaml
+++ b/superchain/configs/mainnet/superchain.yaml
@@ -6,8 +6,8 @@ l1:
 
 protocol_versions_addr: "0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935"
 
-regolith_time: 0
-canyon_time: 1704992401  # Thu Jan 11 17:00:01 UTC 2024
-delta_time: 1708560000   # Thu Feb 22 00:00:00 UTC 2024
-ecotone_time: 1710374401 # Thu Mar 14 00:00:01 UTC 2024
+regolith_time: 0         # Thu  1 Jan 1970 00:00:00 UTC
+canyon_time: 1704992401  # Thu 11 Jan 2024 17:00:01 UTC
+delta_time: 1708560000   # Thu 22 Feb 2024 00:00:00 UTC
+ecotone_time: 1710374401 # Thu 14 Mar 2024 00:00:01 UTC
 

--- a/superchain/configs/mainnet/superchain.yaml
+++ b/superchain/configs/mainnet/superchain.yaml
@@ -6,6 +6,8 @@ l1:
 
 protocol_versions_addr: "0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935"
 
+regolith_time: 0
 canyon_time: 1704992401  # Thu Jan 11 17:00:01 UTC 2024
 delta_time: 1708560000   # Thu Feb 22 00:00:00 UTC 2024
 ecotone_time: 1710374401 # Thu Mar 14 00:00:01 UTC 2024
+

--- a/superchain/configs/mainnet/zora.yaml
+++ b/superchain/configs/mainnet/zora.yaml
@@ -14,4 +14,5 @@ genesis:
   l2:
     hash: "0x47555a45a1af8d4728ca337a1e48375a83919b1ea16591e070a07388b7364e29"
     number: 0
-  l2_time: 1686693839
+  l2_time: 1686693839 # Tue 13 Jun 2023 22:03:59 UTC
+

--- a/superchain/configs/sepolia-dev-0/base-devnet-0.yaml
+++ b/superchain/configs/sepolia-dev-0/base-devnet-0.yaml
@@ -14,4 +14,4 @@ genesis:
   l2:
     hash: "0x1ab91449a7c65b8cd6c06f13e2e7ea2d10b6f9cbf5def79f362f2e7e501d2928"
     number: 0
-  l2_time: 1695433056
+  l2_time: 1695433056 # Sat 23 Sep 2023 01:37:36 UTC

--- a/superchain/configs/sepolia-dev-0/base-devnet-0.yaml
+++ b/superchain/configs/sepolia-dev-0/base-devnet-0.yaml
@@ -15,3 +15,6 @@ genesis:
     hash: "0x1ab91449a7c65b8cd6c06f13e2e7ea2d10b6f9cbf5def79f362f2e7e501d2928"
     number: 0
   l2_time: 1695433056 # Sat 23 Sep 2023 01:37:36 UTC
+
+canyon_time: 1698436800  # Fri 27 Oct 2023 20:00:00 UTC
+delta_time: 1706555000   # Mon 29 Jan 2024 19:03:20 UTC

--- a/superchain/configs/sepolia-dev-0/oplabs-devnet-0.yaml
+++ b/superchain/configs/sepolia-dev-0/oplabs-devnet-0.yaml
@@ -15,5 +15,3 @@ genesis:
     hash: "0x027ae1f4f9a441f9c8a01828f3b6d05803a0f524c07e09263264a38b755f804b"
     number: 0
   l2_time: 1706484048 # Sun 28 Jan 2024 23:20:48 UTC
-
-delta_time: 0

--- a/superchain/configs/sepolia-dev-0/oplabs-devnet-0.yaml
+++ b/superchain/configs/sepolia-dev-0/oplabs-devnet-0.yaml
@@ -15,3 +15,5 @@ genesis:
     hash: "0x027ae1f4f9a441f9c8a01828f3b6d05803a0f524c07e09263264a38b755f804b"
     number: 0
   l2_time: 1706484048 # Sun 28 Jan 2024 23:20:48 UTC
+
+delta_time: 0

--- a/superchain/configs/sepolia-dev-0/oplabs-devnet-0.yaml
+++ b/superchain/configs/sepolia-dev-0/oplabs-devnet-0.yaml
@@ -14,4 +14,4 @@ genesis:
   l2:
     hash: "0x027ae1f4f9a441f9c8a01828f3b6d05803a0f524c07e09263264a38b755f804b"
     number: 0
-  l2_time: 1706484048
+  l2_time: 1706484048 # Sun 28 Jan 2024 23:20:48 UTC

--- a/superchain/configs/sepolia-dev-0/superchain.yaml
+++ b/superchain/configs/sepolia-dev-0/superchain.yaml
@@ -7,7 +7,8 @@ l1:
 protocol_versions_addr: "0x252CbE9517F731C618961D890D534183822dcC8d"
 superchain_config_addr: "0x02d91Cf852423640d93920BE0CAdceC0E7A00FA7"
 
-regolith_time: 0 # genesis
-canyon_time: 1698436800  # Fri Oct 27 20:00:00 UTC 2023
-delta_time: 1706555000   # Mon Jan 29 19:03:20 UTC 2024
-ecotone_time: 1706634000 # Tue Jan 30 17:00:00 UTC 2024
+regolith_time: 0         # Thu  1 Jan 1970 00:00:00 UTC (genesis)
+canyon_time: 1698436800  # Fri 27 Oct 2023 20:00:00 UTC
+delta_time: 1706555000   # Mon 29 Jan 2024 19:03:20 UTC
+ecotone_time: 1706634000 # Tue 30 Jan 2024 17:00:00 UTC
+

--- a/superchain/configs/sepolia-dev-0/superchain.yaml
+++ b/superchain/configs/sepolia-dev-0/superchain.yaml
@@ -7,7 +7,6 @@ l1:
 protocol_versions_addr: "0x252CbE9517F731C618961D890D534183822dcC8d"
 superchain_config_addr: "0x02d91Cf852423640d93920BE0CAdceC0E7A00FA7"
 
-regolith_time: 0         # Thu  1 Jan 1970 00:00:00 UTC (genesis)
 canyon_time: 1698436800  # Fri 27 Oct 2023 20:00:00 UTC
 delta_time: 1706555000   # Mon 29 Jan 2024 19:03:20 UTC
 ecotone_time: 1706634000 # Tue 30 Jan 2024 17:00:00 UTC

--- a/superchain/configs/sepolia-dev-0/superchain.yaml
+++ b/superchain/configs/sepolia-dev-0/superchain.yaml
@@ -7,7 +7,7 @@ l1:
 protocol_versions_addr: "0x252CbE9517F731C618961D890D534183822dcC8d"
 superchain_config_addr: "0x02d91Cf852423640d93920BE0CAdceC0E7A00FA7"
 
-canyon_time: 1698436800  # Fri 27 Oct 2023 20:00:00 UTC
-delta_time: 1706555000   # Mon 29 Jan 2024 19:03:20 UTC
+canyon_time: 0
+delta_time: 0
 ecotone_time: 1706634000 # Tue 30 Jan 2024 17:00:00 UTC
 

--- a/superchain/configs/sepolia-dev-0/superchain.yaml
+++ b/superchain/configs/sepolia-dev-0/superchain.yaml
@@ -7,6 +7,7 @@ l1:
 protocol_versions_addr: "0x252CbE9517F731C618961D890D534183822dcC8d"
 superchain_config_addr: "0x02d91Cf852423640d93920BE0CAdceC0E7A00FA7"
 
+regolith_time: 0 # genesis
 canyon_time: 1698436800  # Fri Oct 27 20:00:00 UTC 2023
 delta_time: 1706555000   # Mon Jan 29 19:03:20 UTC 2024
 ecotone_time: 1706634000 # Tue Jan 30 17:00:00 UTC 2024

--- a/superchain/configs/sepolia/base.yaml
+++ b/superchain/configs/sepolia/base.yaml
@@ -14,4 +14,4 @@ genesis:
   l2:
     hash: "0x0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4"
     number: 0
-  l2_time: 1695768288
+  l2_time: 1695768288 # Tue 26 Sep 2023 22:44:48 UTC

--- a/superchain/configs/sepolia/op.yaml
+++ b/superchain/configs/sepolia/op.yaml
@@ -14,4 +14,4 @@ genesis:
   l2:
     hash: "0x102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d"
     number: 0
-  l2_time: 1691802540
+  l2_time: 1691802540 # Sat 12 Aug 2023 01:09:00 UTC

--- a/superchain/configs/sepolia/pgn.yaml
+++ b/superchain/configs/sepolia/pgn.yaml
@@ -14,4 +14,4 @@ genesis:
   l2:
     hash: "0x1d2ad9a8139d33161b1915698d2ae94019fd0817f2113198b6cb568110fa16ad"
     number: 0
-  l2_time: 1685727972
+  l2_time: 1685727972 # Fri  2 Jun 2023 17:46:12 UTC

--- a/superchain/configs/sepolia/superchain.yaml
+++ b/superchain/configs/sepolia/superchain.yaml
@@ -7,7 +7,8 @@ l1:
 protocol_versions_addr: "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
 superchain_config_addr: "0xC2Be75506d5724086DEB7245bd260Cc9753911Be"
 
-regolith_time: 0 # genesis
-canyon_time: 1699981200 # Tue Nov 14 17:00:00 UTC 2023
-delta_time: 1703203200  # Fri Dec 22 00:00:00 UTC 2023
-ecotone_time: 1708534800 # Wed Feb 21 17:00:00 UTC 2024
+regolith_time: 0         # Thu  1 Jan 1970 00:00:00 UTC (genesis)
+canyon_time: 1699981200  # Tue 14 Nov 2023 17:00:00 UTC
+delta_time: 1703203200   # Fri 22 Dec 2023 00:00:00 UTC
+ecotone_time: 1708534800 # Wed 21 Feb 2024 17:00:00 UTC
+

--- a/superchain/configs/sepolia/superchain.yaml
+++ b/superchain/configs/sepolia/superchain.yaml
@@ -7,6 +7,7 @@ l1:
 protocol_versions_addr: "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
 superchain_config_addr: "0xC2Be75506d5724086DEB7245bd260Cc9753911Be"
 
+regolith_time: 0 # genesis
 canyon_time: 1699981200 # Tue Nov 14 17:00:00 UTC 2023
 delta_time: 1703203200  # Fri Dec 22 00:00:00 UTC 2023
 ecotone_time: 1708534800 # Wed Feb 21 17:00:00 UTC 2024

--- a/superchain/configs/sepolia/superchain.yaml
+++ b/superchain/configs/sepolia/superchain.yaml
@@ -7,7 +7,6 @@ l1:
 protocol_versions_addr: "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
 superchain_config_addr: "0xC2Be75506d5724086DEB7245bd260Cc9753911Be"
 
-regolith_time: 0         # Thu  1 Jan 1970 00:00:00 UTC (genesis)
 canyon_time: 1699981200  # Tue 14 Nov 2023 17:00:00 UTC
 delta_time: 1703203200   # Fri 22 Dec 2023 00:00:00 UTC
 ecotone_time: 1708534800 # Wed 21 Feb 2024 17:00:00 UTC

--- a/superchain/configs/sepolia/zora.yaml
+++ b/superchain/configs/sepolia/zora.yaml
@@ -14,4 +14,4 @@ genesis:
   l2:
     hash: "0x8b17d2d52564a5a90079d9c860e1386272579e87b17ea27a3868513f53facd74"
     number: 0
-  l2_time: 1698080004
+  l2_time: 1698080004 # Mon 23 Oct 2023 16:53:24 UTC

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -49,6 +49,7 @@ type HardForkConfiguration struct {
 	EcotoneTime  *uint64 `yaml:"ecotone_time,omitempty"`
 	FjordTime    *uint64 `yaml:"fjord_time,omitempty"`
 }
+
 type ChainConfig struct {
 	Name         string `yaml:"name"`
 	ChainID      uint64 `yaml:"chain_id"`

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -512,7 +512,6 @@ func (s *SuperchainConfig) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	return nil
 }
 
-// TODO need to wrie a YAML unmarshaler for SuperchainConfig which handles the private fields properly
 
 type Superchain struct {
 	Config SuperchainConfig

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -43,11 +43,10 @@ type ChainGenesis struct {
 }
 
 type HardForkConfiguration struct {
-	RegolithTime *uint64 `yaml:"regolith_time,omitempty"`
-	CanyonTime   *uint64 `yaml:"canyon_time,omitempty"`
-	DeltaTime    *uint64 `yaml:"delta_time,omitempty"`
-	EcotoneTime  *uint64 `yaml:"ecotone_time,omitempty"`
-	FjordTime    *uint64 `yaml:"fjord_time,omitempty"`
+	CanyonTime  *uint64 `yaml:"canyon_time,omitempty"`
+	DeltaTime   *uint64 `yaml:"delta_time,omitempty"`
+	EcotoneTime *uint64 `yaml:"ecotone_time,omitempty"`
+	FjordTime   *uint64 `yaml:"fjord_time,omitempty"`
 }
 
 type ChainConfig struct {
@@ -89,10 +88,6 @@ func (c *ChainConfig) setNilHardforkTimestampsToDefault(s *SuperchainConfig) {
 	}
 
 	// This achieves:
-	//
-	// if c.RegolithTime == nil {
-	// 	c.RegolithTime = s.Config.hardForkDefaults.RegolithTime
-	// }
 
 	// if c.CanyonTime == nil {
 	// 	c.CanyonTime = s.Config.hardForkDefaults.CanyonTime

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -466,17 +466,11 @@ func unMarshalSuperchainConfig(data []byte, s *SuperchainConfig) error {
 		HardForks         *HardForkConfiguration `yaml:",inline"`
 	}{
 		SuperchainConfig: s,
-		HardForks:        &HardForkConfiguration{},
+		HardForks:        &s.hardForkDefaults,
 	}
 
-	err := yaml.Unmarshal(data, temp)
-	if err != nil {
-		return err
-	}
+	return yaml.Unmarshal(data, temp)
 
-	s.hardForkDefaults = *(temp.HardForks)
-
-	return nil
 }
 
 type Superchain struct {

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -512,7 +512,6 @@ func (s *SuperchainConfig) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	return nil
 }
 
-
 type Superchain struct {
 	Config SuperchainConfig
 

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -81,7 +81,7 @@ func (c *ChainConfig) setNilHardforkTimestampsToDefault(s *SuperchainConfig) {
 	for i := 0; i < hfcVal.NumField(); i++ {
 		hardForkName := hfcVal.Type().Field(i).Name
 		overrideValue := cVal.FieldByName(hardForkName)
-		if overrideValue.Interface().(*uint64) == nil {
+		if overrideValue.IsNil() {
 			defaultValue := sVal.FieldByName(hardForkName)
 			overrideValue.Set(defaultValue)
 		}

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -74,21 +74,19 @@ type ChainConfig struct {
 // setNilHardforkTimestampsToDefault overwrites each unspecified hardfork activation time override
 // with the superchain default.
 func (c *ChainConfig) setNilHardforkTimestampsToDefault(s *SuperchainConfig) {
-	cVal := reflect.ValueOf(c).Elem()
+	cVal := reflect.ValueOf(&c.HardForkConfiguration).Elem()
 	sVal := reflect.ValueOf(&s.hardForkDefaults).Elem()
 
-	hfcVal := reflect.ValueOf(HardForkConfiguration{})
-	for i := 0; i < hfcVal.NumField(); i++ {
-		hardForkName := hfcVal.Type().Field(i).Name
-		overrideValue := cVal.FieldByName(hardForkName)
+	for i := 0; i < reflect.Indirect(cVal).NumField(); i++ {
+		overrideValue := cVal.Field(i)
 		if overrideValue.IsNil() {
-			defaultValue := sVal.FieldByName(hardForkName)
+			defaultValue := sVal.Field(i)
 			overrideValue.Set(defaultValue)
 		}
 	}
 
 	// This achieves:
-
+	//
 	// if c.CanyonTime == nil {
 	// 	c.CanyonTime = s.Config.hardForkDefaults.CanyonTime
 	// }

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -74,22 +74,31 @@ type ChainConfig struct {
 // replaceMissingOverridesWithDefaults overwrites each unspecified hardfork activation time override
 // with the superchain default.
 func (c *ChainConfig) replaceMissingOverridesWithDefaults(s Superchain) {
+	dVal := reflect.ValueOf(c)
+	sVal := reflect.ValueOf(&s.Config.hardForkDefaults)
 
-	if c.CanyonTime == nil {
-		c.CanyonTime = s.Config.hardForkDefaults.CanyonTime
+	hfcVal := reflect.ValueOf(HardForkConfiguration{})
+	for i := 0; i < hfcVal.NumField(); i++ {
+		hardForkName := hfcVal.Type().Field(i).Name
+		overrideValue := dVal.Elem().FieldByName(hardForkName)
+
+		if overrideValue.Interface().(*uint64) == nil {
+			defaultValue := sVal.Elem().FieldByName(hardForkName)
+			overrideValue.Set(defaultValue)
+		}
 	}
-	if c.DeltaTime == nil {
-		c.DeltaTime = s.Config.hardForkDefaults.DeltaTime
-	}
-	if c.EcotoneTime == nil {
-		c.EcotoneTime = s.Config.hardForkDefaults.EcotoneTime
-	}
-	if c.FjordTime == nil {
-		c.FjordTime = s.Config.hardForkDefaults.FjordTime
-	}
-	if c.RegolithTime == nil {
-		c.RegolithTime = s.Config.hardForkDefaults.RegolithTime
-	}
+
+	// This achieves:
+	//
+	// if c.RegolithTime == nil {
+	// 	c.RegolithTime = s.Config.hardForkDefaults.RegolithTime
+	// }
+
+	// if c.CanyonTime == nil {
+	// 	c.CanyonTime = s.Config.hardForkDefaults.CanyonTime
+	// }
+	//
+	// ...etc for each field in HardForkConfiguration
 
 }
 

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -49,15 +49,6 @@ type HardForkConfiguration struct {
 	EcotoneTime  *uint64 `yaml:"ecotone_time,omitempty"`
 	FjordTime    *uint64 `yaml:"fjord_time,omitempty"`
 }
-
-type hardForkConfigurationPrivate struct {
-	regolithTime *uint64 `yaml:"regolith_time,omitempty"`
-	canyonTime   *uint64 `yaml:"canyon_time,omitempty"`
-	deltaTime    *uint64 `yaml:"delta_time,omitempty"`
-	ecotoneTime  *uint64 `yaml:"ecotone_time,omitempty"`
-	fjordTime    *uint64 `yaml:"fjord_time,omitempty"`
-}
-
 type ChainConfig struct {
 	Name         string `yaml:"name"`
 	ChainID      uint64 `yaml:"chain_id"`
@@ -85,19 +76,19 @@ type ChainConfig struct {
 func (c *ChainConfig) replaceMissingOverridesWithDefaults(s Superchain) {
 
 	if c.CanyonTime == nil {
-		c.CanyonTime = s.Config.canyonTime
+		c.CanyonTime = s.Config.hardForkDefaults.CanyonTime
 	}
 	if c.DeltaTime == nil {
-		c.DeltaTime = s.Config.deltaTime
+		c.DeltaTime = s.Config.hardForkDefaults.DeltaTime
 	}
 	if c.EcotoneTime == nil {
-		c.EcotoneTime = s.Config.ecotoneTime
+		c.EcotoneTime = s.Config.hardForkDefaults.EcotoneTime
 	}
 	if c.FjordTime == nil {
-		c.FjordTime = s.Config.fjordTime
+		c.FjordTime = s.Config.hardForkDefaults.FjordTime
 	}
 	if c.RegolithTime == nil {
-		c.RegolithTime = s.Config.regolithTime
+		c.RegolithTime = s.Config.hardForkDefaults.RegolithTime
 	}
 
 }
@@ -482,7 +473,7 @@ type SuperchainConfig struct {
 	SuperchainConfigAddr *Address `yaml:"superchain_config_addr,omitempty"`
 
 	// Hardfork Configuration. These values may be overridden by individual chains.
-	hardForkConfigurationPrivate `yaml:",inline"`
+	hardForkDefaults HardForkConfiguration `yaml:",inline"`
 }
 
 // custom unmarshal function to allow yaml to be unmarshalled into unexported fields
@@ -494,7 +485,7 @@ func (s *SuperchainConfig) UnmarshalYAML(unmarshal func(interface{}) error) erro
 		ProtocolVersionsAddr *Address `yaml:"protocol_versions_addr,omitempty"`
 		SuperchainConfigAddr *Address `yaml:"superchain_config_addr,omitempty"`
 
-		HardForkConfiguration `yaml:",inline"`
+		HardForks HardForkConfiguration `yaml:",inline"`
 	}{}
 
 	err := unmarshal(&temp)
@@ -507,11 +498,7 @@ func (s *SuperchainConfig) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	s.L1 = temp.L1
 	s.ProtocolVersionsAddr = temp.ProtocolVersionsAddr
 	s.SuperchainConfigAddr = temp.SuperchainConfigAddr
-	s.canyonTime = temp.CanyonTime
-	s.deltaTime = temp.DeltaTime
-	s.ecotoneTime = temp.EcotoneTime
-	s.fjordTime = temp.FjordTime
-	s.regolithTime = temp.RegolithTime
+	s.hardForkDefaults = temp.HardForks
 
 	return nil
 }

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -447,11 +447,11 @@ func TestHardForkOverridesAndDefaults(t *testing.T) {
 
 		c := ChainConfig{}
 		err := yaml.Unmarshal([]byte(rawYAML), &c)
+		require.NoError(t, err)
+
 		c.setNilHardforkTimestampsToDefault(&s)
 
-		require.NoError(t, err)
 		require.Equal(t, uint64Ptr(uint64(8)), c.CanyonTime)
-
 	})
 
 	t.Run("override: unmarshal with a key and no value", func(t *testing.T) {
@@ -459,11 +459,11 @@ func TestHardForkOverridesAndDefaults(t *testing.T) {
 
 		c := ChainConfig{}
 		err := yaml.Unmarshal([]byte(rawYAML), &c)
+		require.NoError(t, err)
+
 		c.setNilHardforkTimestampsToDefault(&s)
 
-		require.NoError(t, err)
 		require.Equal(t, &defaultCanyonTime, c.CanyonTime)
-
 	})
 
 	t.Run("override: unmarshal with no key and no value", func(t *testing.T) {
@@ -471,9 +471,9 @@ func TestHardForkOverridesAndDefaults(t *testing.T) {
 
 		c := ChainConfig{}
 		err := yaml.Unmarshal([]byte(rawYAML), &c)
-		c.setNilHardforkTimestampsToDefault(&s)
-
 		require.NoError(t, err)
+
+		c.setNilHardforkTimestampsToDefault(&s)
 
 		require.Equal(t, &defaultCanyonTime, c.CanyonTime)
 	})

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -396,12 +396,6 @@ func testNetworkUpgradeTimestampOffset(l2GenesisTime uint64, blockTime uint64, u
 	}
 }
 
-func TestHardforkActivationTimeOverrides(t *testing.T) {
-	require.Equal(t, uint64Ptr(uint64(1679079600)), OPChains[420].RegolithTime, "regolith time not overidden properly for chain 420")
-	require.Equal(t, uint64Ptr(uint64(0)), OPChains[84532].RegolithTime, "regolith time not read properly for chain 84532")
-	require.Equal(t, uint64Ptr(uint64(1706634000)), OPChains[11155421].EcotoneTime, "regolith time not read properly for chain 11155421")
-}
-
 func TestSuperchainConfigUnmarshaling(t *testing.T) {
 	rawYAML := `
 name: Mickey Mouse
@@ -413,7 +407,6 @@ l1:
 protocol_versions_addr: "0x252CbE9517F731C618961D890D534183822dcC8d"
 superchain_config_addr: "0x02d91Cf852423640d93920BE0CAdceC0E7A00FA7"
 
-regolith_time: 0 
 canyon_time: 1
 delta_time: 2
 ecotone_time: 3
@@ -432,7 +425,6 @@ fjord_time:
 	}, s.L1)
 	require.Equal(t, "0x252cbe9517f731c618961d890d534183822dcc8d", s.ProtocolVersionsAddr.String())
 	require.Equal(t, "0x02d91cf852423640d93920be0cadcec0e7a00fa7", s.SuperchainConfigAddr.String())
-	require.Equal(t, uint64Ptr(uint64(0)), s.hardForkDefaults.RegolithTime)
 	require.Equal(t, uint64Ptr(uint64(1)), s.hardForkDefaults.CanyonTime)
 	require.Equal(t, uint64Ptr(uint64(2)), s.hardForkDefaults.DeltaTime)
 	require.Equal(t, uint64Ptr(uint64(3)), s.hardForkDefaults.EcotoneTime)
@@ -451,39 +443,31 @@ func TestHardForkOverridesAndDefaults(t *testing.T) {
 		}}
 
 	t.Run("override: unmarshal with an override", func(t *testing.T) {
-		rawYAML := `
-regolith_time: 7
-canyon_time: 8`
+		rawYAML := `canyon_time: 8`
 
 		c := ChainConfig{}
 		err := yaml.Unmarshal([]byte(rawYAML), &c)
 		c.setNilHardforkTimestampsToDefault(&s)
 
 		require.NoError(t, err)
-
-		require.Equal(t, uint64Ptr(uint64(7)), c.RegolithTime)
 		require.Equal(t, uint64Ptr(uint64(8)), c.CanyonTime)
 
 	})
 
 	t.Run("override: unmarshal with a key and no value", func(t *testing.T) {
-		rawYAML := `
-regolith_time: 2
-canyon_time:`
+		rawYAML := `canyon_time:`
 
 		c := ChainConfig{}
 		err := yaml.Unmarshal([]byte(rawYAML), &c)
 		c.setNilHardforkTimestampsToDefault(&s)
 
 		require.NoError(t, err)
-
-		require.Equal(t, uint64Ptr(uint64(2)), c.RegolithTime)
 		require.Equal(t, &defaultCanyonTime, c.CanyonTime)
 
 	})
 
 	t.Run("override: unmarshal with no key and no value", func(t *testing.T) {
-		rawYAML := `regolith_time: 1679079600 # Fri 17 Mar 2023 19:00:00 UTC`
+		rawYAML := ``
 
 		c := ChainConfig{}
 		err := yaml.Unmarshal([]byte(rawYAML), &c)
@@ -491,7 +475,6 @@ canyon_time:`
 
 		require.NoError(t, err)
 
-		require.Equal(t, uint64Ptr(uint64(1679079600)), c.RegolithTime)
 		require.Equal(t, &defaultCanyonTime, c.CanyonTime)
 	})
 }

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -353,13 +353,13 @@ func TestContractBytecodes(t *testing.T) {
 // TestCanyonTimestampOnBlockBoundary asserts that Canyon will activate on a block's timestamp.
 // This is critical because the create2Deployer only activates on a block's timestamp.
 func TestCanyonTimestampOnBlockBoundary(t *testing.T) {
-	testStandardTimestampOnBlockBoundary(t, func(s *Superchain) *uint64 { return s.Config.CanyonTime })
+	testStandardTimestampOnBlockBoundary(t, func(c *ChainConfig) *uint64 { return c.CanyonTime })
 }
 
 // TestEcotoneTimestampOnBlockBoundary asserts that Ecotone will activate on a block's timestamp.
 // This is critical because the L2 upgrade transactions only activates on a block's timestamp.
 func TestEcotoneTimestampOnBlockBoundary(t *testing.T) {
-	testStandardTimestampOnBlockBoundary(t, func(s *Superchain) *uint64 { return s.Config.EcotoneTime })
+	testStandardTimestampOnBlockBoundary(t, func(c *ChainConfig) *uint64 { return c.EcotoneTime })
 }
 
 // TestAevoForkTimestamps ensures that network upgades that occur on a block boundary
@@ -368,15 +368,15 @@ func TestAevoForkTimestamps(t *testing.T) {
 	aevoGenesisL2Time := uint64(1679193011)
 	aevoBlockTime := uint64(10)
 	config := Superchains["mainnet"]
-	t.Run("canyon", testNetworkUpgradeTimestampOffset(aevoGenesisL2Time, aevoBlockTime, config.Config.CanyonTime))
-	t.Run("ecotone", testNetworkUpgradeTimestampOffset(aevoGenesisL2Time, aevoBlockTime, config.Config.EcotoneTime))
+	t.Run("canyon", testNetworkUpgradeTimestampOffset(aevoGenesisL2Time, aevoBlockTime, config.Config.canyonTime))
+	t.Run("ecotone", testNetworkUpgradeTimestampOffset(aevoGenesisL2Time, aevoBlockTime, config.Config.ecotoneTime))
 }
 
-func testStandardTimestampOnBlockBoundary(t *testing.T, ts func(*Superchain) *uint64) {
+func testStandardTimestampOnBlockBoundary(t *testing.T, ts func(*ChainConfig) *uint64) {
 	for _, superchainConfig := range Superchains {
 		for _, id := range superchainConfig.ChainIDs {
 			chainCfg := OPChains[id]
-			t.Run(chainCfg.Name, testNetworkUpgradeTimestampOffset(chainCfg.Genesis.L2Time, 2, ts(superchainConfig)))
+			t.Run(chainCfg.Name, testNetworkUpgradeTimestampOffset(chainCfg.Genesis.L2Time, 2, ts(chainCfg)))
 		}
 	}
 }
@@ -394,4 +394,45 @@ func testNetworkUpgradeTimestampOffset(l2GenesisTime uint64, blockTime uint64, u
 			t.Fatalf("HF time is not on the block time. network upgade time: %v. L2 start time: %v, block time: %v ", *upgradeTime, l2GenesisTime, blockTime)
 		}
 	}
+}
+
+func TestHardforkActivationTimeOverrides(t *testing.T) {
+	require.Equal(t, uint64(1679079600), *(OPChains[420].RegolithTime), "regolith time not overidden properly for chain 420")
+	require.Equal(t, uint64(0), *(OPChains[84532].RegolithTime), "regolith time not read properly for chain 84532")
+	require.Equal(t, uint64(1706634000), *(OPChains[11155421].EcotoneTime), "regolith time not read properly for chain 11155421")
+}
+
+func TestSuperchainConfigUnmarshaling(t *testing.T) {
+	rawYAML := `
+name: Mickey Mouse
+l1:
+  chain_id: 314
+  public_rpc: https://disney.com
+  explorer: https://disneyscan.io
+
+protocol_versions_addr: "0x252CbE9517F731C618961D890D534183822dcC8d"
+superchain_config_addr: "0x02d91Cf852423640d93920BE0CAdceC0E7A00FA7"
+
+regolith_time: 0 
+canyon_time: 1
+delta_time: 2
+ecotone_time: 3
+`
+
+	s := SuperchainConfig{}
+	err := yaml.Unmarshal([]byte(rawYAML), &s)
+	require.NoError(t, err)
+
+	require.Equal(t, "Mickey Mouse", s.Name)
+	require.Equal(t, SuperchainL1Info{
+		ChainID:   314,
+		PublicRPC: "https://disney.com",
+		Explorer:  "https://disneyscan.io",
+	}, s.L1)
+	require.Equal(t, "0x252cbe9517f731c618961d890d534183822dcc8d", s.ProtocolVersionsAddr.String())
+	require.Equal(t, "0x02d91cf852423640d93920be0cadcec0e7a00fa7", s.SuperchainConfigAddr.String())
+	require.Equal(t, uint64(0), *s.regolithTime)
+	require.Equal(t, uint64(1), *s.canyonTime)
+	require.Equal(t, uint64(2), *s.deltaTime)
+	require.Equal(t, uint64(3), *s.ecotoneTime)
 }

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -368,8 +368,8 @@ func TestAevoForkTimestamps(t *testing.T) {
 	aevoGenesisL2Time := uint64(1679193011)
 	aevoBlockTime := uint64(10)
 	config := Superchains["mainnet"]
-	t.Run("canyon", testNetworkUpgradeTimestampOffset(aevoGenesisL2Time, aevoBlockTime, config.Config.canyonTime))
-	t.Run("ecotone", testNetworkUpgradeTimestampOffset(aevoGenesisL2Time, aevoBlockTime, config.Config.ecotoneTime))
+	t.Run("canyon", testNetworkUpgradeTimestampOffset(aevoGenesisL2Time, aevoBlockTime, config.Config.hardForkDefaults.CanyonTime))
+	t.Run("ecotone", testNetworkUpgradeTimestampOffset(aevoGenesisL2Time, aevoBlockTime, config.Config.hardForkDefaults.EcotoneTime))
 }
 
 func testStandardTimestampOnBlockBoundary(t *testing.T, ts func(*ChainConfig) *uint64) {
@@ -431,8 +431,8 @@ ecotone_time: 3
 	}, s.L1)
 	require.Equal(t, "0x252cbe9517f731c618961d890d534183822dcc8d", s.ProtocolVersionsAddr.String())
 	require.Equal(t, "0x02d91cf852423640d93920be0cadcec0e7a00fa7", s.SuperchainConfigAddr.String())
-	require.Equal(t, uint64(0), *s.regolithTime)
-	require.Equal(t, uint64(1), *s.canyonTime)
-	require.Equal(t, uint64(2), *s.deltaTime)
-	require.Equal(t, uint64(3), *s.ecotoneTime)
+	require.Equal(t, uint64(0), *s.hardForkDefaults.RegolithTime)
+	require.Equal(t, uint64(1), *s.hardForkDefaults.CanyonTime)
+	require.Equal(t, uint64(2), *s.hardForkDefaults.DeltaTime)
+	require.Equal(t, uint64(3), *s.hardForkDefaults.EcotoneTime)
 }

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -481,6 +481,32 @@ func TestHardForkOverridesAndDefaults(t *testing.T) {
 
 }
 
+func TestHardForkOverridesAndDefaults2(t *testing.T) {
+
+	defaultSuperchainConfig := SuperchainConfig{
+		hardForkDefaults: HardForkConfiguration{
+			CanyonTime: uint64Ptr(0),
+			DeltaTime:  uint64Ptr(1),
+		}}
+
+	c := ChainConfig{}
+
+	rawYAML := `
+ecotone_time: 2
+fjord_time: 3
+`
+
+	err := yaml.Unmarshal([]byte(rawYAML), &c)
+	require.NoError(t, err)
+
+	c.setNilHardforkTimestampsToDefault(&defaultSuperchainConfig)
+
+	require.Equal(t, uint64Ptr(uint64(0)), c.CanyonTime)
+	require.Equal(t, uint64Ptr(uint64(1)), c.DeltaTime)
+	require.Equal(t, uint64Ptr(uint64(2)), c.EcotoneTime)
+	require.Equal(t, uint64Ptr(uint64(3)), c.FjordTime)
+}
+
 func uint64Ptr(i uint64) *uint64 {
 	return &i
 }

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -492,7 +492,7 @@ canyon_time:`
 		require.NoError(t, err)
 
 		require.Equal(t, uint64Ptr(uint64(1679079600)), c.RegolithTime)
-		require.Equal(t, defaultCanyonTime, c.CanyonTime)
+		require.Equal(t, &defaultCanyonTime, c.CanyonTime)
 	})
 }
 

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -439,6 +439,53 @@ fjord_time:
 	require.Nil(t, s.hardForkDefaults.FjordTime)
 }
 
+func TestChainConfigUnmarshaling(t *testing.T) {
+
+	// Set a ChainConfig to unmarshal into
+	// which already has a default value set
+	c := ChainConfig{
+		HardForkConfiguration: HardForkConfiguration{
+			CanyonTime: uint64Ptr(uint64(44)), // default value
+		},
+	}
+
+	t.Run("override: unmarshal with an override", func(t *testing.T) {
+		rawYAML := `
+regolith_time: 1679079600 # Fri 17 Mar 2023 19:00:00 UTC
+canyon_time: 98`
+
+		err := yaml.Unmarshal([]byte(rawYAML), &c)
+		require.NoError(t, err)
+
+		require.Equal(t, uint64Ptr(uint64(1679079600)), c.RegolithTime)
+		require.Equal(t, uint64Ptr(uint64(98)), c.CanyonTime)
+
+	})
+
+	t.Run("override: unmarshal with a key and no value", func(t *testing.T) {
+		rawYAML := `
+regolith_time: 1679079600 # Fri 17 Mar 2023 19:00:00 UTC
+canyon_time:`
+
+		err := yaml.Unmarshal([]byte(rawYAML), &c)
+		require.NoError(t, err)
+
+		require.Equal(t, uint64Ptr(uint64(1679079600)), c.RegolithTime)
+		require.Equal(t, uint64Ptr(uint64(44)), c.CanyonTime)
+
+	})
+
+	t.Run("override: unmarshal with no key and no value", func(t *testing.T) {
+		rawYAML := `regolith_time: 1679079600 # Fri 17 Mar 2023 19:00:00 UTC`
+
+		err := yaml.Unmarshal([]byte(rawYAML), &c)
+		require.NoError(t, err)
+
+		require.Equal(t, uint64Ptr(uint64(1679079600)), c.RegolithTime)
+		require.Equal(t, uint64Ptr(uint64(44)), c.CanyonTime)
+	})
+}
+
 func uint64Ptr(i uint64) *uint64 {
 	return &i
 }

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -439,7 +439,7 @@ fjord_time:
 	require.Nil(t, s.hardForkDefaults.FjordTime)
 }
 
-func TestHardForkOverridesAndDefaults(*testing.T) {
+func TestHardForkOverridesAndDefaults(t *testing.T) {
 
 	defaultCanyonTime := uint64(3)
 

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -417,6 +417,7 @@ regolith_time: 0
 canyon_time: 1
 delta_time: 2
 ecotone_time: 3
+fjord_time: 
 `
 
 	s := SuperchainConfig{}
@@ -435,6 +436,7 @@ ecotone_time: 3
 	require.Equal(t, uint64Ptr(uint64(1)), s.hardForkDefaults.CanyonTime)
 	require.Equal(t, uint64Ptr(uint64(2)), s.hardForkDefaults.DeltaTime)
 	require.Equal(t, uint64Ptr(uint64(3)), s.hardForkDefaults.EcotoneTime)
+	require.Nil(t, s.hardForkDefaults.FjordTime)
 }
 
 func uint64Ptr(i uint64) *uint64 {

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -420,7 +420,7 @@ ecotone_time: 3
 `
 
 	s := SuperchainConfig{}
-	err := yaml.Unmarshal([]byte(rawYAML), &s)
+	err := unMarshalSuperchainConfig([]byte(rawYAML), &s)
 	require.NoError(t, err)
 
 	require.Equal(t, "Mickey Mouse", s.Name)
@@ -431,8 +431,8 @@ ecotone_time: 3
 	}, s.L1)
 	require.Equal(t, "0x252cbe9517f731c618961d890d534183822dcc8d", s.ProtocolVersionsAddr.String())
 	require.Equal(t, "0x02d91cf852423640d93920be0cadcec0e7a00fa7", s.SuperchainConfigAddr.String())
-	require.Equal(t, uint64(0), *s.hardForkDefaults.RegolithTime)
-	require.Equal(t, uint64(1), *s.hardForkDefaults.CanyonTime)
-	require.Equal(t, uint64(2), *s.hardForkDefaults.DeltaTime)
-	require.Equal(t, uint64(3), *s.hardForkDefaults.EcotoneTime)
+	require.Equal(t, uint64(0), *(s.hardForkDefaults.RegolithTime))
+	require.Equal(t, uint64(1), *(s.hardForkDefaults.CanyonTime))
+	require.Equal(t, uint64(2), *(s.hardForkDefaults.DeltaTime))
+	require.Equal(t, uint64(3), *(s.hardForkDefaults.EcotoneTime))
 }

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -397,9 +397,9 @@ func testNetworkUpgradeTimestampOffset(l2GenesisTime uint64, blockTime uint64, u
 }
 
 func TestHardforkActivationTimeOverrides(t *testing.T) {
-	require.Equal(t, uint64(1679079600), *(OPChains[420].RegolithTime), "regolith time not overidden properly for chain 420")
-	require.Equal(t, uint64(0), *(OPChains[84532].RegolithTime), "regolith time not read properly for chain 84532")
-	require.Equal(t, uint64(1706634000), *(OPChains[11155421].EcotoneTime), "regolith time not read properly for chain 11155421")
+	require.Equal(t, uint64Ptr(uint64(1679079600)), OPChains[420].RegolithTime, "regolith time not overidden properly for chain 420")
+	require.Equal(t, uint64Ptr(uint64(0)), OPChains[84532].RegolithTime, "regolith time not read properly for chain 84532")
+	require.Equal(t, uint64Ptr(uint64(1706634000)), OPChains[11155421].EcotoneTime, "regolith time not read properly for chain 11155421")
 }
 
 func TestSuperchainConfigUnmarshaling(t *testing.T) {
@@ -431,8 +431,12 @@ ecotone_time: 3
 	}, s.L1)
 	require.Equal(t, "0x252cbe9517f731c618961d890d534183822dcc8d", s.ProtocolVersionsAddr.String())
 	require.Equal(t, "0x02d91cf852423640d93920be0cadcec0e7a00fa7", s.SuperchainConfigAddr.String())
-	require.Equal(t, uint64(0), *(s.hardForkDefaults.RegolithTime))
-	require.Equal(t, uint64(1), *(s.hardForkDefaults.CanyonTime))
-	require.Equal(t, uint64(2), *(s.hardForkDefaults.DeltaTime))
-	require.Equal(t, uint64(3), *(s.hardForkDefaults.EcotoneTime))
+	require.Equal(t, uint64Ptr(uint64(0)), s.hardForkDefaults.RegolithTime)
+	require.Equal(t, uint64Ptr(uint64(1)), s.hardForkDefaults.CanyonTime)
+	require.Equal(t, uint64Ptr(uint64(2)), s.hardForkDefaults.DeltaTime)
+	require.Equal(t, uint64Ptr(uint64(3)), s.hardForkDefaults.EcotoneTime)
+}
+
+func uint64Ptr(i uint64) *uint64 {
+	return &i
 }

--- a/validation/go.mod
+++ b/validation/go.mod
@@ -4,11 +4,11 @@ go 1.21
 
 replace github.com/ethereum-optimism/superchain-registry/superchain => ../superchain
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101304.1
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101308.2-rc.1.0.20240222161420-b2b2a2ce17d5
 
 require (
 	github.com/ethereum-optimism/optimism v1.5.0
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240131175747-1300b1825140
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240222161320-b5d807fec4e4
 	github.com/ethereum/go-ethereum v1.13.11
 	github.com/stretchr/testify v1.8.4
 )
@@ -28,15 +28,16 @@ require (
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/consensys/bavard v0.1.13 // indirect
 	github.com/consensys/gnark-crypto v0.12.1 // indirect
+	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233 // indirect
 	github.com/crate-crypto/go-kzg-4844 v0.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set/v2 v2.1.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/ethereum/c-kzg-4844 v0.4.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/gballet/go-verkle v0.1.1-0.20231031103413-a67434b50f46 // indirect
 	github.com/getsentry/sentry-go v0.18.0 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect

--- a/validation/go.mod
+++ b/validation/go.mod
@@ -4,11 +4,11 @@ go 1.21
 
 replace github.com/ethereum-optimism/superchain-registry/superchain => ../superchain
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101308.2-rc.1.0.20240222161420-b2b2a2ce17d5
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101308.3-0.20240227111709-dee62ab5ca66
 
 require (
 	github.com/ethereum-optimism/optimism v1.5.0
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240222161320-b5d807fec4e4
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240227110823-11c73f54ad9b
 	github.com/ethereum/go-ethereum v1.13.11
 	github.com/stretchr/testify v1.8.4
 )

--- a/validation/go.sum
+++ b/validation/go.sum
@@ -55,8 +55,8 @@ github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5il
 github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etlyjdBU4sfcs2WYQMs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
-github.com/ethereum-optimism/op-geth v1.101308.2-rc.1.0.20240222161420-b2b2a2ce17d5 h1:H7ksA2ycPYPkYuDVoRr8afDI3RAtwA+KGMnFl1kpAIc=
-github.com/ethereum-optimism/op-geth v1.101308.2-rc.1.0.20240222161420-b2b2a2ce17d5/go.mod h1:wJtYlh/Ca7J8nXTnfWxNIVaBfSPLP6xMeU1g88JdImw=
+github.com/ethereum-optimism/op-geth v1.101308.3-0.20240227111709-dee62ab5ca66 h1:PE09cWS4zSBIJuCrO6iwO3+KGAszDCimpKxch3v06XA=
+github.com/ethereum-optimism/op-geth v1.101308.3-0.20240227111709-dee62ab5ca66/go.mod h1:iwgkufxGgnY5BogbupqbnicbV1HavBslQSfF+ozLUkg=
 github.com/ethereum-optimism/optimism v1.5.0 h1:8G02/3fucUZA5CyWCo+iM7vfXgqf92xIoy38Kibqjdc=
 github.com/ethereum-optimism/optimism v1.5.0/go.mod h1:qfr3RZFY/vVH/xhryAaY7+mQPwJXt5PP9CN86tELgdg=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=

--- a/validation/go.sum
+++ b/validation/go.sum
@@ -41,6 +41,8 @@ github.com/consensys/gnark-crypto v0.12.1 h1:lHH39WuuFgVHONRl3J0LRBtuYdQTumFSDtJ
 github.com/consensys/gnark-crypto v0.12.1/go.mod h1:v2Gy7L/4ZRosZ7Ivs+9SfUDr0f5UlG+EM5t7MPHiLuY=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233 h1:d28BXYi+wUpz1KBmiF9bWrjEMacUEREV6MBi2ODnrfQ=
+github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233/go.mod h1:geZJZH3SzKCqnz5VT0q/DyIG/tvu/dZk+VIfXicupJs=
 github.com/crate-crypto/go-kzg-4844 v0.7.0 h1:C0vgZRk4q4EZ/JgPfzuSoxdCq3C3mOZMBShovmncxvA=
 github.com/crate-crypto/go-kzg-4844 v0.7.0/go.mod h1:1kMhvPgI0Ky3yIa+9lFySEBUBXkYxeOi8ZF1sYioxhc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -53,8 +55,8 @@ github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5il
 github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etlyjdBU4sfcs2WYQMs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
-github.com/ethereum-optimism/op-geth v1.101304.1 h1:XGrrh0n1N/ubsLRAF9yPd9UI1+AfwzePimpV5jXzUc4=
-github.com/ethereum-optimism/op-geth v1.101304.1/go.mod h1:12W+vBetjYbDj5D2+V8hizke5yWuLrUDf7UmVkXTnCQ=
+github.com/ethereum-optimism/op-geth v1.101308.2-rc.1.0.20240222161420-b2b2a2ce17d5 h1:H7ksA2ycPYPkYuDVoRr8afDI3RAtwA+KGMnFl1kpAIc=
+github.com/ethereum-optimism/op-geth v1.101308.2-rc.1.0.20240222161420-b2b2a2ce17d5/go.mod h1:wJtYlh/Ca7J8nXTnfWxNIVaBfSPLP6xMeU1g88JdImw=
 github.com/ethereum-optimism/optimism v1.5.0 h1:8G02/3fucUZA5CyWCo+iM7vfXgqf92xIoy38Kibqjdc=
 github.com/ethereum-optimism/optimism v1.5.0/go.mod h1:qfr3RZFY/vVH/xhryAaY7+mQPwJXt5PP9CN86tELgdg=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=
@@ -68,6 +70,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08 h1:f6D9Hr8xV8uYKlyuj8XIruxlh9WjVjdh1gIicAS7ays=
 github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
+github.com/gballet/go-verkle v0.1.1-0.20231031103413-a67434b50f46 h1:BAIP2GihuqhwdILrV+7GJel5lyPV3u1+PgzrWLc0TkE=
+github.com/gballet/go-verkle v0.1.1-0.20231031103413-a67434b50f46/go.mod h1:QNpY22eby74jVhqH4WhDLDwxc/vqsern6pW+u2kbkpc=
 github.com/getsentry/sentry-go v0.18.0 h1:MtBW5H9QgdcJabtZcuJG80BMOwaBpkRDZkxRkNC1sN0=
 github.com/getsentry/sentry-go v0.18.0/go.mod h1:Kgon4Mby+FJ7ZWHFUAZgVaIa8sxHtnRJRLTXZr51aKQ=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
@@ -75,8 +79,6 @@ github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3Bop
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
-github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
-github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
@@ -102,6 +104,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/gofuzz v1.2.1-0.20220503160820-4a35382e8fc8 h1:Ep/joEub9YwcjRY6ND3+Y/w0ncE540RtGatVhtZL0/Q=
+github.com/google/gofuzz v1.2.1-0.20220503160820-4a35382e8fc8/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/validation/gpo-params_test.go
+++ b/validation/gpo-params_test.go
@@ -87,7 +87,7 @@ func TestGasPriceOracleParams(t *testing.T) {
 	}
 
 	checkResourceConfig := func(t *testing.T, chain *ChainConfig, client *ethclient.Client) {
-		if Superchains[chain.Superchain].IsEcotone() {
+		if chain.IsEcotone() {
 			checkEcotoneResourceConfig(t, chain, client)
 		} else {
 			checkPreEcotoneResourceConfig(t, chain, client)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Adds per-chain hardfork time overrides.

* Existing superchain-wide hardfork times remain in the `yaml` files, but are nested under a private struct member to prevent Go consumers accessing them (breaking change for `op-geth` and `monorepo`)
* The hardfork times are instead available in each chains config
* when the module inits, the hardfork times are hydrated and default back to the superchain wide values if no override exists
* the breaking change breaks the `validation` module in this repo because it depends on `op-geth`. Therefore I pointed `validation` at a fixed version of `op-geth` which itself points back to the new version of `superchain` 😵 
* Also updated monorepo to cope with breaking change (also need to update to fixed version of op-geth)
* Bit of a challenge to coordinate merging the changes in the three repos. 


**Tests**

* couple of "spot check" tests for the overrides
* test for new unmarshalling code

**Additional context**
Coupled PRS in the other repos removing overrides:
https://github.com/ethereum-optimism/op-geth/pull/252
https://github.com/ethereum-optimism/optimism/pull/9642



**Metadata**

Towards https://github.com/ethereum-optimism/client-pod/issues/605
