### PR TITLE
refactor: reoorganise test stucture

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,15 +87,11 @@ The format is a gzipped JSON `genesis.json` file, with either:
 
 Run the following command from the `validation` folder to run the Go validation checks, for only the chain you added (replace the chain name or ID accordingly):
 ```
-go test -run=/OP-Sepolia
+go test -run=TestValidation/OP-Sepolia
 ```
 or
 ```
-go test -run=/11155420
-```
-You can even focus on a particular test and chain combination:
-```
-go test -run=TestGasPriceOracleParams/11155420
+go test -run=TestValidation//11155420
 ```
 Omit the `-run=` flag to run checks for all chains.
 

--- a/validation/chainid-rpc_test.go
+++ b/validation/chainid-rpc_test.go
@@ -9,27 +9,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestChainIdRPC(t *testing.T) {
+func testChainIDFromRPCofChain(t *testing.T, chain *ChainConfig) {
 	isExcluded := map[uint64]bool{
 		11155421: true, // sepolia-dev-0/oplabs-devnet-0   No Public RPC declared
 		11763072: true, // sepolia-dev-0/base-devnet-0     No Public RPC declared
 	}
-
-	for declaredChainID, chain := range OPChains {
-		t.Run(perChainTestName(chain), func(t *testing.T) {
-			if isExcluded[declaredChainID] {
-				t.Skip("chain excluded from chain ID RPC check")
-			}
-			// Create an ethclient connection to the specified RPC URL
-			client, err := ethclient.Dial(chain.PublicRPC)
-			require.NoError(t, err, "Failed to connect to the Ethereum client at RPC url %s", chain.PublicRPC)
-			defer client.Close()
-
-			// Fetch the chain ID
-			chainID, err := Retry(client.NetworkID)(context.Background())
-
-			require.NoError(t, err, "Failed to fetch the chain ID")
-			require.Equal(t, declaredChainID, chainID.Uint64(), "Declared a chainId of %s, but RPC returned ID %s", declaredChainID, chainID.Uint64())
-		})
+	if isExcluded[chain.ChainID] {
+		t.Skip("chain excluded from chain ID RPC check")
 	}
+	// Create an ethclient connection to the specified RPC URL
+	client, err := ethclient.Dial(chain.PublicRPC)
+	require.NoError(t, err, "Failed to connect to the Ethereum client at RPC url %s", chain.PublicRPC)
+	defer client.Close()
+
+	// Fetch the chain ID
+	chainID, err := Retry(client.NetworkID)(context.Background())
+
+	require.NoError(t, err, "Failed to fetch the chain ID")
+	require.Equal(t, chain.ChainID, chainID.Uint64(), "Declared a chainId of %s, but RPC returned ID %s", chain.ChainID, chainID.Uint64())
 }

--- a/validation/data-availability_test.go
+++ b/validation/data-availability_test.go
@@ -7,11 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDataAvailability(t *testing.T) {
-	for _, chain := range OPChains {
-		t.Run(perChainTestName(chain), func(t *testing.T) {
-			RunOnStandardAndStandardCandidateChains(t, *chain)
-			require.Nil(t, chain.Plasma, "Standard chains use Ethereum L1 calldata or blobs for data availability (plasma not permitted)")
-		})
-	}
+func testDataAvailabilityOfChain(t *testing.T, chain *ChainConfig) {
+	require.Nil(t, chain.Plasma, "Standard chains use Ethereum L1 calldata or blobs for data availability (plasma not permitted)")
 }

--- a/validation/gas-limit_test.go
+++ b/validation/gas-limit_test.go
@@ -14,31 +14,22 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
-func TestGasLimit(t *testing.T) {
-	checkGasLimit := func(t *testing.T, chain *ChainConfig) {
-		rpcEndpoint := Superchains[chain.Superchain].Config.L1.PublicRPC
+func testGasLimitOfChain(t *testing.T, chain *ChainConfig) {
+	rpcEndpoint := Superchains[chain.Superchain].Config.L1.PublicRPC
 
-		require.NotEmpty(t, rpcEndpoint)
+	require.NotEmpty(t, rpcEndpoint)
 
-		client, err := ethclient.Dial(rpcEndpoint)
-		require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
+	client, err := ethclient.Dial(rpcEndpoint)
+	require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
 
-		contractAddress, err := Addresses[chain.ChainID].AddressFor("SystemConfigProxy")
-		require.NoError(t, err)
+	contractAddress, err := Addresses[chain.ChainID].AddressFor("SystemConfigProxy")
+	require.NoError(t, err)
 
-		desiredParam := standard.Config.Params[chain.Superchain].SystemConfig.GasLimit
-		actualParam, err := getGasLimitWithRetries(context.Background(), common.Address(contractAddress), client)
-		require.NoError(t, err)
+	desiredParam := standard.Config.Params[chain.Superchain].SystemConfig.GasLimit
+	actualParam, err := getGasLimitWithRetries(context.Background(), common.Address(contractAddress), client)
+	require.NoError(t, err)
 
-		assertIntInBounds(t, "gas_limit", actualParam, desiredParam)
-	}
-
-	for _, chain := range OPChains {
-		t.Run(perChainTestName(chain), func(t *testing.T) {
-			RunOnStandardAndStandardCandidateChains(t, *chain)
-			checkGasLimit(t, chain)
-		})
-	}
+	assertIntInBounds(t, "gas_limit", actualParam, desiredParam)
 }
 
 func getGasLimitWithRetries(ctx context.Context, systemConfigAddr common.Address, client *ethclient.Client) (uint64, error) {

--- a/validation/gpo-params_test.go
+++ b/validation/gpo-params_test.go
@@ -18,11 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
-func TestGasPriceOracleParams(t *testing.T) {
-	isExcluded := map[uint64]bool{
-		11155421: true, // sepolia-dev-0/oplabs-devnet-0   (no public endpoint)
-		11763072: true, // sepolia-dev-0/base-devnet-0     (no public endpoint)
-	}
+func testGasPriceOracleParamsOfChain(t *testing.T, chain *ChainConfig) {
 
 	gasPriceOraclAddr := predeploys.GasPriceOracleAddr
 
@@ -62,19 +58,18 @@ func TestGasPriceOracleParams(t *testing.T) {
 		}
 	}
 
-	for chainID, chain := range OPChains {
-		t.Run(perChainTestName(chain), func(t *testing.T) {
-			if isExcluded[chainID] {
-				t.Skip()
-			}
-			RunOnStandardAndStandardCandidateChains(t, *chain)
-			rpcEndpoint := chain.PublicRPC
-			require.NotEmpty(t, rpcEndpoint, "no public endpoint for chain")
-			client, err := ethclient.Dial(rpcEndpoint)
-			require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
-			checkResourceConfig(t, chain, client)
-		})
+	isExcluded := map[uint64]bool{
+		11155421: true, // sepolia-dev-0/oplabs-devnet-0   (no public endpoint)
+		11763072: true, // sepolia-dev-0/base-devnet-0     (no public endpoint)
 	}
+	if isExcluded[chain.ChainID] {
+		t.Skip()
+	}
+	rpcEndpoint := chain.PublicRPC
+	require.NotEmpty(t, rpcEndpoint, "no public endpoint for chain")
+	client, err := ethclient.Dial(rpcEndpoint)
+	require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
+	checkResourceConfig(t, chain, client)
 }
 
 type PreEcotoneGasPriceOracleParams struct {

--- a/validation/gpo-params_test.go
+++ b/validation/gpo-params_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func testGasPriceOracleParamsOfChain(t *testing.T, chain *ChainConfig) {
-
 	gasPriceOraclAddr := predeploys.GasPriceOracleAddr
 
 	checkPreEcotoneResourceConfig := func(t *testing.T, chain *ChainConfig, client *ethclient.Client) {

--- a/validation/key-handover_test.go
+++ b/validation/key-handover_test.go
@@ -23,18 +23,3 @@ func testKeyHandoverOfChain(t *testing.T, chainID uint64) {
 	// L2 Proxy Admin
 	checkResolutions(t, standard.Config.MultisigRoles[superchain].KeyHandover.L1.Universal, chainID, client)
 }
-
-func TestKeyHandover(t *testing.T) {
-	isExcluded := map[uint64]bool{
-		11155421: true, // OP Labs Sepolia devnet 0 (no rpc endpoint)
-	}
-	for chainID, chain := range OPChains {
-		t.Run(perChainTestName(chain), func(t *testing.T) {
-			if isExcluded[chainID] {
-				t.Skip("chain excluded from key handover check")
-			}
-			RunOnlyOnStandardChains(t, *chain)
-			testKeyHandoverOfChain(t, chainID)
-		})
-	}
-}

--- a/validation/resource-config_test.go
+++ b/validation/resource-config_test.go
@@ -15,32 +15,23 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
-func TestResourceConfig(t *testing.T) {
-	checkResourceConfig := func(t *testing.T, chain *ChainConfig) {
-		rpcEndpoint := Superchains[chain.Superchain].Config.L1.PublicRPC
+func testResourceConfigOfChain(t *testing.T, chain *ChainConfig) {
+	rpcEndpoint := Superchains[chain.Superchain].Config.L1.PublicRPC
 
-		require.NotEmpty(t, rpcEndpoint)
+	require.NotEmpty(t, rpcEndpoint)
 
-		client, err := ethclient.Dial(rpcEndpoint)
-		require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
+	client, err := ethclient.Dial(rpcEndpoint)
+	require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
 
-		contractAddress, err := Addresses[chain.ChainID].AddressFor("SystemConfigProxy")
-		require.NoError(t, err)
+	contractAddress, err := Addresses[chain.ChainID].AddressFor("SystemConfigProxy")
+	require.NoError(t, err)
 
-		actualResourceConfig, err := getResourceConfig(context.Background(), common.Address(contractAddress), client)
-		require.NoErrorf(t, err, "RPC endpoint %s: %s", rpcEndpoint)
+	actualResourceConfig, err := getResourceConfig(context.Background(), common.Address(contractAddress), client)
+	require.NoErrorf(t, err, "RPC endpoint %s: %s", rpcEndpoint)
 
-		desiredParams := standard.Config.Params[chain.Superchain].ResourceConfig
+	desiredParams := standard.Config.Params[chain.Superchain].ResourceConfig
 
-		require.Equal(t, bindings.ResourceMeteringResourceConfig(desiredParams), actualResourceConfig, "resource config unacceptable")
-	}
-
-	for _, chain := range OPChains {
-		t.Run(perChainTestName(chain), func(t *testing.T) {
-			RunOnStandardAndStandardCandidateChains(t, *chain)
-			checkResourceConfig(t, chain)
-		})
-	}
+	require.Equal(t, bindings.ResourceMeteringResourceConfig(desiredParams), actualResourceConfig, "resource config unacceptable")
 }
 
 // getResourceConfig will get the resoureConfig stored in the contract at systemConfigAddr.

--- a/validation/security-configs_test.go
+++ b/validation/security-configs_test.go
@@ -105,42 +105,21 @@ func testL1SecurityConfigOfChain(t *testing.T, chainID uint64) {
 	)
 }
 
-func TestL1SecurityConfigs(t *testing.T) {
-	for chainID, chainPtr := range OPChains {
-		chain, chainID := *chainPtr, chainID
-		t.Run(perChainTestName(&chain), func(t *testing.T) {
-			t.Parallel()
-			RunOnStandardAndStandardCandidateChains(t, chain)
-			testL1SecurityConfigOfChain(t, chainID)
-		})
-	}
-}
-
-func testL2SecurityConfigForChain(t *testing.T, chain ChainConfig) {
-	// Create an ethclient connection to the specified RPC URL
-	client, err := ethclient.Dial(chain.PublicRPC)
-	require.NoError(t, err, "Failed to connect to the Ethereum client at RPC url %s", chain.PublicRPC)
-	defer client.Close()
-	checkResolutions(t, standard.Config.Roles.L2.Universal, chain.ChainID, client)
-}
-
-func TestL2SecurityConfigs(t *testing.T) {
+func testL2SecurityConfigForChain(t *testing.T, chain *ChainConfig) {
 	isExcluded := map[uint64]bool{
 		11155421: true, // sepolia-dev-0/oplabs-devnet-0   No Public RPC declared
 		11763072: true, // sepolia-dev-0/base-devnet-0     No Public RPC declared
 	}
 
-	for chainID, chainPtr := range OPChains {
-		chain, chainID := *chainPtr, chainID
-		t.Run(perChainTestName(&chain), func(t *testing.T) {
-			t.Parallel()
-			if isExcluded[chainID] {
-				t.Skip("chain excluded from check")
-			}
-			RunOnStandardAndStandardCandidateChains(t, chain)
-			testL2SecurityConfigForChain(t, chain)
-		})
+	if isExcluded[chain.ChainID] {
+		t.Skip("chain excluded from check")
 	}
+
+	// Create an ethclient connection to the specified RPC URL
+	client, err := ethclient.Dial(chain.PublicRPC)
+	require.NoError(t, err, "Failed to connect to the Ethereum client at RPC url %s", chain.PublicRPC)
+	defer client.Close()
+	checkResolutions(t, standard.Config.Roles.L2.Universal, chain.ChainID, client)
 }
 
 func getAddress(method string, contractAddress Address, client *ethclient.Client) (Address, error) {

--- a/validation/superchain-genesis_test.go
+++ b/validation/superchain-genesis_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func testGenesisHashOfChain(t *testing.T, chainID uint64) {
+	if chainID == 10 {
+		t.Skipf("chain %d: EXCLUDED from Genesis block hash validation", chainID)
+	}
+
 	chainConfig, ok := OPChains[chainID]
 	if !ok {
 		t.Fatalf("no chain with ID %d found", chainID)
@@ -51,35 +55,28 @@ func TestGenesisHash(t *testing.T) {
 	}
 }
 
-func TestGenesisHashAgainstRPC(t *testing.T) {
+func testGenesisHashAgainstRPCofChain(t *testing.T, chain *ChainConfig) {
 	isExcluded := map[uint64]bool{
 		11155421: true, // sepolia-dev-0/oplabs-devnet-0   (no public endpoint)
 		11763072: true, // sepolia-dev-0/base-devnet-0     (no public endpoint)
 	}
 
-	checkOPChainHashAgainstRPC := func(t *testing.T, chain *ChainConfig) {
-		declaredGenesisHash := chain.Genesis.L2.Hash
-		rpcEndpoint := chain.PublicRPC
-		require.NotEmpty(t, rpcEndpoint)
-
-		client, err := ethclient.Dial(rpcEndpoint)
-		require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
-
-		blockByNumber := func(blockNumber uint64) (*types.Block, error) {
-			return client.BlockByNumber(context.Background(), big.NewInt(int64(blockNumber)))
-		}
-		genesisBlock, err := Retry(blockByNumber)(chain.Genesis.L2.Number)
-		require.NoError(t, err)
-
-		require.Equal(t, genesisBlock.Hash(), common.Hash(declaredGenesisHash), "Genesis Block Hash declared as %s, but RPC returned %s", declaredGenesisHash, genesisBlock.Hash())
+	if isExcluded[chain.ChainID] {
+		t.Skip("chain excluded from check")
 	}
 
-	for _, chain := range OPChains {
-		t.Run(perChainTestName(chain), func(t *testing.T) {
-			if isExcluded[chain.ChainID] {
-				t.Skip("chain excluded from check")
-			}
-			checkOPChainHashAgainstRPC(t, chain)
-		})
+	declaredGenesisHash := chain.Genesis.L2.Hash
+	rpcEndpoint := chain.PublicRPC
+	require.NotEmpty(t, rpcEndpoint)
+
+	client, err := ethclient.Dial(rpcEndpoint)
+	require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
+
+	blockByNumber := func(blockNumber uint64) (*types.Block, error) {
+		return client.BlockByNumber(context.Background(), big.NewInt(int64(blockNumber)))
 	}
+	genesisBlock, err := Retry(blockByNumber)(chain.Genesis.L2.Number)
+	require.NoError(t, err)
+
+	require.Equal(t, genesisBlock.Hash(), common.Hash(declaredGenesisHash), "Genesis Block Hash declared as %s, but RPC returned %s", declaredGenesisHash, genesisBlock.Hash())
 }

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -55,42 +55,31 @@ func TestSuperchainWideContractVersions(t *testing.T) {
 	}
 }
 
-func TestContractVersions(t *testing.T) {
+func testOPChainMatchesATag(t *testing.T, chain *ChainConfig) {
 	isExcluded := map[uint64]bool{
 		8453:     true, // mainnet/base
 		11155421: true, // sepolia-dev-0/oplabs-devnet-0
 		11763072: true, // sepolia-dev-0/base-devnet-0
 	}
-
-	checkOPChainMatchesATag := func(t *testing.T, chain *ChainConfig) {
-		rpcEndpoint := Superchains[chain.Superchain].Config.L1.PublicRPC
-		require.NotEmpty(t, rpcEndpoint)
-
-		client, err := ethclient.Dial(rpcEndpoint)
-		require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
-		require.NotNil(t, chain.ContractsVersionTag, "Chain does not declare a contracts_version_tag")
-
-		isFPAC := *chain.ContractsVersionTag == "op-contracts/v1.4.0"
-
-		versions, err := getContractVersionsFromChain(*Addresses[chain.ChainID], client, isFPAC)
-		require.NoError(t, err)
-		matches, err := findOPContractTag(versions)
-		require.NoError(t, err)
-
-		require.Containsf(t, matches, standard.Tag(*chain.ContractsVersionTag), "Chain config does not declare the correct contracts_version_tag")
+	if isExcluded[chain.ChainID] {
+		t.Skipf("chain %d: EXCLUDED from contract version validation", chain.ChainID)
 	}
 
-	for chainID, chain := range OPChains {
-		chainID, chain := chainID, chain
-		t.Run(perChainTestName(chain), func(t *testing.T) {
-			t.Parallel()
-			if isExcluded[chainID] {
-				t.Skipf("chain %d: EXCLUDED from contract version validation", chainID)
-			}
-			RunOnStandardAndStandardCandidateChains(t, *chain)
-			checkOPChainMatchesATag(t, chain)
-		})
-	}
+	rpcEndpoint := Superchains[chain.Superchain].Config.L1.PublicRPC
+	require.NotEmpty(t, rpcEndpoint)
+
+	client, err := ethclient.Dial(rpcEndpoint)
+	require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
+	require.NotNil(t, chain.ContractsVersionTag, "Chain does not declare a contracts_version_tag")
+
+	isFPAC := *chain.ContractsVersionTag == "op-contracts/v1.4.0"
+
+	versions, err := getContractVersionsFromChain(*Addresses[chain.ChainID], client, isFPAC)
+	require.NoError(t, err)
+	matches, err := findOPContractTag(versions)
+	require.NoError(t, err)
+
+	require.Containsf(t, matches, standard.Tag(*chain.ContractsVersionTag), "Chain config does not declare the correct contracts_version_tag")
 }
 
 // getContractVersionsFromChain pulls the appropriate contract versions (depending on the isFPAC argument) from chain

--- a/validation/uniqueness_test.go
+++ b/validation/uniqueness_test.go
@@ -103,9 +103,11 @@ func getGlobalChains() (map[uint]*uniqueProperties, error) {
 	return globalChainIds, nil
 }
 
-var globalChainIds map[uint]*uniqueProperties
-var localChainIds = make(chainIDSet)
-var localChainNames = make(chainNameSet)
+var (
+	globalChainIds  map[uint]*uniqueProperties
+	localChainIds   = make(chainIDSet)
+	localChainNames = make(chainNameSet)
+)
 
 func init() {
 	var err error

--- a/validation/uniqueness_test.go
+++ b/validation/uniqueness_test.go
@@ -103,37 +103,36 @@ func getGlobalChains() (map[uint]*uniqueProperties, error) {
 	return globalChainIds, nil
 }
 
-func TestChainsAreGloballyUnique(t *testing.T) {
-	globalChainIds, err := getGlobalChains()
-	if err != nil {
-		t.Fatal(err)
-	}
-	localChainIds := make(chainIDSet)
-	localChainNames := make(chainNameSet)
+var globalChainIds map[uint]*uniqueProperties
+var localChainIds = make(chainIDSet)
+var localChainNames = make(chainNameSet)
 
+func init() {
+	var err error
+	globalChainIds, err = getGlobalChains()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func testChainIsGloballyUnique(t *testing.T, chain *ChainConfig) {
 	isExcluded := map[uint64]bool{
-		90001:    true, // sepolia/race, known chainId collision
 		11155421: true, // oplabs devnet 0, not in upstream repo
 		11763072: true, // base devnet 0, not in upstream repo
 	}
-
-	for _, chain := range OPChains {
-		t.Run(perChainTestName(chain), func(t *testing.T) {
-			if isExcluded[chain.ChainID] {
-				t.Skip("excluded from global chain id check")
-			}
-			props := globalChainIds[uint(chain.ChainID)]
-			require.NotNil(t, props, "chain ID is not listed at chainid.network")
-			globalChainName := props.Name
-			assert.Equal(t, globalChainName, chain.Name,
-				"Local chain name for %d does not match name from chainid.network", chain.ChainID)
-			assert.NoError(t, localChainIds.AddIfUnique(chain.ChainID))
-			assert.NoError(t, localChainNames.AddIfUnique(chain.Name))
-			normalizedURL, err := normalizeURL(chain.PublicRPC)
-			require.NoError(t, err)
-			assert.Contains(t, props.RPC, normalizedURL, "Specified RPC not specified in chainid.network")
-		})
+	if isExcluded[chain.ChainID] {
+		t.Skip("excluded from global chain id check")
 	}
+	props := globalChainIds[uint(chain.ChainID)]
+	require.NotNil(t, props, "chain ID is not listed at chainid.network")
+	globalChainName := props.Name
+	assert.Equal(t, globalChainName, chain.Name,
+		"Local chain name for %d does not match name from chainid.network", chain.ChainID)
+	assert.NoError(t, localChainIds.AddIfUnique(chain.ChainID))
+	assert.NoError(t, localChainNames.AddIfUnique(chain.Name))
+	normalizedURL, err := normalizeURL(chain.PublicRPC)
+	require.NoError(t, err)
+	assert.Contains(t, props.RPC, normalizedURL, "Specified RPC not specified in chainid.network")
 }
 
 func normalizeURL(rawURL string) (string, error) {

--- a/validation/utils_test.go
+++ b/validation/utils_test.go
@@ -68,16 +68,3 @@ func TestIsIntWithinBounds(t *testing.T) {
 		})
 	}
 }
-
-func RunOnStandardAndStandardCandidateChains(t *testing.T, chain superchain.ChainConfig) {
-	if chain.StandardChainCandidate || chain.SuperchainLevel == superchain.Standard {
-		return
-	}
-	t.Skip("Chain excluded from this check (NOT a Standard Chain and NOT optimistically running standard checks)")
-}
-
-func RunOnlyOnStandardChains(t *testing.T, chain superchain.ChainConfig) {
-	if chain.SuperchainLevel != superchain.Standard {
-		t.Skip("Chain excluded from this check (NOT a Standard Chain)")
-	}
-}

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -57,7 +57,6 @@ func testUniversal(t *testing.T, chain *ChainConfig) {
 	t.Run("ChainID RPC Check", func(t *testing.T) {
 		testChainIDFromRPCofChain(t, chain)
 	})
-
 }
 
 // testStandardCandidate should be applied only to a fully Standard Chain,

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -1,0 +1,88 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/superchain-registry/superchain"
+	. "github.com/ethereum-optimism/superchain-registry/superchain"
+)
+
+func TestValidation(t *testing.T) {
+	// Entry point for validation checks which run
+	// on each OP chain.
+	for _, chain := range OPChains {
+		chain := chain
+		t.Run(perChainTestName(chain), func(t *testing.T) {
+			t.Parallel()
+			testValidation(t, chain)
+		})
+	}
+}
+
+func testValidation(t *testing.T, chain *ChainConfig) {
+	t.Run("Universal Checks", func(t *testing.T) {
+		testUniversal(t, chain)
+	})
+
+	t.Run("Standard Chain", func(t *testing.T) {
+		if chain.SuperchainLevel != superchain.Standard {
+			t.Skip("Chain excluded from this check (NOT a Standard Chain)")
+		}
+		testStandard(t, chain)
+	})
+
+	t.Run("Standard or Standard Candidate Chain", func(t *testing.T) {
+		if !chain.StandardChainCandidate && chain.SuperchainLevel != Standard {
+			t.Skip("Chain excluded from this check (NOT a Standard or a Standard Candidate Chain)")
+		}
+		testStandardCandidate(t, chain)
+	})
+}
+
+// testUniversal should be applied to each chain in the registry
+// regardless of superchain_level. There should be no
+// exceptions, since the test is e.g.
+// designed to protect downstream software or
+// sanity checking basic consistency conditions.
+func testUniversal(t *testing.T, chain *ChainConfig) {
+	t.Run("Genesis Hash Check (op-geth)", func(t *testing.T) {
+		testGenesisHashOfChain(t, chain.ChainID)
+	})
+	t.Run("Genesis Check (RPC)", func(t *testing.T) {
+		testGenesisHashAgainstRPCofChain(t, chain)
+	})
+	t.Run("Uniqueness Check", func(t *testing.T) {
+		testChainIsGloballyUnique(t, chain)
+	})
+	t.Run("ChainID RPC Check", func(t *testing.T) {
+		testChainIDFromRPCofChain(t, chain)
+	})
+
+}
+
+// testStandardCandidate should be applied only to a fully Standard Chain,
+// i.e. not to a Standard Candidate Chain.
+func testStandardCandidate(t *testing.T, chain *ChainConfig) {
+	t.Run("Standard Config Params", func(t *testing.T) {
+		testDataAvailabilityOfChain(t, chain)
+		testResourceConfigOfChain(t, chain)
+		testL2OOParamsOfChain(t, chain)
+		testGasLimitOfChain(t, chain)
+		testGasPriceOracleParamsOfChain(t, chain)
+	})
+	t.Run("Standard Config Roles", func(t *testing.T) {
+		testL1SecurityConfigOfChain(t, chain.ChainID)
+		testL2SecurityConfigForChain(t, chain)
+	})
+	t.Run("Standard Contract Versions", func(t *testing.T) {
+		testOPChainMatchesATag(t, chain)
+	})
+}
+
+// testStandard should be applied only to a fully Standard Chain,
+// i.e. not to a Standard Candidate Chain.
+func testStandard(t *testing.T, chain *ChainConfig) {
+	t.Run("Key Handover Check", func(t *testing.T) {
+		testKeyHandoverOfChain(t, chain.ChainID)
+	})
+}


### PR DESCRIPTION
Step 1 in the effort to make the validation checks as legible as possible, and as efficient as possible. 

In particular, this change makes it easier to discover the overall logic of the validation checks:
* they apply to each chain in the registry in general, and can be filtered / focussed to a single chain easily as well as run in parallel across channels
* the first level of sub tests allows tests to be skipped depending on the class of each chain in the loo
* the next level down sorts the validation checks into categories (roles, versions, parameters)