### PR TITLE
refactor (validation module): move "admin roles" standard config to TOML declaration file

### DIFF
--- a/validation/security-configs_test.go
+++ b/validation/security-configs_test.go
@@ -48,8 +48,9 @@ func testSecurityConfigOfChain(t *testing.T, chainID uint64) {
 		for method, output := range methodToOutput {
 
 			var want Address
-			if strings.HasPrefix(output, "0x") {
-				want = MustHexToAddress(output)
+
+			if common.IsHexAddress(output) {
+				want = Address(common.HexToAddress(output))
 			} else {
 				want, err = Addresses[chainID].AddressFor(output)
 				require.NoError(t, err)

--- a/validation/security-configs_test.go
+++ b/validation/security-configs_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	. "github.com/ethereum-optimism/superchain-registry/superchain"
+	"github.com/ethereum-optimism/superchain-registry/validation/standard"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -25,30 +26,6 @@ func testSecurityConfigOfChain(t *testing.T, chainID uint64) {
 	client, err := ethclient.Dial(rpcEndpoint)
 	require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
 
-	type resolution struct {
-		name                     string
-		method                   string
-		shouldResolveToAddressOf string
-	}
-
-	contractCallResolutions := []resolution{
-		{"AddressManager", "owner()", "ProxyAdmin"},
-		{"SystemConfigProxy", "owner()", "SystemConfigOwner"},
-		{"ProxyAdmin", "owner()", "ProxyAdminOwner"},
-		{"L1CrossDomainMessengerProxy", "PORTAL()", "OptimismPortalProxy"},
-		{"L1ERC721BridgeProxy", "admin()", "ProxyAdmin"},
-		{"L1ERC721BridgeProxy", "messenger()", "L1CrossDomainMessengerProxy"},
-		{"L1StandardBridgeProxy", "getOwner()", "ProxyAdmin"},
-		{"L1StandardBridgeProxy", "messenger()", "L1CrossDomainMessengerProxy"},
-		{"OptimismMintableERC20FactoryProxy", "admin()", "ProxyAdmin"},
-		{"OptimismMintableERC20FactoryProxy", "BRIDGE()", "L1StandardBridgeProxy"},
-		{"OptimismPortalProxy", "admin()", "ProxyAdmin"},
-		{"ProxyAdmin", "owner()", "ProxyAdminOwner"},
-		{"ProxyAdmin", "addressManager()", "AddressManager"},
-		{"SystemConfigProxy", "admin()", "ProxyAdmin"},
-		{"SystemConfigProxy", "owner()", "SystemConfigOwner"},
-	}
-
 	portalProxyAddress, err := Addresses[chainID].AddressFor("OptimismPortalProxy")
 	require.NoError(t, err)
 	portalProxy, err := bindings.NewOptimismPortal(common.Address(portalProxyAddress), client)
@@ -61,36 +38,29 @@ func testSecurityConfigOfChain(t *testing.T, chainID uint64) {
 	// Portal version `3` is the first version of the `OptimismPortal` that supported the fault proof system.
 	isFPAC := majorVersion >= 3
 
-	if isFPAC {
-		contractCallResolutions = append(contractCallResolutions,
-			resolution{"DisputeGameFactoryProxy", "admin()", "ProxyAdmin"},
-			resolution{"DisputeGameFactoryProxy", "owner()", "ProxyAdminOwner"},
-			resolution{"AnchorStateRegistryProxy", "admin()", "ProxyAdmin"},
-			resolution{"DelayedWETHProxy", "admin()", "ProxyAdmin"},
-			resolution{"OptimismPortalProxy", "guardian()", "Guardian"},
-			resolution{"OptimismPortalProxy", "systemConfig()", "SystemConfigProxy"},
-		)
-	} else {
-		contractCallResolutions = append(contractCallResolutions,
-			resolution{"OptimismPortalProxy", "GUARDIAN()", "Guardian"},
-			resolution{"OptimismPortalProxy", "SYSTEM_CONFIG()", "SystemConfigProxy"},
-			resolution{"OptimismPortalProxy", "L2_ORACLE()", "L2OutputOracleProxy"},
-			resolution{"L2OutputOracleProxy", "admin()", "ProxyAdmin"},
-			resolution{"L2OutputOracleProxy", "CHALLENGER()", "Challenger"},
-		)
-	}
+	contractCallResolutions := standard.Config[OPChains[chainID].Superchain].L1.GetResolutions(isFPAC)
 
-	for _, r := range contractCallResolutions {
-		contractAddress, err := Addresses[chainID].AddressFor(r.name)
+	for contract, methodToOutput := range contractCallResolutions {
+
+		contractAddress, err := Addresses[chainID].AddressFor(contract)
 		require.NoError(t, err)
 
-		want, err := Addresses[chainID].AddressFor(r.shouldResolveToAddressOf)
-		require.NoError(t, err)
+		for method, output := range methodToOutput {
 
-		got, err := getAddressWithRetries(r.method, contractAddress, client)
-		require.NoErrorf(t, err, "problem calling %s.%s", contractAddress, r.method)
+			var want Address
+			if strings.HasPrefix(output, "0x") {
+				want = MustHexToAddress(output)
+			} else {
+				want, err = Addresses[chainID].AddressFor(output)
+				require.NoError(t, err)
+			}
 
-		assert.Equal(t, want, got, "%s.%s = %s, expected %s (%s)", r.name, r.method, got, want, r.shouldResolveToAddressOf)
+			got, err := getAddressWithRetries(method, contractAddress, client)
+			require.NoErrorf(t, err, "problem calling %s.%s %s", contract, contractAddress, method)
+
+			assert.Equal(t, want, got, "%s.%s = %s, expected %s (%s)", contract, method, got, want, output)
+		}
+
 	}
 
 	// Perform an extra check on a mapping value of "L1CrossDomainMessengerProxy":

--- a/validation/standard/config.go
+++ b/validation/standard/config.go
@@ -1,6 +1,8 @@
 package standard
 
-import "math/big"
+import (
+	"math/big"
+)
 
 // Config is keyed by superchain target, e.g. "mainnet" or "sepolia" or "sepolia-dev-0"
 var Config map[string]*ConfigType
@@ -12,6 +14,32 @@ type ResourceConfig struct {
 	MinimumBaseFee              uint32   `toml:"minimum_base_fee"`
 	SystemTxMaxGas              uint32   `toml:"system_tx_max_gas"`
 	MaximumBaseFee              *big.Int `toml:"maximum_base_fee"`
+}
+
+type (
+	Resolutions map[string]map[string]string // e.g. "AddressManager": "owner()":  "ProxyAdmin"
+	L1          struct {
+		Universal Resolutions `toml:"universal"`
+		NonFPAC   Resolutions `toml:"nonFPAC"`
+		FPAC      Resolutions `toml:"FPAC"`
+	}
+)
+
+func (r L1) GetResolutions(isFPAC bool) Resolutions {
+	combinedResolutions := make(Resolutions)
+	for k, v := range r.Universal {
+		combinedResolutions[k] = v
+	}
+	if isFPAC {
+		for k, v := range r.FPAC {
+			combinedResolutions[k] = v
+		}
+	} else {
+		for k, v := range r.NonFPAC {
+			combinedResolutions[k] = v
+		}
+	}
+	return combinedResolutions
 }
 
 type L2OOParamsBounds struct {
@@ -51,4 +79,5 @@ type ConfigType struct {
 	L2OOParams     L2OOParamsBounds     `toml:"l2_output_oracle"`
 	GPOParams      GasPriceOracleBounds `toml:"gas_price_oracle"`
 	SystemConfig   SystemConfig         `toml:"system_config"`
+	L1             L1                   `toml:"l1"`
 }

--- a/validation/standard/standard-config-mainnet.toml
+++ b/validation/standard/standard-config-mainnet.toml
@@ -24,3 +24,34 @@ base_fee_scalar = [0, 10_000_000]
 
 [system_config]
 gas_limit = [8_000_000, 200_000_000]
+
+# Standard Chain Config Roles
+[l1.universal]
+AddressManager."owner()" = "ProxyAdmin"
+SystemConfigProxy."owner()" = "SystemConfigOwner"
+ProxyAdmin."owner()" = "ProxyAdminOwner"
+L1CrossDomainMessengerProxy."PORTAL()" = "OptimismPortalProxy"
+L1ERC721BridgeProxy."admin()" = "ProxyAdmin"
+L1ERC721BridgeProxy."messenger()" = "L1CrossDomainMessengerProxy"
+L1StandardBridgeProxy."getOwner()" = "ProxyAdmin"
+L1StandardBridgeProxy."messenger()" = "L1CrossDomainMessengerProxy"
+OptimismMintableERC20FactoryProxy."admin()" = "ProxyAdmin"
+OptimismMintableERC20FactoryProxy."BRIDGE()" = "L1StandardBridgeProxy"
+OptimismPortalProxy."admin()" = "ProxyAdmin"
+ProxyAdmin."addressManager()" = "AddressManager"
+SystemConfigProxy."admin()" = "ProxyAdmin"
+
+[l1.nonFPAC]
+OptimismPortalProxy."GUARDIAN()" = "Guardian"
+OptimismPortalProxy."SYSTEM_CONFIG()" = "SystemConfigProxy"
+OptimismPortalProxy."L2_ORACLE()" = "L2OutputOracleProxy"
+L2OutputOracleProxy."admin()" = "ProxyAdmin"
+L2OutputOracleProxy."CHALLENGER()" = "Challenger"
+
+[l1.FPAC]
+DisputeGameFactoryProxy."admin()" = "ProxyAdmin"
+DisputeGameFactoryProxy."owner()" = "ProxyAdminOwner"
+AnchorStateRegistryProxy."admin()" = "ProxyAdmin"
+DelayedWETHProxy."admin()" = "ProxyAdmin"
+OptimismPortalProxy."guardian()" = "Guardian"
+OptimismPortalProxy."systemConfig()" = "SystemConfigProxy"

--- a/validation/standard/standard-config-sepolia-dev-0.toml
+++ b/validation/standard/standard-config-sepolia-dev-0.toml
@@ -24,3 +24,34 @@ base_fee_scalar = [0, 10_000_000]
 
 [system_config]
 gas_limit = [1000, 60_000_000]
+
+# Standard Chain Config Roles
+[l1.universal]
+AddressManager."owner()" = "ProxyAdmin"
+SystemConfigProxy."owner()" = "SystemConfigOwner"
+ProxyAdmin."owner()" = "ProxyAdminOwner"
+L1CrossDomainMessengerProxy."PORTAL()" = "OptimismPortalProxy"
+L1ERC721BridgeProxy."admin()" = "ProxyAdmin"
+L1ERC721BridgeProxy."messenger()" = "L1CrossDomainMessengerProxy"
+L1StandardBridgeProxy."getOwner()" = "ProxyAdmin"
+L1StandardBridgeProxy."messenger()" = "L1CrossDomainMessengerProxy"
+OptimismMintableERC20FactoryProxy."admin()" = "ProxyAdmin"
+OptimismMintableERC20FactoryProxy."BRIDGE()" = "L1StandardBridgeProxy"
+OptimismPortalProxy."admin()" = "ProxyAdmin"
+ProxyAdmin."addressManager()" = "AddressManager"
+SystemConfigProxy."admin()" = "ProxyAdmin"
+
+[l1.nonFPAC]
+OptimismPortalProxy."GUARDIAN()" = "Guardian"
+OptimismPortalProxy."SYSTEM_CONFIG()" = "SystemConfigProxy"
+OptimismPortalProxy."L2_ORACLE()" = "L2OutputOracleProxy"
+L2OutputOracleProxy."admin()" = "ProxyAdmin"
+L2OutputOracleProxy."CHALLENGER()" = "Challenger"
+
+[l1.FPAC]
+DisputeGameFactoryProxy."admin()" = "ProxyAdmin"
+DisputeGameFactoryProxy."owner()" = "ProxyAdminOwner"
+AnchorStateRegistryProxy."admin()" = "ProxyAdmin"
+DelayedWETHProxy."admin()" = "ProxyAdmin"
+OptimismPortalProxy."guardian()" = "Guardian"
+OptimismPortalProxy."systemConfig()" = "SystemConfigProxy"

--- a/validation/standard/standard-config-sepolia.toml
+++ b/validation/standard/standard-config-sepolia.toml
@@ -24,3 +24,34 @@ base_fee_scalar = [0, 10_000_000]
 
 [system_config]
 gas_limit = [1000, 60_000_000]
+
+# Standard Chain Config Roles
+[l1.universal]
+AddressManager."owner()" = "ProxyAdmin"
+SystemConfigProxy."owner()" = "SystemConfigOwner"
+ProxyAdmin."owner()" = "ProxyAdminOwner"
+L1CrossDomainMessengerProxy."PORTAL()" = "OptimismPortalProxy"
+L1ERC721BridgeProxy."admin()" = "ProxyAdmin"
+L1ERC721BridgeProxy."messenger()" = "L1CrossDomainMessengerProxy"
+L1StandardBridgeProxy."getOwner()" = "ProxyAdmin"
+L1StandardBridgeProxy."messenger()" = "L1CrossDomainMessengerProxy"
+OptimismMintableERC20FactoryProxy."admin()" = "ProxyAdmin"
+OptimismMintableERC20FactoryProxy."BRIDGE()" = "L1StandardBridgeProxy"
+OptimismPortalProxy."admin()" = "ProxyAdmin"
+ProxyAdmin."addressManager()" = "AddressManager"
+SystemConfigProxy."admin()" = "ProxyAdmin"
+
+[l1.nonFPAC]
+OptimismPortalProxy."GUARDIAN()" = "Guardian"
+OptimismPortalProxy."SYSTEM_CONFIG()" = "SystemConfigProxy"
+OptimismPortalProxy."L2_ORACLE()" = "L2OutputOracleProxy"
+L2OutputOracleProxy."admin()" = "ProxyAdmin"
+L2OutputOracleProxy."CHALLENGER()" = "Challenger"
+
+[l1.FPAC]
+DisputeGameFactoryProxy."admin()" = "ProxyAdmin"
+DisputeGameFactoryProxy."owner()" = "ProxyAdminOwner"
+AnchorStateRegistryProxy."admin()" = "ProxyAdmin"
+DelayedWETHProxy."admin()" = "ProxyAdmin"
+OptimismPortalProxy."guardian()" = "Guardian"
+OptimismPortalProxy."systemConfig()" = "SystemConfigProxy"


### PR DESCRIPTION
Towards https://github.com/ethereum-optimism/client-pod/issues/913

This is just some tidy up, which concentrates more of [the "standard config"](https://specs.optimism.io/protocol/configurability.html?highlight=output%20frequency#admin-roles) in a single file, making it easier to inspect.
