### PR TITLE
Centralize all validation exclusions

### DIFF
--- a/validation/chainid-rpc_test.go
+++ b/validation/chainid-rpc_test.go
@@ -10,13 +10,7 @@ import (
 )
 
 func testChainIDFromRPC(t *testing.T, chain *ChainConfig) {
-	isExcluded := map[uint64]bool{
-		11155421: true, // sepolia-dev-0/oplabs-devnet-0   No Public RPC declared
-		11763072: true, // sepolia-dev-0/base-devnet-0     No Public RPC declared
-	}
-	if isExcluded[chain.ChainID] {
-		t.Skip("chain excluded from chain ID RPC check")
-	}
+	skipIfExcluded(t, chain.ChainID)
 	// Create an ethclient connection to the specified RPC URL
 	client, err := ethclient.Dial(chain.PublicRPC)
 	require.NoError(t, err, "Failed to connect to the Ethereum client at RPC url %s", chain.PublicRPC)

--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -64,4 +64,5 @@ var exclusions = map[string]map[uint64]bool{
 	"Uniqueness_Check": {
 		11155421: true, // oplabs devnet 0, not in upstream repo
 		11763072: true, // base devnet 0, not in upstream repo}
-	}}
+	},
+}

--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -56,4 +56,8 @@ var exclusions = map[string]map[uint64]bool{
 		8453:     true, // mainnet/base
 		11155421: true, // sepolia-dev-0/oplabs-devnet-0
 		11763072: true, // sepolia-dev-0/base-devnet-0
+	},
+	"Uniqueness_Check": {
+		11155421: true, // oplabs devnet 0, not in upstream repo
+		11763072: true, // base devnet 0, not in upstream repo}
 	}}

--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -1,0 +1,59 @@
+package validation
+
+import (
+	"regexp"
+	"testing"
+)
+
+func skipIfExcluded(t *testing.T, chainID uint64) {
+	for pattern := range exclusions {
+		matches, err := regexp.Match(pattern, []byte(t.Name()))
+		if err != nil {
+			panic(err)
+		}
+		if matches && exclusions[pattern][chainID] {
+			t.Skip("Excluded!")
+		}
+	}
+}
+
+var exclusions = map[string]map[uint64]bool{
+	"ChainID_RPC_Check": {
+		11155421: true, // sepolia-dev-0/oplabs-devnet-0   No Public RPC declared
+		11763072: true, // sepolia-dev-0/base-devnet-0     No Public RPC declared
+	},
+	"L2OO_Params": {
+		10:        true, // OP mainnet - Upgraded to fault proofs
+		999999999: true, // sepolia/zora  Incorrect finalizationPeriodSeconds, 604800 is not within bounds [12 12]
+		1740:      true, // sepolia/metal Incorrect finalizationPeriodSeconds, 604800 is not within bounds [12 12]
+		919:       true, // sepolia/mode  Incorrect finalizationPeriodSeconds, 180 is not within bounds [12 12]
+		11155420:  true, // sepolia/op No L2OO because this chain uses Fault Proofs https://github.com/ethereum-optimism/superchain-registry/issues/219
+		11155421:  true, // oplabs-sepolia-devnet-0 No L2OO because this chain uses Fault Proofs https://github.com/ethereum-optimism/superchain-registry/issues/219
+	},
+	"L1_Security_Config": {
+		8453:      true, // base (incorrect challenger, incorrect guardian)
+		11763072:  true, // base-devnet-0 (incorrect challenger, incorrect guardian)
+		90001:     true, // race (incorrect challenger, incorrect guardian)
+		84532:     true, // base-sepolia (incorrect challenger)
+		7777777:   true, // zora (incorrect challenger)
+		1750:      true, // metal (incorrect challenger)
+		919:       true, // mode sepolia (incorrect challenger)
+		999999999: true, // zora sepolia (incorrect challenger)
+		34443:     true, // mode (incorrect challenger)
+	},
+	"L2_Security_Config": {
+		11155421: true, // sepolia-dev-0/oplabs-devnet-0   No Public RPC declared
+		11763072: true, // sepolia-dev-0/base-devnet-0     No Public RPC declared
+	},
+	"Genesis_Hash_Check": {
+		10: true, // OP Mainnet
+	},
+	"Genesis_RPC_Check": {
+		11155421: true, // sepolia-dev-0/oplabs-devnet-0   No Public RPC declared
+		11763072: true, // sepolia-dev-0/base-devnet-0     No Public RPC declared
+	},
+	"Standard_Contract_Versions": {
+		8453:     true, // mainnet/base
+		11155421: true, // sepolia-dev-0/oplabs-devnet-0
+		11763072: true, // sepolia-dev-0/base-devnet-0
+	}}

--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -22,6 +22,10 @@ var exclusions = map[string]map[uint64]bool{
 		11155421: true, // sepolia-dev-0/oplabs-devnet-0   No Public RPC declared
 		11763072: true, // sepolia-dev-0/base-devnet-0     No Public RPC declared
 	},
+	"GPO_Params": {
+		11155421: true, // sepolia-dev-0/oplabs-devnet-0   (no public endpoint)
+		11763072: true, // sepolia-dev-0/base-devnet-0     (no public endpoint)
+	},
 	"L2OO_Params": {
 		10:        true, // OP mainnet - Upgraded to fault proofs
 		999999999: true, // sepolia/zora  Incorrect finalizationPeriodSeconds, 604800 is not within bounds [12 12]

--- a/validation/gpo-params_test.go
+++ b/validation/gpo-params_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func testGasPriceOracleParams(t *testing.T, chain *ChainConfig) {
+	skipIfExcluded(t, chain.ChainID)
+
 	gasPriceOraclAddr := predeploys.GasPriceOracleAddr
 
 	checkPreEcotoneResourceConfig := func(t *testing.T, chain *ChainConfig, client *ethclient.Client) {
@@ -57,13 +59,6 @@ func testGasPriceOracleParams(t *testing.T, chain *ChainConfig) {
 		}
 	}
 
-	isExcluded := map[uint64]bool{
-		11155421: true, // sepolia-dev-0/oplabs-devnet-0   (no public endpoint)
-		11763072: true, // sepolia-dev-0/base-devnet-0     (no public endpoint)
-	}
-	if isExcluded[chain.ChainID] {
-		t.Skip()
-	}
 	rpcEndpoint := chain.PublicRPC
 	require.NotEmpty(t, rpcEndpoint, "no public endpoint for chain")
 	client, err := ethclient.Dial(rpcEndpoint)

--- a/validation/l2oo_test.go
+++ b/validation/l2oo_test.go
@@ -24,17 +24,7 @@ type L2OOParams struct {
 }
 
 func testL2OOParams(t *testing.T, chain *ChainConfig) {
-	isExcluded := map[uint64]bool{
-		10:        true, // OP mainnet - Upgraded to fault proofs
-		999999999: true, // sepolia/zora  Incorrect finalizationPeriodSeconds, 604800 is not within bounds [12 12]
-		1740:      true, // sepolia/metal Incorrect finalizationPeriodSeconds, 604800 is not within bounds [12 12]
-		919:       true, // sepolia/mode  Incorrect finalizationPeriodSeconds, 180 is not within bounds [12 12]
-		11155420:  true, // sepolia/op No L2OO because this chain uses Fault Proofs https://github.com/ethereum-optimism/superchain-registry/issues/219
-		11155421:  true, // oplabs-sepolia-devnet-0 No L2OO because this chain uses Fault Proofs https://github.com/ethereum-optimism/superchain-registry/issues/219
-	}
-	if isExcluded[chain.ChainID] {
-		t.Skip()
-	}
+	skipIfExcluded(t, chain.ChainID)
 
 	rpcEndpoint := Superchains[chain.Superchain].Config.L1.PublicRPC
 

--- a/validation/security-configs_test.go
+++ b/validation/security-configs_test.go
@@ -52,6 +52,8 @@ var checkResolutions = func(t *testing.T, r standard.Resolutions, chainID uint64
 }
 
 func testL1SecurityConfig(t *testing.T, chainID uint64) {
+	skipIfExcluded(t, chainID)
+
 	rpcEndpoint := Superchains[OPChains[chainID].Superchain].Config.L1.PublicRPC
 	require.NotEmpty(t, rpcEndpoint, "no rpc specified")
 
@@ -72,20 +74,7 @@ func testL1SecurityConfig(t *testing.T, chainID uint64) {
 
 	checkResolutions(t, standard.Config.Roles.L1.GetResolutions(isFaultProofs), chainID, client)
 
-	isExcluded := map[uint64]bool{
-		8453:      true, // base (incorrect challenger, incorrect guardian)
-		11763072:  true, // base-devnet-0 (incorrect challenger, incorrect guardian)
-		90001:     true, // race (incorrect challenger, incorrect guardian)
-		84532:     true, // base-sepolia (incorrect challenger)
-		7777777:   true, // zora (incorrect challenger)
-		1750:      true, // metal (incorrect challenger)
-		919:       true, // mode sepolia (incorrect challenger)
-		999999999: true, // zora sepolia (incorrect challenger)
-		34443:     true, // mode (incorrect challenger)
-	}
-	if !isExcluded[chainID] {
-		checkResolutions(t, standard.Config.MultisigRoles[OPChains[chainID].Superchain].L1.GetResolutions(isFaultProofs), chainID, client)
-	}
+	checkResolutions(t, standard.Config.MultisigRoles[OPChains[chainID].Superchain].L1.GetResolutions(isFaultProofs), chainID, client)
 
 	// Perform an extra check on a mapping value of "L1CrossDomainMessengerProxy":
 	// This is because L1CrossDomainMessenger's proxy is a ResolvedDelegateProxy, and

--- a/validation/security-configs_test.go
+++ b/validation/security-configs_test.go
@@ -106,15 +106,7 @@ func testL1SecurityConfig(t *testing.T, chainID uint64) {
 }
 
 func testL2SecurityConfig(t *testing.T, chain *ChainConfig) {
-	isExcluded := map[uint64]bool{
-		11155421: true, // sepolia-dev-0/oplabs-devnet-0   No Public RPC declared
-		11763072: true, // sepolia-dev-0/base-devnet-0     No Public RPC declared
-	}
-
-	if isExcluded[chain.ChainID] {
-		t.Skip("chain excluded from check")
-	}
-
+	skipIfExcluded(t, chain.ChainID)
 	// Create an ethclient connection to the specified RPC URL
 	client, err := ethclient.Dial(chain.PublicRPC)
 	require.NoError(t, err, "Failed to connect to the Ethereum client at RPC url %s", chain.PublicRPC)

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -56,14 +56,7 @@ func TestSuperchainWideContractVersions(t *testing.T) {
 }
 
 func testContractsMatchATag(t *testing.T, chain *ChainConfig) {
-	isExcluded := map[uint64]bool{
-		8453:     true, // mainnet/base
-		11155421: true, // sepolia-dev-0/oplabs-devnet-0
-		11763072: true, // sepolia-dev-0/base-devnet-0
-	}
-	if isExcluded[chain.ChainID] {
-		t.Skipf("chain %d: EXCLUDED from contract version validation", chain.ChainID)
-	}
+	skipIfExcluded(t, chain.ChainID)
 
 	rpcEndpoint := Superchains[chain.Superchain].Config.L1.PublicRPC
 	require.NotEmpty(t, rpcEndpoint)

--- a/validation/uniqueness_test.go
+++ b/validation/uniqueness_test.go
@@ -118,13 +118,8 @@ func init() {
 }
 
 func testIsGloballyUnique(t *testing.T, chain *ChainConfig) {
-	isExcluded := map[uint64]bool{
-		11155421: true, // oplabs devnet 0, not in upstream repo
-		11763072: true, // base devnet 0, not in upstream repo
-	}
-	if isExcluded[chain.ChainID] {
-		t.Skip("excluded from global chain id check")
-	}
+	skipIfExcluded(t, chain.ChainID)
+
 	props := globalChainIds[uint(chain.ChainID)]
 	require.NotNil(t, props, "chain ID is not listed at chainid.network")
 	globalChainName := props.Name

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -45,10 +45,10 @@ func testValidation(t *testing.T, chain *ChainConfig) {
 // designed to protect downstream software or
 // sanity checking basic consistency conditions.
 func testUniversal(t *testing.T, chain *ChainConfig) {
-	t.Run("Genesis Hash Check (op-geth)", func(t *testing.T) {
+	t.Run("Genesis Hash Check", func(t *testing.T) {
 		testGenesisHash(t, chain.ChainID)
 	})
-	t.Run("Genesis Check (RPC)", func(t *testing.T) {
+	t.Run("Genesis RPC Check", func(t *testing.T) {
 		testGenesisHashAgainstRPC(t, chain)
 	})
 	t.Run("Uniqueness Check", func(t *testing.T) {
@@ -63,15 +63,15 @@ func testUniversal(t *testing.T, chain *ChainConfig) {
 // i.e. not to a Standard Candidate Chain.
 func testStandardCandidate(t *testing.T, chain *ChainConfig) {
 	t.Run("Standard Config Params", func(t *testing.T) {
-		testDataAvailability(t, chain)
-		testResourceConfig(t, chain)
-		testL2OOParams(t, chain)
-		testGasLimit(t, chain)
-		testGasPriceOracleParams(t, chain)
+		t.Run("Data Availabilty", func(t *testing.T) { testDataAvailability(t, chain) })
+		t.Run("Resource Config", func(t *testing.T) { testResourceConfig(t, chain) })
+		t.Run("L2OO Params", func(t *testing.T) { testL2OOParams(t, chain) })
+		t.Run("Gas Limit", func(t *testing.T) { testGasLimit(t, chain) })
+		t.Run("GPO Params", func(t *testing.T) { testGasPriceOracleParams(t, chain) })
 	})
 	t.Run("Standard Config Roles", func(t *testing.T) {
-		testL1SecurityConfig(t, chain.ChainID)
-		testL2SecurityConfig(t, chain)
+		t.Run("L1 Security Config", func(t *testing.T) { testL1SecurityConfig(t, chain.ChainID) })
+		t.Run("L2 Security Config", func(t *testing.T) { testL2SecurityConfig(t, chain) })
 	})
 	t.Run("Standard Contract Versions", func(t *testing.T) {
 		testContractsMatchATag(t, chain)

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -63,7 +63,7 @@ func testUniversal(t *testing.T, chain *ChainConfig) {
 // i.e. not to a Standard Candidate Chain.
 func testStandardCandidate(t *testing.T, chain *ChainConfig) {
 	t.Run("Standard Config Params", func(t *testing.T) {
-		t.Run("Data Availabilty", func(t *testing.T) { testDataAvailability(t, chain) })
+		t.Run("Data Availability", func(t *testing.T) { testDataAvailability(t, chain) })
 		t.Run("Resource Config", func(t *testing.T) { testResourceConfig(t, chain) })
 		t.Run("L2OO Params", func(t *testing.T) { testL2OOParams(t, chain) })
 		t.Run("Gas Limit", func(t *testing.T) { testGasLimit(t, chain) })


### PR DESCRIPTION
Should make them easier to audit. 

TODO: 
- [x] centralize remaining exclusions, may need to break some tests up