### PR TITLE
validation: add `TestGenesisHashAgainstRPC`

### DIFF
--- a/validation/superchain-genesis_test.go
+++ b/validation/superchain-genesis_test.go
@@ -82,5 +82,4 @@ func TestGenesisHashAgainstRPC(t *testing.T) {
 			checkOPChainHashAgainstRPC(t, chain)
 		})
 	}
-
 }

--- a/validation/superchain-genesis_test.go
+++ b/validation/superchain-genesis_test.go
@@ -55,7 +55,6 @@ func TestGenesisHash(t *testing.T) {
 
 func TestGenesisHashAgainstRPC(t *testing.T) {
 	isExcluded := map[uint64]bool{
-		10:       true, // mainnet/op (Genesis Block Hash declared as 0xdbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3, but RPC returned 0x7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b)
 		11155421: true, // sepolia-dev-0/oplabs-devnet-0   (no public endpoint)
 		11763072: true, // sepolia-dev-0/base-devnet-0     (no public endpoint)
 	}
@@ -68,7 +67,7 @@ func TestGenesisHashAgainstRPC(t *testing.T) {
 		client, err := ethclient.Dial(rpcEndpoint)
 		require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
 
-		genesisBlock, err := client.BlockByNumber(context.Background(), big.NewInt(0))
+		genesisBlock, err := client.BlockByNumber(context.Background(), big.NewInt(int64(chain.Genesis.L2.Number)))
 		require.NoError(t, err)
 
 		require.Equal(t, genesisBlock.Hash(), common.Hash(declaredGenesisHash), "Genesis Block Hash declared as %s, but RPC returned %s", declaredGenesisHash, genesisBlock.Hash())

--- a/validation/superchain-genesis_test.go
+++ b/validation/superchain-genesis_test.go
@@ -1,12 +1,15 @@
 package validation
 
 import (
+	"context"
+	"math/big"
 	"testing"
 
 	. "github.com/ethereum-optimism/superchain-registry/superchain"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,4 +51,36 @@ func TestGenesisHash(t *testing.T) {
 			testGenesisHashOfChain(t, chainID)
 		})
 	}
+}
+
+func TestGenesisHashAgainstRPC(t *testing.T) {
+	isExcluded := map[uint64]bool{
+		10:       true, // mainnet/op (Genesis Block Hash declared as 0xdbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3, but RPC returned 0x7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b)
+		11155421: true, // sepolia-dev-0/oplabs-devnet-0   (no public endpoint)
+		11763072: true, // sepolia-dev-0/base-devnet-0     (no public endpoint)
+	}
+
+	checkOPChainHashAgainstRPC := func(t *testing.T, chain *ChainConfig) {
+		declaredGenesisHash := chain.Genesis.L2.Hash
+		rpcEndpoint := chain.PublicRPC
+		require.NotEmpty(t, rpcEndpoint)
+
+		client, err := ethclient.Dial(rpcEndpoint)
+		require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
+
+		genesisBlock, err := client.BlockByNumber(context.Background(), big.NewInt(0))
+		require.NoError(t, err)
+
+		require.Equal(t, genesisBlock.Hash(), common.Hash(declaredGenesisHash), "Genesis Block Hash declared as %s, but RPC returned %s", declaredGenesisHash, genesisBlock.Hash())
+	}
+
+	for _, chain := range OPChains {
+		t.Run(perChainTestName(chain), func(t *testing.T) {
+			if isExcluded[chain.ChainID] {
+				t.Skip("chain excluded from check")
+			}
+			checkOPChainHashAgainstRPC(t, chain)
+		})
+	}
+
 }


### PR DESCRIPTION
We are already running a check on the genesis hash, comparing the declared genesis hash submitted in the chain config with one compute by reconstructing the genesis block from the "extra" submitted data. That test has some exclusions which are currently being investigated. 

This adds another sanity check, that the declared genesis hash matches what you get over the RPC. 