### PR TITLE
SubmissionInterval not more equality check

### DIFF
--- a/validation/standard-config-mainnet.toml
+++ b/validation/standard-config-mainnet.toml
@@ -8,7 +8,7 @@ system_tx_max_gas = 1000000
 maximum_base_fee = "340_282_366_920_938_463_463_374_607_431_768_211_455"
 
 [l2_output_oracle]
-submission_interval = 1800
+submission_interval = 86400
 l2_block_time = 2
 finalization_period_seconds = 604800
 

--- a/validation/standard-config.go
+++ b/validation/standard-config.go
@@ -15,7 +15,7 @@ type ResourceConfig struct {
 }
 
 type L2OOParams struct {
-	SubmissionInterval        *big.Int `toml:"submission_interval"`         // Interval in blocks at which checkpoints must be submitted.
+	SubmissionInterval        *big.Int `toml:"submission_interval"`         // Max Interval in blocks at which checkpoints must be submitted. Can be less that this value.
 	L2BlockTime               *big.Int `toml:"l2_block_time"`               // The time per L2 block, in seconds.
 	FinalizationPeriodSeconds *big.Int `toml:"finalization_period_seconds"` // The minimum time (in seconds) that must elapse before a withdrawal can be finalized.
 }


### PR DESCRIPTION
Output frequency can be 24 hours or less: https://specs.optimism.io/protocol/configurability.html#policy-parameters 

That's **86400** seconds.

