### PR TITLE
fix: scrape hardfork times in add-chain.sh

### DIFF
--- a/scripts/add-chain.sh
+++ b/scripts/add-chain.sh
@@ -75,6 +75,11 @@ genesis:
     hash: "$(jq -j .genesis.l2.hash $ROLLUP_CONFIG)"
     number: $(jq -j .genesis.l2.number $ROLLUP_CONFIG)
   l2_time: $(jq -j .genesis.l2_time $ROLLUP_CONFIG)
+
+canyon_time: $(jq -j .canyon_time $ROLLUP_CONFIG)
+delta_time: $(jq -j .delta_time $ROLLUP_CONFIG)
+ecotone_time: $(jq -j .ecotone_time $ROLLUP_CONFIG)
+
 EOF
 
 


### PR DESCRIPTION
This is an import step since we enabled per chain overrides of hardfork times https://github.com/ethereum-optimism/superchain-registry/pull/101.