### PR TITLE
Update rpc endpoints

### DIFF
--- a/superchain/configs/mainnet/superchain.yaml
+++ b/superchain/configs/mainnet/superchain.yaml
@@ -1,7 +1,7 @@
 name: Mainnet
 l1:
   chain_id: 1
-  public_rpc: https://ethereum-mainnet-rpc.allthatnode.com
+  public_rpc: https://ethereum-rpc.publicnode.com
   explorer: https://etherscan.io
 
 protocol_versions_addr: "0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935"

--- a/superchain/configs/sepolia-dev-0/superchain.yaml
+++ b/superchain/configs/sepolia-dev-0/superchain.yaml
@@ -1,7 +1,7 @@
 name: Sepolia Dev 0
 l1:
   chain_id: 11155111
-  public_rpc: https://ethereum-sepolia-rpc.allthatnode.com
+  public_rpc: https://ethereum-sepolia-rpc.publicnode.com
   explorer: https://sepolia.etherscan.io
 
 protocol_versions_addr: "0x252CbE9517F731C618961D890D534183822dcC8d"

--- a/superchain/configs/sepolia/superchain.yaml
+++ b/superchain/configs/sepolia/superchain.yaml
@@ -1,7 +1,7 @@
 name: Sepolia
 l1:
   chain_id: 11155111
-  public_rpc: https://ethereum-sepolia-rpc.allthatnode.com
+  public_rpc: https://ethereum-sepolia-rpc.publicnode.com
   explorer: https://sepolia.etherscan.io
 
 protocol_versions_addr: "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"


### PR DESCRIPTION
allthatnode recently changed their API to require an API key for queries, so it became impossible to run the validation checks locally without some hacking. 

On CI we are using a an API-key with Infura. So this change is to ease local development (important for chain contributors). 