### PR TITLE
fix: release plz embeddings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   release-plz:
-    name: Release-plz
+    name: Release-plz - ${{ matrix.dir }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,18 +26,6 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      # If releases break due to dirty `Cargo.lock` changes, toggle this step back on.
-      # If the cargo lock file changes due to upstream dependency versions updating,
-      # with semvers still matching, the workflow will have "uncommitted" changes
-      # which would prevent the release. This step commits any `Cargo.lock` changes
-      # so the release can proceed.
-      # - name: Commit Cargo.lock
-      #   working-directory: ${{ matrix.dir }}
-      #   run: |
-      #     git config --local user.email "action@github.com"
-      #     git config --local user.name "GitHub Action"
-      #     git add Cargo.lock
-      #     git commit -m "Update Cargo.lock" || echo "No changes to commit"
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         with:

--- a/bindings/rust-bindings/build.rs
+++ b/bindings/rust-bindings/build.rs
@@ -1,0 +1,20 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is not set");
+
+    let superchain_configs = PathBuf::from(&manifest_dir).join("../../superchain/configs");
+    let superchain_extra = PathBuf::from(&manifest_dir).join("../../superchain/extra");
+    let superchain_implementations = PathBuf::from(&manifest_dir).join("../../superchain/implementations");
+
+    println!("cargo:rerun-if-env-changed=CARGO_MANIFEST_DIR");
+    println!("cargo:rerun-if-changed={}", superchain_configs.display());
+    println!("cargo:rerun-if-changed={}", superchain_extra.display());
+    println!("cargo:rerun-if-changed={}", superchain_implementations.display());
+
+    println!("cargo:rustc-env=SUPERCHAIN_CONFIGS={}", superchain_configs.display());
+    println!("cargo:rustc-env=SUPERCHAIN_EXTRA={}", superchain_extra.display());
+    println!("cargo:rustc-env=SUPERCHAIN_IMPLEMENTATIONS={}", superchain_implementations.display());
+}
+

--- a/bindings/rust-bindings/build.rs
+++ b/bindings/rust-bindings/build.rs
@@ -6,15 +6,27 @@ fn main() {
 
     let superchain_configs = PathBuf::from(&manifest_dir).join("../../superchain/configs");
     let superchain_extra = PathBuf::from(&manifest_dir).join("../../superchain/extra");
-    let superchain_implementations = PathBuf::from(&manifest_dir).join("../../superchain/implementations");
+    let superchain_implementations =
+        PathBuf::from(&manifest_dir).join("../../superchain/implementations");
 
     println!("cargo:rerun-if-env-changed=CARGO_MANIFEST_DIR");
     println!("cargo:rerun-if-changed={}", superchain_configs.display());
     println!("cargo:rerun-if-changed={}", superchain_extra.display());
-    println!("cargo:rerun-if-changed={}", superchain_implementations.display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        superchain_implementations.display()
+    );
 
-    println!("cargo:rustc-env=SUPERCHAIN_CONFIGS={}", superchain_configs.display());
-    println!("cargo:rustc-env=SUPERCHAIN_EXTRA={}", superchain_extra.display());
-    println!("cargo:rustc-env=SUPERCHAIN_IMPLEMENTATIONS={}", superchain_implementations.display());
+    println!(
+        "cargo:rustc-env=SUPERCHAIN_CONFIGS={}",
+        superchain_configs.display()
+    );
+    println!(
+        "cargo:rustc-env=SUPERCHAIN_EXTRA={}",
+        superchain_extra.display()
+    );
+    println!(
+        "cargo:rustc-env=SUPERCHAIN_IMPLEMENTATIONS={}",
+        superchain_implementations.display()
+    );
 }
-

--- a/bindings/rust-bindings/src/embed.rs
+++ b/bindings/rust-bindings/src/embed.rs
@@ -1,12 +1,11 @@
 use include_dir::{include_dir, Dir};
 
 /// Directory containing the configuration files for the superchain.
-pub(crate) static CONFIGS_DIR: Dir<'_> =
-    include_dir!("$CARGO_MANIFEST_DIR/../../superchain/configs");
+pub(crate) static CONFIGS_DIR: Dir<'_> = include_dir!("$SUPERCHAIN_CONFIGS");
 
 /// Directory containing the extra files for the superchain.
-pub(crate) static EXTRA_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../superchain/extra");
+pub(crate) static EXTRA_DIR: Dir<'_> = include_dir!("$SUPERCHAIN_EXTRA");
 
 /// Directory containing the implementation addresses for the superchain.
-pub(crate) static IMPLEMENTATIONS_DIR: Dir<'_> =
-    include_dir!("$CARGO_MANIFEST_DIR/../../superchain/implementations");
+pub(crate) static IMPLEMENTATIONS_DIR: Dir<'_> = include_dir!("$SUPERCHAIN_IMPLEMENTATIONS");
+

--- a/bindings/rust-bindings/src/embed.rs
+++ b/bindings/rust-bindings/src/embed.rs
@@ -8,4 +8,3 @@ pub(crate) static EXTRA_DIR: Dir<'_> = include_dir!("$SUPERCHAIN_EXTRA");
 
 /// Directory containing the implementation addresses for the superchain.
 pub(crate) static IMPLEMENTATIONS_DIR: Dir<'_> = include_dir!("$SUPERCHAIN_IMPLEMENTATIONS");
-


### PR DESCRIPTION
## Overview

Fixes the release-plz workflow by moving directory embeddings earlier on into the build process, prior to linking the shared objects in the rust target folder.