### PR TITLE
chore: Use modern esmodules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@eth-optimism/superchain-registry",
   "version": "0.0.1-alpha.1",
+  "type": "module",
   "description": "[Optimism] Superchain Registry",
   "author": "Optimism",
   "private": false,

--- a/scripts/codegen.js
+++ b/scripts/codegen.js
@@ -1,6 +1,8 @@
-const fs = require('fs')
-const path = require('path')
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 /**
  * Generates the chainids.json file that sits at the root of the
  * superchain/configs folder. Useful to have a combined JSON file for all of
@@ -66,7 +68,7 @@ const addresses = () => {
       const filename = filepath.replace('.json', '')
       const chain = path.relative(folder, filename).replace(path.sep, '/')
       const content = fs.readFileSync(filepath, 'utf8')
-      
+
       if (chainids[chain]) {
         result[chainids[chain]] = JSON.parse(content)
       }


### PR DESCRIPTION
Updates the package.json to use modern esmodules rather than the older commonjs. This helps with general compatibility and futureproofness.

The result of this change is `require()` and `module.exports` syntax by default will not work unless the file is explicitly a `.cjs` file or using `ts-node`, `tsx`, or `esbuild` or some other tool. You should instead use module syntax `import {Foo} from 'foo'` and `export default Foo`
