### PR TITLE
Temporarily exclude standard conduit chains from contract version checks

### DIFF
--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -54,6 +54,7 @@ func TestSuperchainWideContractVersions(t *testing.T) {
 func TestContractVersions(t *testing.T) {
 	isExcluded := map[uint64]bool{
 		919:       true, // sepolia/mode   L1CrossDomainMessengerProxy.version=1.4.1, https://github.com/ethereum-optimism/security-pod/issues/105
+		1740:      true, // sepolia/metal  L1CrossDomainMessengerProxy.version=1.4.1, https://github.com/ethereum-optimism/security-pod/issues/105
 		1750:      true, // mainnet/metal  L1CrossDomainMessengerProxy.version=1.4.1, https://github.com/ethereum-optimism/security-pod/issues/105
 		8453:      true, // mainnet/base
 		8866:      true, // mainnet/pontem L1CrossDomainMessengerProxy.version=1.4.1, https://github.com/ethereum-optimism/security-pod/issues/105

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -54,6 +54,7 @@ func TestSuperchainWideContractVersions(t *testing.T) {
 func TestContractVersions(t *testing.T) {
 	isExcluded := map[uint64]bool{
 		919:       true, // sepolia/mode   L1CrossDomainMessengerProxy.version=1.4.1, https://github.com/ethereum-optimism/security-pod/issues/105
+		1750:      true, // mainnet/metal  L1CrossDomainMessengerProxy.version=1.4.1, https://github.com/ethereum-optimism/security-pod/issues/105
 		8453:      true, // mainnet/base
 		8866:      true, // mainnet/pontem L1CrossDomainMessengerProxy.version=1.4.1, https://github.com/ethereum-optimism/security-pod/issues/105
 		34443:     true, // mainnet/mode

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -53,6 +53,7 @@ func TestSuperchainWideContractVersions(t *testing.T) {
 
 func TestContractVersions(t *testing.T) {
 	isExcluded := map[uint64]bool{
+		919:       true, // sepolia/mode   L1CrossDomainMessengerProxy.version=1.4.1, https://github.com/ethereum-optimism/security-pod/issues/105
 		8453:      true, // mainnet/base
 		8866:      true, // mainnet/pontem L1CrossDomainMessengerProxy.version=1.4.1, https://github.com/ethereum-optimism/security-pod/issues/105
 		34443:     true, // mainnet/mode

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -54,6 +54,7 @@ func TestSuperchainWideContractVersions(t *testing.T) {
 func TestContractVersions(t *testing.T) {
 	isExcluded := map[uint64]bool{
 		8453:      true, // mainnet/base
+		8866:      true, // mainnet/pontem L1CrossDomainMessengerProxy.version=1.4.1, https://github.com/ethereum-optimism/security-pod/issues/105
 		34443:     true, // mainnet/mode
 		84532:     true, // sepolia/base
 		90001:     true, // sepolia/race, due to https://github.com/ethereum-optimism/superchain-registry/issues/147


### PR DESCRIPTION
See https://github.com/ethereum-optimism/security-pod/issues/105

Reminder: Frontier chains are now excluded from contract version checks.

We can either merge these exclusions to `main` now (optimistically), _or_ cherry pick the work onto the open PR #107 .