### PR TITLE
Widen bounds on GPO params

### DIFF
--- a/superchain/params.go
+++ b/superchain/params.go
@@ -110,7 +110,7 @@ var GasPriceOracleParams = map[string]UpgradeFilter{
 		},
 		Ecotone: &EcotoneGasPriceOracleParamsWithBounds{
 			Decimals:          makeBigIntAndBounds(6, [2]int64{6, 6}),
-			BlobBaseFeeScalar: Uint32AndBounds{862_000, [2]uint32{500_000, 862_000}},
+			BlobBaseFeeScalar: Uint32AndBounds{862_000, [2]uint32{500_000, 1_000_000}},
 			BaseFeeScalar:     Uint32AndBounds{7600, [2]uint32{970, 7600}},
 		},
 	},


### PR DESCRIPTION
prevents:

```
        	Test:       	TestGasPriceOracleParams/Zora_(7777777)
        	Messages:   	blobBaseFeeScalar 950496 out of bounds [500000 862000]
```
