### PR TITLE
Fix rate limiting errors in Circle CI

### DIFF
--- a/superchain/init.go
+++ b/superchain/init.go
@@ -3,6 +3,7 @@ package superchain
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path"
 	"strings"
 
@@ -96,6 +97,22 @@ func init() {
 			Addresses[chainConfig.ChainID] = &addrs
 			GenesisSystemConfigs[chainConfig.ChainID] = &genesisSysCfg
 
+		}
+
+		ciMainnetRPC := os.Getenv("CIRCLE_CI_MAINNET_RPC")
+		ciSepoliaRPC := os.Getenv("CIRCLE_CI_SEPOLIA_RPC")
+
+		switch superchainEntry.Superchain {
+		case "mainnet":
+			if ciMainnetRPC != "" {
+				fmt.Println("Using env var for mainnet rpc")
+				superchainEntry.Config.L1.PublicRPC = ciMainnetRPC
+			}
+		case "sepolia", "sepolia-dev-0":
+			if ciSepoliaRPC != "" {
+				fmt.Println("Using env var for sepolia rpc")
+				superchainEntry.Config.L1.PublicRPC = ciSepoliaRPC
+			}
 		}
 
 		Superchains[superchainEntry.Superchain] = &superchainEntry

--- a/validation/internal/legacy/l2outputoracle-1.3.0.go
+++ b/validation/internal/legacy/l2outputoracle-1.3.0.go
@@ -31,6 +31,7 @@ func bindL2OutputOracle(address common.Address, caller bind.ContractCaller, tran
 	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
 }
 
+
 // NewL2OutputOracleCaller creates a new read-only instance of L2OutputOracle, bound to a specific deployed contract.
 func NewL2OutputOracleCaller(address common.Address, caller bind.ContractCaller) (*L2OutputOracleCaller, error) {
 	contract, err := bindL2OutputOracle(address, caller, nil, nil)

--- a/validation/internal/legacy/l2outputoracle-1.3.0.go
+++ b/validation/internal/legacy/l2outputoracle-1.3.0.go
@@ -31,7 +31,6 @@ func bindL2OutputOracle(address common.Address, caller bind.ContractCaller, tran
 	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
 }
 
-
 // NewL2OutputOracleCaller creates a new read-only instance of L2OutputOracle, bound to a specific deployed contract.
 func NewL2OutputOracleCaller(address common.Address, caller bind.ContractCaller) (*L2OutputOracleCaller, error) {
 	contract, err := bindL2OutputOracle(address, caller, nil, nil)


### PR DESCRIPTION
**Description**

We are seeing frequent Circle CI test failures due to rate limiting on the `allthatnode` RPC endpoints that are stored in the superchain config files. This PR adds a check for env vars within the superchain `init()` function. If the correct env vars exist, they will override the RPC endpoints with ones that have higher rate limits. For local testing, by devs or users wanting to add a new chain, the existing RPC endpoints will still be used.

**Tests**

No tests added. Manually tested that the correct RPC endpoints were used based off of the existence of the `CIRCLE_CI_MAINNET_RPC` and `CIRCLE_CI_SEPOLIA_RPC` env vars.

**Metadata**

- Fixes https://github.com/ethereum-optimism/superchain-registry/issues/217
