### PR TITLE
validation: allow checks to be focussed to a single chain (using test name regex)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,20 @@ The format is a gzipped JSON `genesis.json` file, with either:
 - a `stateHash` attribute: to omit a large state (e.g. for networks with a re-genesis or migration history).
   Nodes can load the genesis block header, and state-sync to complete the node initialization.
 
-### 4. Raise your Pull Request
+### 4. Run tests locally
+Run the following command to run the registry's validation checks, for only the chain you added (replace the chain name or ID accordingly):
+```
+go test -run=/OP-Sepolia
+```
+or
+```
+go test -run=/11155420
+```
+You can even focus on a particular test and chain combination:
+```
+go test -run=TestGasPriceOracleParams/11155420
+```
+### 5. Raise your Pull Request
 Automated checks will run, and your PR will be reviewed in due course.
 
 ## Adding a superchain target

--- a/validation/gpo-params_test.go
+++ b/validation/gpo-params_test.go
@@ -42,8 +42,6 @@ func TestGasPriceOracleParams(t *testing.T) {
 			"overhead parameter %d out of bounds %d", actualParams.Overhead, desiredParams.Overhead)
 		require.True(t, isBigIntWithinBounds(actualParams.Scalar, desiredParams.Scalar),
 			"scalar parameter %d out of bounds %d", actualParams.Scalar, desiredParams.Scalar)
-
-		t.Logf("gas price oracle params are acceptable")
 	}
 
 	checkEcotoneResourceConfig := func(t *testing.T, chain *ChainConfig, client *ethclient.Client) {
@@ -67,8 +65,6 @@ func TestGasPriceOracleParams(t *testing.T) {
 			"blobBaseFeeScalar %d out of bounds %d", actualParams.BlobBaseFeeScalar, desiredParams.BlobBaseFeeScalar)
 		require.True(t, isWithinBounds(actualParams.BaseFeeScalar, desiredParams.BaseFeeScalar),
 			"baseFeeScalar parameter %d out of bounds %d", actualParams.BaseFeeScalar, desiredParams.BaseFeeScalar)
-
-		t.Logf("gas price oracle params are acceptable")
 	}
 
 	checkResourceConfig := func(t *testing.T, chain *ChainConfig, client *ethclient.Client) {

--- a/validation/gpo-params_test.go
+++ b/validation/gpo-params_test.go
@@ -81,7 +81,7 @@ func TestGasPriceOracleParams(t *testing.T) {
 
 	for chainID, chain := range OPChains {
 		if !isExcluded[chainID] {
-			t.Run(chain.Name+fmt.Sprintf(" (%d)", chainID), func(t *testing.T) {
+			t.Run(perChainTestName(chain), func(t *testing.T) {
 				SkipCheckIfFrontierChain(t, *chain)
 				rpcEndpoint := chain.PublicRPC
 				require.NotEmpty(t, rpcEndpoint, "no public endpoint for chain")

--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -78,8 +78,6 @@ func TestL2OOParams(t *testing.T) {
 		require.NoErrorf(t, err, "RPC endpoint %s", rpcEndpoint)
 
 		requireEqualParams(t, desiredParams, actualParams)
-
-		t.Logf("✅ L2OutputOracle config params acceptable")
 	}
 
 	for chainID, chain := range OPChains {

--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -79,16 +79,17 @@ func TestL2OOParams(t *testing.T) {
 
 		requireEqualParams(t, desiredParams, actualParams)
 
-		t.Logf("L2OutputOracle config params acceptable")
+		t.Logf("✅ L2OutputOracle config params acceptable")
 	}
 
 	for chainID, chain := range OPChains {
-		if !isExcluded[chainID] {
-			t.Run(chain.Name+fmt.Sprintf(" (%d)", chainID), func(t *testing.T) {
-				SkipCheckIfFrontierChain(t, *chain)
-				checkL2OOParams(t, chain)
-			})
-		}
+		t.Run(perChainTestName(chain), func(t *testing.T) {
+			if isExcluded[chainID] {
+				t.Skip()
+			}
+			SkipCheckIfFrontierChain(t, *chain)
+			checkL2OOParams(t, chain)
+		})
 	}
 }
 

--- a/validation/resource-config_test.go
+++ b/validation/resource-config_test.go
@@ -32,8 +32,6 @@ func TestResourceConfig(t *testing.T) {
 		require.NoErrorf(t, err, "RPC endpoint %s: %s", rpcEndpoint)
 
 		require.Equal(t, bindings.ResourceMeteringResourceConfig(OPMainnetResourceConfig), actualResourceConfig, "resource config unacceptable")
-
-		t.Logf("resource metering acceptable")
 	}
 
 	for _, chain := range OPChains {

--- a/validation/resource-config_test.go
+++ b/validation/resource-config_test.go
@@ -36,8 +36,8 @@ func TestResourceConfig(t *testing.T) {
 		t.Logf("resource metering acceptable")
 	}
 
-	for chainID, chain := range OPChains {
-		t.Run(chain.Name+fmt.Sprintf(" (%d)", chainID), func(t *testing.T) {
+	for _, chain := range OPChains {
+		t.Run(perChainTestName(chain), func(t *testing.T) {
 			SkipCheckIfFrontierChain(t, *chain)
 			checkResourceConfig(t, chain)
 		})

--- a/validation/superchain-genesis_test.go
+++ b/validation/superchain-genesis_test.go
@@ -38,13 +38,12 @@ func TestGenesisHash(t *testing.T) {
 		10: true, // OP Mainnet, requires override (see https://github.com/ethereum-optimism/op-geth/blob/daade41d463b4ff332c6ed955603e47dcd25528b/core/superchain.go#L83-L94)
 	}
 	for chainID, chain := range OPChains {
-		if isExcluded[chain.ChainID] {
-			t.Logf("chain %d: EXCLUDED from Genesis block hash validation", chainID)
-		} else {
-			t.Run(chain.Name, func(t *testing.T) {
-				SkipCheckIfFrontierChain(t, *chain)
-				testGenesisHashOfChain(t, chainID)
-			})
-		}
+		t.Run(perChainTestName(chain), func(t *testing.T) {
+			if isExcluded[chain.ChainID] {
+				t.Skipf("chain %d: EXCLUDED from Genesis block hash validation", chainID)
+			}
+			SkipCheckIfFrontierChain(t, *chain)
+			testGenesisHashOfChain(t, chainID)
+		})
 	}
 }

--- a/validation/superchain-genesis_test.go
+++ b/validation/superchain-genesis_test.go
@@ -30,7 +30,6 @@ func testGenesisHashOfChain(t *testing.T, chainID uint64) {
 	computedGenesisHash := computedGenesis.ToBlock().Hash()
 
 	require.Equal(t, common.Hash(declaredGenesisHash), computedGenesisHash, "chain %d: Genesis block hash must match computed value", chainID)
-	t.Logf("chain %d: Genesis block hash passed validation", chainID)
 }
 
 func TestGenesisHash(t *testing.T) {

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -97,14 +97,13 @@ func TestContractVersions(t *testing.T) {
 	}
 
 	for chainID, chain := range OPChains {
-		if isExcluded[chainID] {
-			t.Logf("chain %d: EXCLUDED from contract version validation", chainID)
-		} else {
-			t.Run(chain.Name, func(t *testing.T) {
-				SkipCheckIfFrontierChain(t, *chain)
-				checkOPChainSatisfiesSemver(t, chain)
-			})
-		}
+		t.Run(perChainTestName(chain), func(t *testing.T) {
+			if isExcluded[chainID] {
+				t.Skipf("chain %d: EXCLUDED from contract version validation", chainID)
+			}
+			SkipCheckIfFrontierChain(t, *chain)
+			checkOPChainSatisfiesSemver(t, chain)
+		})
 	}
 }
 

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -37,7 +37,7 @@ func TestSuperchainWideContractVersions(t *testing.T) {
 		}
 
 		if isExcludedFromSuperchainConfigCheck[superchain.Config.Name] {
-			t.Logf("%s excluded from SuperChainConfig version check", superchain.Config.Name)
+			t.Skipf("%s excluded from SuperChainConfig version check", superchain.Config.Name)
 			return
 		}
 
@@ -113,8 +113,6 @@ func checkSemverForContract(t *testing.T, contractName string, contractAddress *
 
 	require.Condition(t, func() bool { return isSemverAcceptable(desiredSemver, actualSemver) },
 		"%s.version=%s (UNACCEPTABLE desired version %s)", contractName, actualSemver, desiredSemver)
-
-	t.Logf("%s.version=%s (acceptable compared to %s)", contractName, actualSemver, desiredSemver)
 }
 
 // getVersion will get the version of a contract at a given address, if it exposes a version() method.

--- a/validation/utils_test.go
+++ b/validation/utils_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// perChainTestName ensures test can easily be filtered by chain name or chain id using the -run=regex testflag.
+func perChainTestName(chain *superchain.ChainConfig) string {
+	return chain.Name + fmt.Sprintf(" (%d)", chain.ChainID)
+}
+
 // isBigIntWithinBounds returns true if actual is within bounds, where the bounds are [lower bound, upper bound] and are inclusive.
 var isBigIntWithinBounds = func(actual *big.Int, bounds [2]*big.Int) bool {
 	if (bounds[1].Cmp(bounds[0])) < 0 {


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/security-pod/issues/101 

This is an alternative to #154, which leans on native go testing features a bit more. 

I think the main downside is that to understand the behaviour, the user needs to understand:

```
        -run regexp
            Run only those tests, examples, and fuzz tests matching the regular
            expression. For tests, the regular expression is split by unbracketed
            slash (/) characters into a sequence of regular expressions, and each
            part of a test's identifier must match the corresponding element in
            the sequence, if any. Note that possible parents of matches are
            run too, so that -run=X/Y matches and runs and reports the result
            of all tests matching X, even those without sub-tests matching Y,
            because it must run them to look for those sub-tests.
            See also -skip.
```

The main upsides are:
* less boiler plate code to maintain
* can focus by chain name or chain id

It is not currently supported to support hex encoded chain ids. 