### PR TITLE
improvements to the readme / contributing refactor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,98 @@
 # Superchain Registry Contributing Guide
+The Superchain Registry repository contains:
+* raw ["per-chain" config data](./README.md#3-understand-output) in `yaml` and `json/json.gz` files arranged in a semantically meaningful directory structure
+* [superchain-wide config data](#superchain-wide-config-data)
+* a Go workspace with
+  - a [`superchain`](#superchain-go-module) module
+  - a [`validation`](#validation-go-module) module
+  - an [`add-chain`](#add-chain-go-module) module
+  - The modules are tracked by a top level `go.work` file. The associated `go.work.sum` file is gitignored and not important to typical workflows, which should mirror those of the [CI configuration](.circleci/config.yml).
+* a Forge/Solidity script [`CheckSecurityConfigs`](#checksecurityconfigs)
+* Automatically generated summary `chainIds.json` file
 
-See [Superchain Upgrades] OP-Stack specifications.
 
-[Superchain Upgrades]: https://specs.optimism.io/protocol/superchain-upgrades.html
+## Superchain-wide config data
+A superchain target defines a set of layer 2 chains which share a `SuperchainConfig` and `ProtocolVersions` contract deployment on layer 1. It is usually named after the layer 1 chain, possibly with an extra identifier to distinguish devnets.
 
-## Superchain Go Module
 
-Superchain configs can be imported as Go-module:
+> **Note**
+> Example: `sepolia` and `sepolia-dev-0` are distinct superchain targets, although they are on the same layer 1 chain.
+
+### Adding a superchain target
+A new Superchain Target can be added by creating a new superchain config directory,
+with a `superchain.yaml` config file.
+
+> **Note**
+> This is an infrequent operation and unecessary if you are just looking to add a chain to an existing superchain.
+
+Here's an example:
+
+```bash
+cd superchain-registry
+
+export SUPERCHAIN_TARGET=goerli-dev-0
+mkdir superchain/configs/$SUPERCHAIN_TARGET
+
+cat > superchain/configs/$SUPERCHAIN_TARGET/superchain.yaml << EOF
+name: Goerli Dev 0
+l1:
+  chain_id: 5
+  public_rpc: https://ethereum-goerli-rpc.allthatnode.com
+  explorer: https://goerli.etherscan.io
+
+protocol_versions_addr: null # todo
+superchain_config_addr: null # todo
+EOF
+```
+Superchain-wide configuration, like the `ProtocolVersions` contract address, should be configured here when available.
+
+### Approved contract versions
+Each superchain target should have a `semver.yaml` file in the same directory declaring the approved contract semantic versions for that superchain, e.g:
+```yaml
+l1_cross_domain_messenger: 1.4.0
+l1_erc721_bridge: 1.0.0
+l1_standard_bridge: 1.1.0
+l2_output_oracle: 1.3.0
+optimism_mintable_erc20_factory: 1.1.0
+optimism_portal: 1.6.0
+system_config: 1.3.0
+
+# superchain-wide contracts
+protocol_versions: 1.0.0
+superchain_config: 1.1.0
+```
+See the `semver.yaml` files in existing superchain targets for the latest set of contracts to specify.
+
+### `implementations`
+Per superchain a set of canonical implementation deployments, per semver version, is tracked.
+As default, an empty collection of deployments can be set:
+```bash
+cat > superchain/implementations/networks/$SUPERCHAIN_TARGET.yaml << EOF
+l1_cross_domain_messenger:
+l1_erc721_bridge:
+l1_standard_bridge:
+l2_output_oracle:
+optimism_mintable_erc20_factory:
+optimism_portal:
+system_config:
+EOF
+```
+
+## `superchain` Go Module
+
+Per chain and supechain-wide configs and extra data are embedded into the `superchain` go module, which can be imported like so:
+
 ```
 go get github.com/ethereum-optimism/superchain-registry/superchain@latest
 ```
-See [`op-chain-ops`] for config tooling and
- for smart-contract bindings.
-
-[`op-chain-ops`]: https://github.com/ethereum-optimism/optimism/tree/develop/op-chain-ops
-[`op-bindings`]: https://github.com/ethereum-optimism/optimism/tree/develop/op-bindings
+The configs are consumed by downstream OPStack software, i.e. `op-geth` and `op-node`.
 
 
-## Validation Go Module
-A second module exists in this repo whose purpose is to validate the config exported by the `superchain` module. It is a separate module to avoid import cycles and polluting downstream dependencies with things like `go-ethereum` (which is used in the validation tests). The modules are tracked by a top level `go.work` file. The associated `go.work.sum` file is gitignored and not important to typical workflows, which should mirror those of the [CI configuration](.circleci/config.yml).
+## `validation` Go Module
+A second module exists in this repo whose purpose is to validate the config exported by the `superchain` module. It is a separate module to avoid import cycles and polluting downstream dependencies with things like `go-ethereum` (which is used in the validation tests).
+
+## `add-chain` Go module
+This module contains the CLI tool for generating `superchain` compliant configs and extra data to the registry.
 
 ## CheckSecurityConfigs
 
@@ -107,3 +181,26 @@ graph TD
   DelayedWETHProxy -- "admin()" --> ProxyAdmin
   DelayedWETHProxy -- "owner()" --> ProxyAdminOwner
 ```
+
+## Setting up your editor for formatting and linting
+If you use VSCode, you can place the following in a `settings.json` file in the gitignored `.vscode` directory:
+
+```json
+{
+    "go.formatTool": "gofumpt",
+    "go.lintTool": "golangci-lint",
+    "go.lintOnSave": "workspace",
+    "gopls": {
+        "formatting.gofumpt": true,
+    },
+}
+```
+The `semver.yaml` files each represent the semantic versioning lockfile for the all of the smart contracts in that superchain.
+It is meant to be used when building transactions that upgrade the implementations set in the proxies.
+
+
+
+## Links
+See [Superchain Upgrades] OP-Stack specifications.
+
+[Superchain Upgrades]: https://specs.optimism.io/protocol/superchain-upgrades.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ system_config: 1.3.0
 protocol_versions: 1.0.0
 superchain_config: 1.1.0
 ```
-See the `semver.yaml` files in existing superchain targets for the latest set of contracts to specify.
+It is meant to be used when building transactions that upgrade the implementations set in the proxies. See the `semver.yaml` files in existing superchain targets for the latest set of contracts to specify.
 
 ### `implementations`
 Per superchain a set of canonical implementation deployments, per semver version, is tracked.
@@ -195,9 +195,6 @@ If you use VSCode, you can place the following in a `settings.json` file in the 
     },
 }
 ```
-The `semver.yaml` files each represent the semantic versioning lockfile for the all of the smart contracts in that superchain.
-It is meant to be used when building transactions that upgrade the implementations set in the proxies.
-
 
 
 ## Links

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ Per chain and supechain-wide configs and extra data are embedded into the `super
 ```
 go get github.com/ethereum-optimism/superchain-registry/superchain@latest
 ```
-The configs are consumed by downstream OPStack software, i.e. `op-geth` and `op-node`.
+The configs are consumed by downstream OP Stack software, i.e. `op-geth` and `op-node`.
 
 
 ## `validation` Go Module

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,6 @@ It is meant to be used when building transactions that upgrade the implementatio
 
 
 ## Links
-See [Superchain Upgrades] OP-Stack specifications.
+See [Superchain Upgrades] OP Stack specifications.
 
 [Superchain Upgrades]: https://specs.optimism.io/protocol/superchain-upgrades.html

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!WARNING]
 > This repository is a **work in progress**.  At a later date, it will be proposed to, and must be approved by, Optimism Governance.  Until that time, the configuration described here is subject to change.
 
-> [!IMPORTANT] 
+> [!IMPORTANT]
 > We're making some changes to this repository and we've paused adding new chains for now. We'll reopen this process once the repository is ready. The Superchain itself, of course, remains open for business.
 
 The Superchain Registry repository hosts Superchain-configuration data in a minimal human-readable form.
@@ -15,12 +15,11 @@ The superchain configs are made available in minimal form, to embed in OP-Stack 
 Full deployment artifacts and genesis-states can be derived from the minimal form
 using the reference [`op-chain-ops`] tooling.
 
-The `semver.yaml` files each represent the semantic versioning lockfile for the all of the smart contracts in that superchain.
-It is meant to be used when building transactions that upgrade the implementations set in the proxies.
+[`op-chain-ops`]: https://github.com/ethereum-optimism/optimism/tree/develop/op-chain-ops
 
 ## Adding a Chain
 
-The following are the steps you need to take to add a chain to the 
+The following are the steps you need to take to add a chain to the registry:
 
 ### 0. Install dependencies
 You will need [`jq`](https://jqlang.github.io/jq/download/) and [`foundry`](https://book.getfoundry.sh/getting-started/installation) installed, as well as Go.
@@ -28,9 +27,6 @@ You will need [`jq`](https://jqlang.github.io/jq/download/) and [`foundry`](http
 ### 1. Set env vars
 
 To contribute a standard OP-Stack chain configuration, the following data is required: contracts deployment, rollup config, L2 genesis. We provide a tool to scrape this information from your local [monorepo](https://github.com/ethereum-optimism/optimism) folder.
-
-> [!NOTE]
-> The standard configuration requirements are defined in the [specs](https://specs.optimism.io/protocol/configurability.html). However, these requirements are currently a draft, pending governance approval.
 
 First, make a copy of `.env.example` named `.env`, and alter the variables to appropriate values.
 
@@ -92,6 +88,10 @@ go test -run=TestGasPriceOracleParams/11155420
 ```
 Omit the `-run=` flag to run checks for all chains.
 
+> [!NOTE]
+> Your chain will be checked against the standard configuration requirements. These  are defined in the [specs](https://specs.optimism.io/protocol/configurability.html). However, these requirements are currently a draft, pending governance approval.
+
+
 #### Solidity validation checks
 Run
 ```shell
@@ -105,86 +105,6 @@ When opening a PR:
 - Open one PR per chain you would like to add. This ensures the merge of one chain is not blocked by unexpected issues.
 
 Once the PR is opened, the same automated checks from Step 4 will then run on your PR, and your PR will be reviewed in due course. Once these checks pass the PR will be merged.
-
-## Adding a superchain target
-A superchain target defines a set of layer 2 chains which share a `SuperchainConfig` and `ProtocolVersions` contract deployment on layer 1. It is usually named after the layer 1 chain, possibly with an extra identifier to distinguish devnets.
-
-
-> **Note**
-> Example: `sepolia` and `sepolia-dev-0` are distinct superchain targets, although they are on the same layer 1 chain.
-
-
-A new Superchain Target can be added by creating a new superchain config directory,
-with a `superchain.yaml` config file.
-
-> **Note**
-> This is an infrequent operation and unecessary if you are just looking to add a chain to an existing superchain.
-
-Here's an example:
-
-```bash
-cd superchain-registry
-
-export SUPERCHAIN_TARGET=goerli-dev-0
-mkdir superchain/configs/$SUPERCHAIN_TARGET
-
-cat > superchain/configs/$SUPERCHAIN_TARGET/superchain.yaml << EOF
-name: Goerli Dev 0
-l1:
-  chain_id: 5
-  public_rpc: https://ethereum-goerli-rpc.allthatnode.com
-  explorer: https://goerli.etherscan.io
-
-protocol_versions_addr: null # todo
-superchain_config_addr: null # todo
-EOF
-```
-Superchain-wide configuration, like the `ProtocolVersions` contract address, should be configured here when available.
-
-### Approved contract versions
-Each superchain target should have a `semver.yaml` file in the same directory declaring the approved contract semantic versions for that superchain, e.g:
-```yaml
-l1_cross_domain_messenger: 1.4.0
-l1_erc721_bridge: 1.0.0
-l1_standard_bridge: 1.1.0
-l2_output_oracle: 1.3.0
-optimism_mintable_erc20_factory: 1.1.0
-optimism_portal: 1.6.0
-system_config: 1.3.0
-
-# superchain-wide contracts
-protocol_versions: 1.0.0
-superchain_config:
-```
-
-### `implementations`
-Per superchain a set of canonical implementation deployments, per semver version, is tracked.
-As default, an empty collection of deployments can be set:
-```bash
-cat > superchain/implementations/networks/$SUPERCHAIN_TARGET.yaml << EOF
-l1_cross_domain_messenger:
-l1_erc721_bridge:
-l1_standard_bridge:
-l2_output_oracle:
-optimism_mintable_erc20_factory:
-optimism_portal:
-system_config:
-EOF
-```
-
-## Setting up your editor for formatting and linting
-If you use VSCode, you can place the following in a `settings.json` file in the gitignored `.vscode` directory:
-
-```json
-{
-    "go.formatTool": "gofumpt",
-    "go.lintTool": "golangci-lint",
-    "go.lintOnSave": "workspace",
-    "gopls": {
-        "formatting.gofumpt": true,
-    },
-}
-```
 
 ## License
 


### PR DESCRIPTION
See #246 

* Moves the "add superchain target" material back to contributing (this is a pretty rare operation and most likely done by us)
* adds a TOC to the contributing page
* a few other small typo and broken link fixes