### PR TITLE
mainnet: activate Fjord on Wed Jul 10 16:00:01 UTC 2024

### DIFF
--- a/superchain/configs/mainnet/metal.yaml
+++ b/superchain/configs/mainnet/metal.yaml
@@ -5,7 +5,7 @@ sequencer_rpc: https://rpc.metall2.com
 explorer: https://explorer.metall2.com
 
 superchain_level: 2
-superchain_time: null # Missing hardfork times are NOT yet inherited from superchain.yaml
+superchain_time: 0 # Missing hardfork times are inherited from superchain.yaml
 
 batch_inbox_addr: "0xc83f7d9f2d4a76e81145849381aba02602373723"
 
@@ -17,7 +17,3 @@ genesis:
     hash: "0xd31c12ffff2d563897ad9a041c0d26790d635911bdbbfa589347fa955f75281e"
     number: 0
   l2_time: 1711563515
-
-canyon_time: 1704992401  # Thu 11 Jan 2024 17:00:01 UTC
-delta_time: 1708560000   # Thu 22 Feb 2024 00:00:00 UTC
-ecotone_time: 1710374401 # Thu 14 Mar 2024 00:00:01 UTC

--- a/superchain/configs/mainnet/superchain.yaml
+++ b/superchain/configs/mainnet/superchain.yaml
@@ -7,7 +7,7 @@ l1:
 protocol_versions_addr: "0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935"
 superchain_config_addr: "0x95703e0982140d16f8eba6d158fccede42f04a4c"
 
-canyon_time: 1704992401  # Thu 11 Jan 2024 17:00:01 UTC
-delta_time: 1708560000   # Thu 22 Feb 2024 00:00:00 UTC
+canyon_time:  1704992401 # Thu 11 Jan 2024 17:00:01 UTC
+delta_time:   1708560000 # Thu 22 Feb 2024 00:00:00 UTC
 ecotone_time: 1710374401 # Thu 14 Mar 2024 00:00:01 UTC
-
+fjord_time:   1720627201 # Wed Jul 10 16:00:01 UTC 2024


### PR DESCRIPTION
* unix time 1720627201

Also fix Metal Mainnet to activate together with the superchain

The "failed" diff check confirms activation on all expected chains, including Metal.
