### PR TITLE
superchain: add mainnet superchain config address

### DIFF
--- a/superchain/configs/mainnet/superchain.yaml
+++ b/superchain/configs/mainnet/superchain.yaml
@@ -5,6 +5,7 @@ l1:
   explorer: https://etherscan.io
 
 protocol_versions_addr: "0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935"
+superchain_config_addr: "0x95703e0982140d16f8eba6d158fccede42f04a4c"
 
 canyon_time: 1704992401  # Thu 11 Jan 2024 17:00:01 UTC
 delta_time: 1708560000   # Thu 22 Feb 2024 00:00:00 UTC


### PR DESCRIPTION
**Description**

Sourced from https://www.notion.so/oplabs/Mainnet-Extended-Pause-Contracts-2122cb7664294cab867fc5068a37c1d6

Follows the same format for sepolia.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

