### PR TITLE
Update CODEOWNERS per new team responsibilities

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,10 +10,6 @@
 /validation @ethereum-optimism/go-reviewers
 /superchain @ethereum-optimism/go-reviewers
 
-## JS&TS
-*.js @roninjin10
-package.json @roninjin10
-
 ## Solidity
 *.sol @ethereum-optimism/security-reviewers
 


### PR DESCRIPTION
Security team will continue to own the 3 existing PRs to support them across the finish line:
1. https://github.com/ethereum-optimism/superchain-registry/pull/125
2. https://github.com/ethereum-optimism/superchain-registry/pull/119
3. https://github.com/ethereum-optimism/superchain-registry/pull/107

Making this change so future onboarding PRs will go directly to @OPMattie 's team