### PR TITLE
sepolia-dev-0: activate Fjord

### DIFF
--- a/superchain/configs/sepolia-dev-0/base-devnet-0.yaml
+++ b/superchain/configs/sepolia-dev-0/base-devnet-0.yaml
@@ -5,7 +5,7 @@ sequencer_rpc: ""
 explorer: ""
 
 superchain_level: 2
-superchain_time: 0 # Missing hardfork times are inherited from superchain.yaml
+superchain_time: 1706634000 # joined from Ecotone
 
 system_config_addr: "0x7f67dc4959cb3e532b10a99f41bdd906c46fdfde"
 batch_inbox_addr: "0xff00000000000000000000000000000011763072"

--- a/superchain/configs/sepolia-dev-0/superchain.yaml
+++ b/superchain/configs/sepolia-dev-0/superchain.yaml
@@ -10,4 +10,4 @@ superchain_config_addr: "0x02d91Cf852423640d93920BE0CAdceC0E7A00FA7"
 canyon_time: 0
 delta_time: 0
 ecotone_time: 1706634000 # Tue 30 Jan 2024 17:00:00 UTC
-
+fjord_time: 1715961600 # Fri May 17 16:00:00 UTC 2024


### PR DESCRIPTION
at unix time 1715961600
Fri May 17 16:00:00 UTC 2024

The "failed" diff check shows that the fjord activation time is correctly set on both chains, while no other activation times are changed.

The change of base devnet's `superchain_time` is just cosmetic and doesn't have a real effect.