### PR TITLE
fix(bindings): Auto Impl Hash Trait

### DIFF
--- a/bindings/rust-bindings/Cargo.lock
+++ b/bindings/rust-bindings/Cargo.lock
@@ -504,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]

--- a/bindings/rust-primitives/src/addresses.rs
+++ b/bindings/rust-primitives/src/addresses.rs
@@ -7,7 +7,7 @@ use hashbrown::HashMap;
 pub type Addresses = HashMap<u64, AddressList>;
 
 /// The set of network-specific contracts for a given chain.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "PascalCase"))]
 pub struct AddressList {

--- a/bindings/rust-primitives/src/block.rs
+++ b/bindings/rust-primitives/src/block.rs
@@ -4,7 +4,7 @@ use alloy_primitives::B256;
 use core::fmt::Display;
 
 /// Block identifier.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BlockID {
     /// Block hash

--- a/bindings/rust-primitives/src/chain_config.rs
+++ b/bindings/rust-primitives/src/chain_config.rs
@@ -10,7 +10,7 @@ use hashbrown::HashMap;
 pub type OPChains = HashMap<u64, ChainConfig>;
 
 /// Plasma configuration.
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PlasmaConfig {
     /// Plasma DA challenge address
@@ -22,7 +22,7 @@ pub struct PlasmaConfig {
 }
 
 /// Hardfork configuration.
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HardForkConfiguration {
     /// Canyon hardfork activation time
@@ -36,7 +36,7 @@ pub struct HardForkConfiguration {
 }
 
 /// A chain configuration.
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChainConfig {
     /// Chain name (e.g. "Base")

--- a/bindings/rust-primitives/src/genesis.rs
+++ b/bindings/rust-primitives/src/genesis.rs
@@ -9,7 +9,7 @@ use hashbrown::HashMap;
 pub type GenesisSystemConfigs = HashMap<u64, SystemConfig>;
 
 /// Chain genesis information.
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChainGenesis {
     /// L1 genesis block

--- a/bindings/rust-primitives/src/superchain.rs
+++ b/bindings/rust-primitives/src/superchain.rs
@@ -9,7 +9,7 @@ use hashbrown::HashMap;
 pub type Superchains = HashMap<String, Superchain>;
 
 /// A superchain configuration.
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Superchain {
     /// Superchain configuration file contents.
@@ -21,7 +21,7 @@ pub struct Superchain {
 }
 
 /// A superchain configuration file format
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SuperchainConfig {
     /// Superchain name (e.g. "Mainnet")
@@ -38,7 +38,7 @@ pub struct SuperchainConfig {
 }
 
 /// Superchain L1 anchor information
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SuperchainL1Info {
     /// L1 chain ID
@@ -50,7 +50,7 @@ pub struct SuperchainL1Info {
 }
 
 /// Level of integration with the superchain.
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(
     feature = "serde",
     derive(serde_repr::Serialize_repr, serde_repr::Deserialize_repr)

--- a/bindings/rust-primitives/src/system_config.rs
+++ b/bindings/rust-primitives/src/system_config.rs
@@ -14,7 +14,7 @@ pub const CONFIG_UPDATE_TOPIC: B256 =
 pub const CONFIG_UPDATE_EVENT_VERSION_0: B256 = B256::ZERO;
 
 /// System configuration.
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct SystemConfig {
@@ -33,7 +33,7 @@ pub struct SystemConfig {
 }
 
 /// Represents type of update to the system config.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 #[repr(u64)]
 pub enum SystemConfigUpdateType {
     /// Batcher update type


### PR DESCRIPTION
**Description**

Adds the `Hash` marker to superchain primitive types to allow types to be hashed.