### PR TITLE
superchain: remove global `ok` boolean

### DIFF
--- a/superchain/params.go
+++ b/superchain/params.go
@@ -4,13 +4,13 @@ import (
 	"math/big"
 )
 
-var uint128Max, ok = big.NewInt(0).SetString("ffffffffffffffffffffffffffffffff", 16)
-
-func init() {
+var uint128Max = func() *big.Int {
+	r, ok := new(big.Int).SetString("ffffffffffffffffffffffffffffffff", 16)
 	if !ok {
 		panic("cannot construct uint128Max")
 	}
-}
+	return r
+}()
 
 type ResourceConfig struct {
 	MaxResourceLimit            uint32


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Better not have a global `ok` boolean floating around from the `uint128Max` initialization.
