### PR TITLE
validation: add superchain config check

### DIFF
--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -26,6 +26,9 @@ var exclusions = map[string]map[uint64]bool{
 		11155421: true, // sepolia-dev-0/oplabs-devnet-0   (no public endpoint)
 		11763072: true, // sepolia-dev-0/base-devnet-0     (no public endpoint)
 	},
+	"Superchain_Config": {
+		11763072: true, // sepolia-dev-0/base-devnet-0 (old version of OptimismPortal)
+	},
 	"L2OO_Params": {
 		11155421: true, // sepolia-dev-0/oplabs-devnet-0 (does not yet declare a contract versions tag)
 		11763072: true, // sepolia-dev-0/base-devnet-0  (does not yet declare a contract versions tag)

--- a/validation/retry.go
+++ b/validation/retry.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Retry[S, T any](fn func(S) (T, error)) func(S) (T, error) {
-	const maxAttempts = 10
+	const maxAttempts = 3
 	return func(s S) (T, error) {
 		return retry.Do(context.Background(), maxAttempts, retry.Exponential(), func() (T, error) {
 			return fn(s)

--- a/validation/superchain-config_test.go
+++ b/validation/superchain-config_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func testSuperchainConfig(t *testing.T, chain *ChainConfig) {
+	skipIfExcluded(t, chain.ChainID)
 	expected := Superchains[chain.Superchain].Config.SuperchainConfigAddr
 	require.NotNil(t, expected, "Superchain does not declare a superchain_config_addr")
 

--- a/validation/superchain-config_test.go
+++ b/validation/superchain-config_test.go
@@ -1,0 +1,26 @@
+package validation
+
+import (
+	"testing"
+
+	. "github.com/ethereum-optimism/superchain-registry/superchain"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/require"
+)
+
+func testSuperchainConfig(t *testing.T, chain *ChainConfig) {
+	expected := Superchains[chain.Superchain].Config.SuperchainConfigAddr
+	require.NotNil(t, expected, "Superchain does not declare a superchain_config_addr")
+
+	rpcEndpoint := Superchains[chain.Superchain].Config.L1.PublicRPC
+	require.NotEmpty(t, rpcEndpoint, "no rpc specified")
+
+	client, err := ethclient.Dial(rpcEndpoint)
+	require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
+	opp := Addresses[chain.ChainID].OptimismPortalProxy
+
+	got, err := getAddress("superchainConfig()", opp, client)
+	require.NoError(t, err)
+
+	require.Equal(t, *expected, got)
+}

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -68,6 +68,7 @@ func testStandardCandidate(t *testing.T, chain *ChainConfig) {
 		t.Run("L2OO Params", func(t *testing.T) { testL2OOParams(t, chain) })
 		t.Run("Gas Limit", func(t *testing.T) { testGasLimit(t, chain) })
 		t.Run("GPO Params", func(t *testing.T) { testGasPriceOracleParams(t, chain) })
+		t.Run("Superchain Config", func(t *testing.T) { testSuperchainConfig(t, chain) })
 	})
 	t.Run("Standard Config Roles", func(t *testing.T) {
 		t.Run("L1 Security Config", func(t *testing.T) { testL1SecurityConfig(t, chain.ChainID) })


### PR DESCRIPTION
This serves as a check that the chain is actually (via an on chain call) in the superchain that it claims to be (via its config directory name).