### PR TITLE
add-chain: add compress-genesis subcommand

### DIFF
--- a/add-chain/cmd/compress-genesis.go
+++ b/add-chain/cmd/compress-genesis.go
@@ -1,0 +1,255 @@
+package cmd
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
+	"github.com/ethereum-optimism/superchain-registry/add-chain/flags"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/urfave/cli/v2"
+)
+
+var CompressGenesisCmd = cli.Command{
+	Name: "compress-genesis",
+	Flags: []cli.Flag{
+		flags.L2GenesisFlag,
+		flags.L2GenesisHeaderFlag,
+		flags.ChainShortNameFlag,
+		flags.SuperchainTargetFlag,
+	},
+	Usage: "Generate a single gzipped data file from a bytecode hex string",
+	Action: func(ctx *cli.Context) error {
+		// Get the current script filepath
+		_, thisFile, _, ok := runtime.Caller(0)
+		if !ok {
+			panic("error getting current filepath")
+		}
+		superchainRepoRoot := filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
+		superchainTarget := ctx.String(flags.SuperchainTargetFlag.Name)
+		if superchainTarget == "" {
+			return fmt.Errorf("must set superchain-target (SCR_SUPERCHAIN_TARGET)")
+		}
+		chainShortName := ctx.String(flags.ChainShortNameFlag.Name)
+		if chainShortName == "" {
+			return fmt.Errorf("must set chain-short-name (SCR_CHAIN_SHORT_NAME)")
+		}
+
+		zipOutputDir := filepath.Join(superchainRepoRoot, "/superchain/extra/genesis", superchainTarget, chainShortName+".json.gz")
+		genesisPath := ctx.Path(flags.L2GenesisFlag.Name)
+		if genesisPath == "" {
+			// When the genesis-state is too large, or not meant to be available, only the header data is made available.
+			// This allows the user to verify the header-chain starting from genesis, and state-sync the latest state,
+			// skipping the historical state.
+			// Archive nodes that depend on this historical state should instantiate the chain from a full genesis dump
+			// with allocation data, or datadir.
+			genesisHeaderPath := ctx.Path(flags.L2GenesisHeaderFlag.Name)
+			genesisHeader, err := loadJSON[types.Header](genesisHeaderPath)
+			if err != nil {
+				return fmt.Errorf("genesis-header %q failed to load: %w", genesisHeaderPath, err)
+			}
+			if genesisHeader.TxHash != types.EmptyTxsHash {
+				return errors.New("genesis-header based genesis must have no transactions")
+			}
+			if genesisHeader.ReceiptHash != types.EmptyReceiptsHash {
+				return errors.New("genesis-header based genesis must have no receipts")
+			}
+			if genesisHeader.UncleHash != types.EmptyUncleHash {
+				return errors.New("genesis-header based genesis must have no uncle hashes")
+			}
+			if genesisHeader.WithdrawalsHash != nil && *genesisHeader.WithdrawalsHash != types.EmptyWithdrawalsHash {
+				return errors.New("genesis-header based genesis must have no withdrawals")
+			}
+			out := Genesis{
+				Nonce:         genesisHeader.Nonce.Uint64(),
+				Timestamp:     genesisHeader.Time,
+				ExtraData:     genesisHeader.Extra,
+				GasLimit:      genesisHeader.GasLimit,
+				Difficulty:    (*hexutil.Big)(genesisHeader.Difficulty),
+				Mixhash:       genesisHeader.MixDigest,
+				Coinbase:      genesisHeader.Coinbase,
+				Number:        genesisHeader.Number.Uint64(),
+				GasUsed:       genesisHeader.GasUsed,
+				ParentHash:    genesisHeader.ParentHash,
+				BaseFee:       (*hexutil.Big)(genesisHeader.BaseFee),
+				ExcessBlobGas: genesisHeader.ExcessBlobGas, // EIP-4844
+				BlobGasUsed:   genesisHeader.BlobGasUsed,   // EIP-4844
+				Alloc:         make(jsonutil.LazySortedJsonMap[common.Address, GenesisAccount]),
+				StateHash:     &genesisHeader.Root,
+			}
+			if err := writeGzipJSON(zipOutputDir, out); err != nil {
+				return fmt.Errorf("failed to write output: %w", err)
+			}
+			return nil
+		}
+
+		genesis, err := loadJSON[core.Genesis](genesisPath)
+		if err != nil {
+			return fmt.Errorf("failed to load L2 genesis: %w", err)
+		}
+
+		// export all contract bytecodes, write them to bytecodes collection
+		bytecodesDir := filepath.Join(superchainRepoRoot, "/superchain/extra/bytecodes")
+		fmt.Printf("using output bytecodes dir: %s\n", bytecodesDir)
+		if err := os.MkdirAll(bytecodesDir, 0o755); err != nil {
+			return fmt.Errorf("failed to make bytecodes dir: %w", err)
+		}
+		for addr, account := range genesis.Alloc {
+			if len(account.Code) > 0 {
+				err = writeBytecode(bytecodesDir, account.Code, addr)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		// convert into allocation data
+		out := Genesis{
+			Nonce:         genesis.Nonce,
+			Timestamp:     genesis.Timestamp,
+			ExtraData:     genesis.ExtraData,
+			GasLimit:      genesis.GasLimit,
+			Difficulty:    (*hexutil.Big)(genesis.Difficulty),
+			Mixhash:       genesis.Mixhash,
+			Coinbase:      genesis.Coinbase,
+			Number:        genesis.Number,
+			GasUsed:       genesis.GasUsed,
+			ParentHash:    genesis.ParentHash,
+			BaseFee:       (*hexutil.Big)(genesis.BaseFee),
+			ExcessBlobGas: genesis.ExcessBlobGas, // EIP-4844
+			BlobGasUsed:   genesis.BlobGasUsed,   // EIP-4844
+			Alloc:         make(jsonutil.LazySortedJsonMap[common.Address, GenesisAccount]),
+		}
+
+		// write genesis, but only reference code by code-hash, and don't encode the L2 predeploys to save space.
+		for addr, account := range genesis.Alloc {
+			var codeHash common.Hash
+			if len(account.Code) > 0 {
+				codeHash = crypto.Keccak256Hash(account.Code)
+			}
+			outAcc := GenesisAccount{
+				CodeHash: codeHash,
+				Nonce:    account.Nonce,
+			}
+			if account.Balance != nil && account.Balance.Cmp(common.Big0) != 0 {
+				outAcc.Balance = (*hexutil.Big)(account.Balance)
+			}
+			if len(account.Storage) > 0 {
+				outAcc.Storage = make(jsonutil.LazySortedJsonMap[common.Hash, common.Hash])
+				for k, v := range account.Storage {
+					outAcc.Storage[k] = v
+				}
+			}
+			out.Alloc[addr] = outAcc
+		}
+
+		// write genesis alloc
+		if err := writeGzipJSON(zipOutputDir, out); err != nil {
+			return fmt.Errorf("failed to write output: %w", err)
+		}
+		return nil
+	},
+}
+
+func writeBytecode(bytecodesDir string, code []byte, addr common.Address) error {
+	codeHash := crypto.Keccak256Hash(code)
+	name := filepath.Join(bytecodesDir, fmt.Sprintf("%s.bin.gz", codeHash))
+	_, err := os.Stat(name)
+	if err == nil {
+		// file already exists
+		return nil
+	}
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to check for pre-existing bytecode %s for address %s: %w", codeHash, addr, err)
+	}
+	var buf bytes.Buffer
+	w, err := gzip.NewWriterLevel(&buf, 9)
+	if err != nil {
+		return fmt.Errorf("failed to construct gzip writer for bytecode %s: %w", codeHash, err)
+	}
+	if _, err := w.Write(code); err != nil {
+		return fmt.Errorf("failed to write bytecode %s to gzip writer: %w", codeHash, err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("failed to close gzip writer: %w", err)
+	}
+	// new bytecode
+	if err := os.WriteFile(name, buf.Bytes(), 0o755); err != nil {
+		return fmt.Errorf("failed to write bytecode %s of account %s: %w", codeHash, addr, err)
+	}
+	fmt.Printf("created new bytecodes file: %s\n", filepath.Base(name))
+	return nil
+}
+
+type GenesisAccount struct {
+	CodeHash common.Hash                                          `json:"codeHash,omitempty"`
+	Storage  jsonutil.LazySortedJsonMap[common.Hash, common.Hash] `json:"storage,omitempty"`
+	Balance  *hexutil.Big                                         `json:"balance,omitempty"`
+	Nonce    uint64                                               `json:"nonce,omitempty"`
+}
+
+type Genesis struct {
+	Nonce         uint64         `json:"nonce"`
+	Timestamp     uint64         `json:"timestamp"`
+	ExtraData     []byte         `json:"extraData"`
+	GasLimit      uint64         `json:"gasLimit"`
+	Difficulty    *hexutil.Big   `json:"difficulty"`
+	Mixhash       common.Hash    `json:"mixHash"`
+	Coinbase      common.Address `json:"coinbase"`
+	Number        uint64         `json:"number"`
+	GasUsed       uint64         `json:"gasUsed"`
+	ParentHash    common.Hash    `json:"parentHash"`
+	BaseFee       *hexutil.Big   `json:"baseFeePerGas"`
+	ExcessBlobGas *uint64        `json:"excessBlobGas"` // EIP-4844
+	BlobGasUsed   *uint64        `json:"blobGasUsed"`   // EIP-4844
+
+	Alloc jsonutil.LazySortedJsonMap[common.Address, GenesisAccount] `json:"alloc"`
+	// For genesis definitions without full state (OP-Mainnet, OP-Goerli)
+	StateHash *common.Hash `json:"stateHash,omitempty"`
+}
+
+func loadJSON[X any](inputPath string) (*X, error) {
+	if inputPath == "" {
+		return nil, errors.New("no path specified")
+	}
+	f, err := os.OpenFile(inputPath, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %w", inputPath, err)
+	}
+	defer f.Close()
+	var obj X
+	if err := json.NewDecoder(f).Decode(&obj); err != nil {
+		return nil, fmt.Errorf("failed to decode file %q: %w", inputPath, err)
+	}
+	return &obj, nil
+}
+
+func writeGzipJSON(outputPath string, value any) error {
+	fmt.Printf("using output gzip filepath: %s\n", outputPath)
+	f, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		return fmt.Errorf("failed to open output file: %w", err)
+	}
+	defer f.Close()
+	w, err := gzip.NewWriterLevel(f, flate.BestCompression)
+	if err != nil {
+		return fmt.Errorf("failed to create gzip writer: %w", err)
+	}
+	defer w.Close()
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(value); err != nil {
+		return fmt.Errorf("failed to encode to JSON: %w", err)
+	}
+	return nil
+}

--- a/add-chain/cmd/compress-genesis.go
+++ b/add-chain/cmd/compress-genesis.go
@@ -39,11 +39,11 @@ var CompressGenesisCmd = cli.Command{
 		superchainRepoRoot := filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
 		superchainTarget := ctx.String(flags.SuperchainTargetFlag.Name)
 		if superchainTarget == "" {
-			return fmt.Errorf("must set superchain-target (SCR_SUPERCHAIN_TARGET)")
+			return fmt.Errorf("missing required flag: %s", flags.SuperchainTargetFlag.Name)
 		}
 		chainShortName := ctx.String(flags.ChainShortNameFlag.Name)
 		if chainShortName == "" {
-			return fmt.Errorf("must set chain-short-name (SCR_CHAIN_SHORT_NAME)")
+			return fmt.Errorf("missing required flag: %s", flags.ChainShortNameFlag.Name)
 		}
 
 		zipOutputDir := filepath.Join(superchainRepoRoot, "/superchain/extra/genesis", superchainTarget, chainShortName+".json.gz")

--- a/add-chain/e2e_test.go
+++ b/add-chain/e2e_test.go
@@ -91,7 +91,7 @@ func TestAddChain_Main(t *testing.T) {
 		})
 	}
 
-	t.Run("compress genesis", func(t *testing.T) {
+	t.Run("compress-genesis", func(t *testing.T) {
 		// Must run this test to produce the .json.gz output artifact for the
 		// subsequent CheckGenesisConfig test
 		t.Parallel()
@@ -101,9 +101,9 @@ func TestAddChain_Main(t *testing.T) {
 		args := []string{
 			"add-chain",
 			"compress-genesis",
-			"--l2-genesis=" + "./testdata/monorepo/op-node/genesis_baseline.json",
+			"--l2-genesis=" + "./testdata/monorepo/op-node/genesis_zorasep.json",
 			"--superchain-target=" + "sepolia",
-			"--chain-short-name=" + "testchain_b",
+			"--chain-short-name=" + "testchain_zs",
 		}
 		err = runApp(args)
 		require.NoError(t, err, "add-chain compress-genesis failed")

--- a/add-chain/e2e_test.go
+++ b/add-chain/e2e_test.go
@@ -90,6 +90,24 @@ func TestAddChain_Main(t *testing.T) {
 			compareJsonFiles(t, "superchain/extra/genesis-system-configs/sepolia/", tt.name, tt.chainShortName)
 		})
 	}
+
+	t.Run("compress genesis", func(t *testing.T) {
+		// Must run this test to produce the .json.gz output artifact for the
+		// subsequent CheckGenesisConfig test
+		t.Parallel()
+		err := os.Setenv("SCR_RUN_TESTS", "true")
+		require.NoError(t, err, "failed to set SCR_RUN_TESTS env var")
+
+		args := []string{
+			"add-chain",
+			"compress-genesis",
+			"--l2-genesis=" + "./testdata/monorepo/op-node/genesis_baseline.json",
+			"--superchain-target=" + "sepolia",
+			"--chain-short-name=" + "testchain_b",
+		}
+		err = runApp(args)
+		require.NoError(t, err, "add-chain compress-genesis failed")
+	})
 }
 
 func TestAddChain_CheckRollupConfig(t *testing.T) {

--- a/add-chain/flags/flags.go
+++ b/add-chain/flags/flags.go
@@ -97,3 +97,18 @@ var (
 		Required: true,
 	}
 )
+
+var (
+	L2GenesisFlag = &cli.PathFlag{
+		Name:    "l2-genesis",
+		Value:   "genesis.json",
+		Usage:   "Path to genesis json (go-ethereum format)",
+		EnvVars: prefixEnvVars("L2_GENESIS"),
+	}
+	L2GenesisHeaderFlag = &cli.PathFlag{
+		Name:    "l2-genesis-header",
+		Value:   "genesis-header.json",
+		Usage:   "Alternative to l2-genesis flag, if genesis-state is omitted. Path to block header at genesis",
+		EnvVars: prefixEnvVars("L2_GENESIS_HEADER"),
+	}
+)

--- a/add-chain/go.mod
+++ b/add-chain/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/holiman/uint256 v1.2.4 // indirect
 	github.com/klauspost/compress v1.17.2 // indirect
 	github.com/kr/pretty v0.3.1 // indirect

--- a/add-chain/main.go
+++ b/add-chain/main.go
@@ -33,8 +33,12 @@ var app = &cli.App{
 		flags.DeploymentsDirFlag,
 		flags.StandardChainCandidateFlag,
 	},
-	Action:   entrypoint,
-	Commands: []*cli.Command{&cmd.PromoteToStandardCmd, &cmd.CheckRollupConfigCmd},
+	Action: entrypoint,
+	Commands: []*cli.Command{
+		&cmd.PromoteToStandardCmd,
+		&cmd.CheckRollupConfigCmd,
+		&cmd.CompressGenesisCmd,
+	},
 }
 
 func main() {

--- a/scripts/add-chain.sh
+++ b/scripts/add-chain.sh
@@ -10,11 +10,4 @@ source ${SUPERCHAIN_REPO}/.env
 
 go run ./add-chain --chain-type=$1 $2
 go run ./add-chain check-rollup-config
-
-# create extra genesis data
-mkdir -p $SUPERCHAIN_REPO/superchain/extra/genesis/$SUPERCHAIN_TARGET
-cd $MONOREPO_DIR
-go run ./op-chain-ops/cmd/registry-data \
-  --l2-genesis=$GENESIS_CONFIG \
-  --bytecodes-dir=$SUPERCHAIN_REPO/superchain/extra/bytecodes \
-  --output=$SUPERCHAIN_REPO/superchain/extra/genesis/$SUPERCHAIN_TARGET/$CHAIN_SHORT_NAME.json.gz
+go run ./add-chain compress-genesis


### PR DESCRIPTION
Moves the monorepo `op-chain-ops/cmd/registry-data` logic into the `add-chain compress-genesis` subcommand. This helps unify the location of the commands chain operators need to use in order to add a chain to the `superchain-registry`.