### PR TITLE
feat: Add Rust Reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,11 @@
 
 # Code and script ownership
 
+# Rust
+*.rs @ethereum-optimism/rust-reviewers
+Cargo.toml @ethereum-optimism/rust-reviewers
+/bindings/rust-* @ethereum-optimism/rust-reviewers
+
 ## Go
 *.go @ethereum-optimism/go-reviewers
 /go.work @ethereum-optimism/go-reviewers
@@ -13,6 +18,3 @@
 
 ## Solidity
 *.sol @ethereum-optimism/security-reviewers
-
-
-


### PR DESCRIPTION
**Description**

> [!Warning]
>
> Pending approval of the `rust-reviewers` team.

Adds [`@ethereum-optimism/rust-reviewers`](https://github.com/orgs/ethereum-optimism/teams/rust-reviewers/members) to the `CODEOWNERS` file for rust bindings and any rust-related source files.