### PR TITLE
Upper bound increased for gas limit: 200,000,000 gas

### DIFF
--- a/validation/standard/standard-config-mainnet.toml
+++ b/validation/standard/standard-config-mainnet.toml
@@ -23,4 +23,4 @@ blob_base_fee_scalar = [0, 10_000_000]
 base_fee_scalar = [0, 10_000_000]
 
 [system_config]
-gas_limit = [8_000_000, 60_000_000]
+gas_limit = [8_000_000, 200_000_000]


### PR DESCRIPTION
As per spec update: https://github.com/ethereum-optimism/specs/pull/195 