### PR TITLE
feat: exclude `sealchain1` & `sealchain2` from semver and the bounds …

### DIFF
--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -31,6 +31,8 @@ func TestL2OOParams(t *testing.T) {
 		1740:      true, // sepolia/metal Incorrect finalizationPeriodSeconds, 604800 is not within bounds [12 12]
 		919:       true, // sepolia/mode  Incorrect finalizationPeriodSeconds, 180 is not within bounds [12 12]
 		11155420:  true, // sepolia/op No L2OO because this chain uses Fault Proofs https://github.com/ethereum-optimism/superchain-registry/issues/219
+		6619:      true, // sepolia/sealchain1 1800 is not within bounds [12 12].
+		18714:     true, // sepolia/sealchain2 1800 is not within bounds [12 12].
 	}
 
 	assertInBounds := func(t *testing.T, name string, got *big.Int, want [2]*big.Int) {

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -65,6 +65,9 @@ func TestContractVersions(t *testing.T) {
 		7777777:   true, // mainnet/zora
 		11155421:  true, // sepolia-dev-0/oplabs-devnet-0
 		999999999: true, // sepolia/zora
+		6619:      true, // sepolia/sealchain1 (temporary because of the version before fault proofs)
+		18714:     true, // sepolia/sealchain2 (temporary because of the version before fault proofs)
+
 	}
 
 	checkOPChainSatisfiesSemver := func(t *testing.T, chain *ChainConfig) {


### PR DESCRIPTION
The seal `sealchain1` & `sealchain2` are two chains pre-fault proofs thus the version of `<3.8.0`. 
Also, the [Challenge Period](https://specs.optimism.io/protocol/withdrawals.html#withdrawal-flow) exclusion is cause because the upperbounds of `12 seconds` so 1 block is clearly *not enough* for the current use cases. 
This is worth noting that theses chains are temporary and will be removed in the future days as we mentionned with @geoknee. 
