### PR TITLE
standard-config: loosen bounds on `l2oo.submissionInterval`

### DIFF
--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -29,15 +29,13 @@ func TestL2OOParams(t *testing.T) {
 	isExcluded := map[uint64]bool{
 		999999999: true, // sepolia/zora    Incorrect submissionInterval, wanted 120 got 180
 		1740:      true, // sepolia/metal Incorrect submissionInterval
-		1750:      true, // mainnet/metal Incorrect submissionInterval
 		919:       true, // sepolia/mode Incorrect submissionInterval
-		8866:      true, // mainnet/superlumio Incorrect submissionInterval
 	}
 
 	assertInBounds := func(t *testing.T, name string, got *big.Int, want [2]*big.Int) {
 		assert.True(t,
 			isBigIntWithinBounds(got, want),
-			fmt.Sprintf("Incorrect %s, %d is not within bounds %d", name, want, got))
+			fmt.Sprintf("Incorrect %s, %d is not within bounds %d", name, got, want))
 	}
 
 	checkL2OOParams := func(t *testing.T, chain *ChainConfig) {
@@ -65,8 +63,8 @@ func TestL2OOParams(t *testing.T) {
 		require.NoErrorf(t, err, "RPC endpoint %s", rpcEndpoint)
 
 		assertInBounds(t, "submissionInterval", actualParams.SubmissionInterval, desiredParams.SubmissionInterval)
-		assertInBounds(t, "submissionInterval", actualParams.L2BlockTime, desiredParams.L2BlockTime)
-		assertInBounds(t, "submissionInterval", actualParams.FinalizationPeriodSeconds, desiredParams.FinalizationPeriodSeconds)
+		assertInBounds(t, "l2BlockTime", actualParams.L2BlockTime, desiredParams.L2BlockTime)
+		assertInBounds(t, "finalizationPeriodSeconds", actualParams.FinalizationPeriodSeconds, desiredParams.FinalizationPeriodSeconds)
 	}
 
 	for chainID, chain := range OPChains {

--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -27,9 +27,9 @@ type L2OOParams struct {
 
 func TestL2OOParams(t *testing.T) {
 	isExcluded := map[uint64]bool{
-		999999999: true, // sepolia/zora    Incorrect submissionInterval, wanted 120 got 180
-		1740:      true, // sepolia/metal Incorrect submissionInterval
-		919:       true, // sepolia/mode Incorrect submissionInterval
+		999999999: true, // sepolia/zora  Incorrect finalizationPeriodSeconds, 604800 is not within bounds [12 12]
+		1740:      true, // sepolia/metal Incorrect finalizationPeriodSeconds, 604800 is not within bounds [12 12]
+		919:       true, // sepolia/mode  Incorrect finalizationPeriodSeconds, 180 is not within bounds [12 12]
 	}
 
 	assertInBounds := func(t *testing.T, name string, got *big.Int, want [2]*big.Int) {

--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -64,7 +64,7 @@ func TestL2OOParams(t *testing.T) {
 
 		assertInBounds(t, "submissionInterval", actualParams.SubmissionInterval, desiredParams.SubmissionInterval)
 		assertInBounds(t, "l2BlockTime", actualParams.L2BlockTime, desiredParams.L2BlockTime)
-		assertInBounds(t, "finalizationPeriodSeconds", actualParams.FinalizationPeriodSeconds, desiredParams.FinalizationPeriodSeconds)
+		assertInBounds(t, "challengePeriodSeconds", actualParams.FinalizationPeriodSeconds, desiredParams.ChallengePeriodSeconds)
 	}
 
 	for chainID, chain := range OPChains {

--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -20,9 +20,9 @@ import (
 )
 
 type L2OOParams struct {
-	SubmissionInterval        *big.Int `toml:"submission_interval"`         // Interval in blocks at which checkpoints must be submitted.
-	L2BlockTime               *big.Int `toml:"l2_block_time"`               // The time per L2 block, in seconds.
-	FinalizationPeriodSeconds *big.Int `toml:"finalization_period_seconds"` // The minimum time (in seconds) that must elapse before a withdrawal can be finalized.
+	SubmissionInterval        *big.Int
+	L2BlockTime               *big.Int
+	FinalizationPeriodSeconds *big.Int
 }
 
 func TestL2OOParams(t *testing.T) {

--- a/validation/standard-config-mainnet.toml
+++ b/validation/standard-config-mainnet.toml
@@ -8,7 +8,7 @@ system_tx_max_gas = 1000000
 maximum_base_fee = "340_282_366_920_938_463_463_374_607_431_768_211_455"
 
 [l2_output_oracle]
-submission_interval = [1800, 1800]
+submission_interval = [0, 86400]
 l2_block_time = [2, 2]
 finalization_period_seconds = [604800, 604800]
 

--- a/validation/standard-config-mainnet.toml
+++ b/validation/standard-config-mainnet.toml
@@ -8,7 +8,7 @@ system_tx_max_gas = 1000000
 maximum_base_fee = "340_282_366_920_938_463_463_374_607_431_768_211_455"
 
 [l2_output_oracle]
-submission_interval = [0, 86400]
+submission_interval = [1, 86400]
 l2_block_time = [2, 2]
 challenge_period_seconds = [604800, 604800]
 

--- a/validation/standard-config-mainnet.toml
+++ b/validation/standard-config-mainnet.toml
@@ -8,9 +8,9 @@ system_tx_max_gas = 1000000
 maximum_base_fee = "340_282_366_920_938_463_463_374_607_431_768_211_455"
 
 [l2_output_oracle]
-submission_interval = 1800
-l2_block_time = 2
-finalization_period_seconds = 604800
+submission_interval = [1800, 1800]
+l2_block_time = [2, 2]
+finalization_period_seconds = [604800, 604800]
 
 [gas_price_oracle.pre-ecotone]
 decimals = [6, 6]

--- a/validation/standard-config-mainnet.toml
+++ b/validation/standard-config-mainnet.toml
@@ -10,7 +10,7 @@ maximum_base_fee = "340_282_366_920_938_463_463_374_607_431_768_211_455"
 [l2_output_oracle]
 submission_interval = [0, 86400]
 l2_block_time = [2, 2]
-finalization_period_seconds = [604800, 604800]
+challenge_period_seconds = [604800, 604800]
 
 [gas_price_oracle.pre-ecotone]
 decimals = [6, 6]

--- a/validation/standard-config-mainnet.toml
+++ b/validation/standard-config-mainnet.toml
@@ -10,7 +10,7 @@ maximum_base_fee = "340_282_366_920_938_463_463_374_607_431_768_211_455"
 [l2_output_oracle]
 submission_interval = [1, 86400]
 l2_block_time = [2, 2]
-challenge_period_seconds = [604800, 604800]
+challenge_period_seconds = [604800, 604800] # i.e. finalization period
 
 [gas_price_oracle.pre-ecotone]
 decimals = [6, 6]

--- a/validation/standard-config-sepolia-dev-0.toml
+++ b/validation/standard-config-sepolia-dev-0.toml
@@ -8,7 +8,7 @@ system_tx_max_gas = 1000000
 maximum_base_fee = "340_282_366_920_938_463_463_374_607_431_768_211_455"
 
 [l2_output_oracle]
-submission_interval = [0, 86400]
+submission_interval = [1, 86400]
 l2_block_time = [2, 2]
 challenge_period_seconds = [12, 12]
 

--- a/validation/standard-config-sepolia-dev-0.toml
+++ b/validation/standard-config-sepolia-dev-0.toml
@@ -10,7 +10,7 @@ maximum_base_fee = "340_282_366_920_938_463_463_374_607_431_768_211_455"
 [l2_output_oracle]
 submission_interval = [0, 86400]
 l2_block_time = [2, 2]
-finalization_period_seconds = [12, 12]
+challenge_period_seconds = [12, 12]
 
 [gas_price_oracle.pre-ecotone]
 decimals = [6, 6]

--- a/validation/standard-config-sepolia-dev-0.toml
+++ b/validation/standard-config-sepolia-dev-0.toml
@@ -8,7 +8,7 @@ system_tx_max_gas = 1000000
 maximum_base_fee = "340_282_366_920_938_463_463_374_607_431_768_211_455"
 
 [l2_output_oracle]
-submission_interval = [120, 120]
+submission_interval = [0, 86400]
 l2_block_time = [2, 2]
 finalization_period_seconds = [12, 12]
 

--- a/validation/standard-config-sepolia-dev-0.toml
+++ b/validation/standard-config-sepolia-dev-0.toml
@@ -10,7 +10,7 @@ maximum_base_fee = "340_282_366_920_938_463_463_374_607_431_768_211_455"
 [l2_output_oracle]
 submission_interval = [1, 86400]
 l2_block_time = [2, 2]
-challenge_period_seconds = [12, 12]
+challenge_period_seconds = [12, 12] # i.e. finalization period
 
 [gas_price_oracle.pre-ecotone]
 decimals = [6, 6]

--- a/validation/standard-config-sepolia-dev-0.toml
+++ b/validation/standard-config-sepolia-dev-0.toml
@@ -8,9 +8,9 @@ system_tx_max_gas = 1000000
 maximum_base_fee = "340_282_366_920_938_463_463_374_607_431_768_211_455"
 
 [l2_output_oracle]
-submission_interval = 120
-l2_block_time = 2
-finalization_period_seconds = 12
+submission_interval = [120, 120]
+l2_block_time = [2, 2]
+finalization_period_seconds = [12, 12]
 
 [gas_price_oracle.pre-ecotone]
 decimals = [6, 6]

--- a/validation/standard-config-sepolia.toml
+++ b/validation/standard-config-sepolia.toml
@@ -8,7 +8,7 @@ system_tx_max_gas = 1000000
 maximum_base_fee = "340_282_366_920_938_463_463_374_607_431_768_211_455"
 
 [l2_output_oracle]
-submission_interval = [0, 86400]
+submission_interval = [1, 86400]
 l2_block_time = [2, 2]
 challenge_period_seconds = [12, 12]
 

--- a/validation/standard-config-sepolia.toml
+++ b/validation/standard-config-sepolia.toml
@@ -10,7 +10,7 @@ maximum_base_fee = "340_282_366_920_938_463_463_374_607_431_768_211_455"
 [l2_output_oracle]
 submission_interval = [0, 86400]
 l2_block_time = [2, 2]
-finalization_period_seconds = [12, 12]
+challenge_period_seconds = [12, 12]
 
 [gas_price_oracle.pre-ecotone]
 decimals = [6, 6]

--- a/validation/standard-config-sepolia.toml
+++ b/validation/standard-config-sepolia.toml
@@ -8,7 +8,7 @@ system_tx_max_gas = 1000000
 maximum_base_fee = "340_282_366_920_938_463_463_374_607_431_768_211_455"
 
 [l2_output_oracle]
-submission_interval = [120, 120]
+submission_interval = [0, 86400]
 l2_block_time = [2, 2]
 finalization_period_seconds = [12, 12]
 

--- a/validation/standard-config-sepolia.toml
+++ b/validation/standard-config-sepolia.toml
@@ -10,7 +10,7 @@ maximum_base_fee = "340_282_366_920_938_463_463_374_607_431_768_211_455"
 [l2_output_oracle]
 submission_interval = [1, 86400]
 l2_block_time = [2, 2]
-challenge_period_seconds = [12, 12]
+challenge_period_seconds = [12, 12] # i.e. finalization period
 
 [gas_price_oracle.pre-ecotone]
 decimals = [6, 6]

--- a/validation/standard-config-sepolia.toml
+++ b/validation/standard-config-sepolia.toml
@@ -8,9 +8,9 @@ system_tx_max_gas = 1000000
 maximum_base_fee = "340_282_366_920_938_463_463_374_607_431_768_211_455"
 
 [l2_output_oracle]
-submission_interval = 120
-l2_block_time = 2
-finalization_period_seconds = 12
+submission_interval = [120, 120]
+l2_block_time = [2, 2]
+finalization_period_seconds = [12, 12]
 
 [gas_price_oracle.pre-ecotone]
 decimals = [6, 6]

--- a/validation/standard-config.go
+++ b/validation/standard-config.go
@@ -15,9 +15,9 @@ type ResourceConfig struct {
 }
 
 type L2OOParamsBounds struct {
-	SubmissionInterval        BigIntBounds `toml:"submission_interval"`         // Interval in blocks at which checkpoints must be submitted.
-	L2BlockTime               BigIntBounds `toml:"l2_block_time"`               // The time per L2 block, in seconds.
-	FinalizationPeriodSeconds BigIntBounds `toml:"finalization_period_seconds"` // The minimum time (in seconds) that must elapse before a withdrawal can be finalized.
+	SubmissionInterval     BigIntBounds `toml:"submission_interval"`      // Interval in blocks at which checkpoints must be submitted.
+	L2BlockTime            BigIntBounds `toml:"l2_block_time"`            // The time per L2 block, in seconds.
+	ChallengePeriodSeconds BigIntBounds `toml:"challenge_period_seconds"` // Length of time for which an output root can be removed, and for which it is not considered finalized.
 }
 
 type GasPriceOracleBounds struct {

--- a/validation/standard-config.go
+++ b/validation/standard-config.go
@@ -14,10 +14,10 @@ type ResourceConfig struct {
 	MaximumBaseFee              *big.Int `toml:"maximum_base_fee"`
 }
 
-type L2OOParams struct {
-	SubmissionInterval        *big.Int `toml:"submission_interval"`         // Interval in blocks at which checkpoints must be submitted.
-	L2BlockTime               *big.Int `toml:"l2_block_time"`               // The time per L2 block, in seconds.
-	FinalizationPeriodSeconds *big.Int `toml:"finalization_period_seconds"` // The minimum time (in seconds) that must elapse before a withdrawal can be finalized.
+type L2OOParamsBounds struct {
+	SubmissionInterval        BigIntBounds `toml:"submission_interval"`         // Interval in blocks at which checkpoints must be submitted.
+	L2BlockTime               BigIntBounds `toml:"l2_block_time"`               // The time per L2 block, in seconds.
+	FinalizationPeriodSeconds BigIntBounds `toml:"finalization_period_seconds"` // The minimum time (in seconds) that must elapse before a withdrawal can be finalized.
 }
 
 type GasPriceOracleBounds struct {
@@ -44,6 +44,6 @@ type EcotoneGasPriceOracleBounds struct {
 
 type StandardConfigTy struct {
 	ResourceConfig ResourceConfig       `toml:"resource_config"`
-	L2OOParams     L2OOParams           `toml:"l2_output_oracle"`
+	L2OOParams     L2OOParamsBounds     `toml:"l2_output_oracle"`
 	GPOParams      GasPriceOracleBounds `toml:"gas_price_oracle"`
 }


### PR DESCRIPTION
Output frequency can be 24 hours or less: https://specs.optimism.io/protocol/configurability.html#policy-parameters 