### PR TITLE
fix: clean up validation check exclusions

### DIFF
--- a/validation/gpo-params_test.go
+++ b/validation/gpo-params_test.go
@@ -19,14 +19,8 @@ import (
 
 func TestGasPriceOracleParams(t *testing.T) {
 	isExcluded := map[uint64]bool{
-		291:       true, // mainnet/orderly                 (incorrect scalar parameter)
-		424:       true, // mainnet/pgn                     (blobBaseFeeScalar out of bounds)
-		957:       true, // mainnet/lyra                    (incorrect scalar parameter)
-		58008:     true, // sepolia/pgn                     (blobBaseFeeScalar out of bounds)
-		84532:     true, // sepolia/base                    (blobBaseFeeScalar out of bounds)
-		11155421:  true, // sepolia-dev-0/oplabs-devnet-0   (no public endpoint)
-		11763072:  true, // sepolia-dev-0/base-devnet-0     (no public endpoint)
-		999999999: true, // sepolia/zora                    (blobBaseFeeScalar out of bounds)
+		11155421: true, // sepolia-dev-0/oplabs-devnet-0   (no public endpoint)
+		11763072: true, // sepolia-dev-0/base-devnet-0     (no public endpoint)
 	}
 
 	gasPriceOraclAddr := predeploys.GasPriceOracleAddr
@@ -86,9 +80,9 @@ func TestGasPriceOracleParams(t *testing.T) {
 	}
 
 	for chainID, chain := range OPChains {
-		SkipCheckIfFrontierChain(t, *chain)
 		if !isExcluded[chainID] {
 			t.Run(chain.Name+fmt.Sprintf(" (%d)", chainID), func(t *testing.T) {
+				SkipCheckIfFrontierChain(t, *chain)
 				rpcEndpoint := chain.PublicRPC
 				require.NotEmpty(t, rpcEndpoint, "no public endpoint for chain")
 				client, err := ethclient.Dial(rpcEndpoint)

--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -83,7 +83,6 @@ func TestL2OOParams(t *testing.T) {
 	}
 
 	for chainID, chain := range OPChains {
-
 		if !isExcluded[chainID] {
 			t.Run(chain.Name+fmt.Sprintf(" (%d)", chainID), func(t *testing.T) {
 				SkipCheckIfFrontierChain(t, *chain)

--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -83,9 +83,12 @@ func TestL2OOParams(t *testing.T) {
 	}
 
 	for chainID, chain := range OPChains {
-		SkipCheckIfFrontierChain(t, *chain)
+
 		if !isExcluded[chainID] {
-			t.Run(chain.Name+fmt.Sprintf(" (%d)", chainID), func(t *testing.T) { checkL2OOParams(t, chain) })
+			t.Run(chain.Name+fmt.Sprintf(" (%d)", chainID), func(t *testing.T) {
+				SkipCheckIfFrontierChain(t, *chain)
+				checkL2OOParams(t, chain)
+			})
 		}
 	}
 }

--- a/validation/resource-config_test.go
+++ b/validation/resource-config_test.go
@@ -17,10 +17,6 @@ import (
 )
 
 func TestResourceConfig(t *testing.T) {
-	isExcluded := map[uint64]bool{
-		997: true, // OP_Labs_devnet_0 (uses old SystemConfigProxy with no resourceConfig() getter )
-	}
-
 	checkResourceConfig := func(t *testing.T, chain *ChainConfig) {
 		rpcEndpoint := Superchains[chain.Superchain].Config.L1.PublicRPC
 
@@ -41,10 +37,10 @@ func TestResourceConfig(t *testing.T) {
 	}
 
 	for chainID, chain := range OPChains {
-		SkipCheckIfFrontierChain(t, *chain)
-		if !isExcluded[chainID] {
-			t.Run(chain.Name+fmt.Sprintf(" (%d)", chainID), func(t *testing.T) { checkResourceConfig(t, chain) })
-		}
+		t.Run(chain.Name+fmt.Sprintf(" (%d)", chainID), func(t *testing.T) {
+			SkipCheckIfFrontierChain(t, *chain)
+			checkResourceConfig(t, chain)
+		})
 	}
 }
 

--- a/validation/superchain-genesis_test.go
+++ b/validation/superchain-genesis_test.go
@@ -37,13 +37,14 @@ func TestGenesisHash(t *testing.T) {
 	isExcluded := map[uint64]bool{
 		10: true, // OP Mainnet, requires override (see https://github.com/ethereum-optimism/op-geth/blob/daade41d463b4ff332c6ed955603e47dcd25528b/core/superchain.go#L83-L94)
 	}
-
 	for chainID, chain := range OPChains {
-		SkipCheckIfFrontierChain(t, *chain)
 		if isExcluded[chain.ChainID] {
 			t.Logf("chain %d: EXCLUDED from Genesis block hash validation", chainID)
 		} else {
-			t.Run(chain.Name, func(t *testing.T) { testGenesisHashOfChain(t, chainID) })
+			t.Run(chain.Name, func(t *testing.T) {
+				SkipCheckIfFrontierChain(t, *chain)
+				testGenesisHashOfChain(t, chainID)
+			})
 		}
 	}
 }

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -53,17 +53,13 @@ func TestSuperchainWideContractVersions(t *testing.T) {
 
 func TestContractVersions(t *testing.T) {
 	isExcluded := map[uint64]bool{
-		291:       true, // mainnet/orderly
-		424:       true, // mainnet/pgn
-		957:       true, // mainnet/lyra
 		8453:      true, // mainnet/base
 		34443:     true, // mainnet/mode
-		58008:     true, // sepolia/pgn
 		84532:     true, // sepolia/base
 		90001:     true, // sepolia/race, due to https://github.com/ethereum-optimism/superchain-registry/issues/147
 		7777777:   true, // mainnet/zora
 		11155421:  true, // sepolia-dev-0/oplabs-devnet-0
-		999999999: true, // sepolia/zoras
+		999999999: true, // sepolia/zora
 	}
 
 	checkOPChainSatisfiesSemver := func(t *testing.T, chain *ChainConfig) {
@@ -97,11 +93,13 @@ func TestContractVersions(t *testing.T) {
 	}
 
 	for chainID, chain := range OPChains {
-		SkipCheckIfFrontierChain(t, *chain)
 		if isExcluded[chainID] {
 			t.Logf("chain %d: EXCLUDED from contract version validation", chainID)
 		} else {
-			t.Run(chain.Name, func(t *testing.T) { checkOPChainSatisfiesSemver(t, chain) })
+			t.Run(chain.Name, func(t *testing.T) {
+				SkipCheckIfFrontierChain(t, *chain)
+				checkOPChainSatisfiesSemver(t, chain)
+			})
 		}
 	}
 }


### PR DESCRIPTION
Towards #150 

- ensure `t.Skip()` command is properly nested under `t.Run()`, so we skip the subtest only
- trim down `isExcluded` lists
  - either that chain now passes because tests have been relaxed
  - that chain no longer exists
  - that chain is skipped because it is a Frontier chain

