### PR TITLE
fix: checksummed addresses for mode mainnet 

### DIFF
--- a/superchain/configs/mainnet/mode.yaml
+++ b/superchain/configs/mainnet/mode.yaml
@@ -6,8 +6,8 @@ explorer: https://explorer.mode.network
 
 superchain_level: 2
 
-system_config_addr: "0x5e6432f18bc5d497b1ab2288a025fbf9d69e2221"
-batch_inbox_addr: "0x24e59d9d3bd73ccc28dc54062af7ef7bff58bd67"
+system_config_addr: "0x5e6432F18Bc5d497B1Ab2288a025Fbf9D69E2221"
+batch_inbox_addr: "0x24E59d9d3Bd73ccC28Dc54062AF7EF7bFF58Bd67"
 
 genesis:
   l1:  # L1 anchor-point of the rollup


### PR DESCRIPTION
```
cast to-check-sum-address 0x5e6432f18bc5d497b1ab2288a025fbf9d69e2221
cast to-check-sum-address 0x24e59d9d3bd73ccc28dc54062af7ef7bff58bd67
```

Output: 

```
0x5e6432F18Bc5d497B1Ab2288a025Fbf9D69E2221
0x24E59d9d3Bd73ccC28Dc54062AF7EF7bFF58Bd67
```