### PR TITLE
Run contract version validation first (standard candidate chains)

### DIFF
--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -52,29 +52,25 @@ var exclusions = map[string]map[uint64]bool{
 	},
 	"Standard_Contract_Versions": {
 		8453:      true, // mainnet/base         MCP (at time of writing)
-		957:       true, // mainnet/lyra         MCP (at time of writing)
 		1750:      true, // mainnet/metal        MCP (at time of writing)
 		34443:     true, // mainnet/mode         MCP (at time of writing)
-		291:       true, // mainnet/orderly      MCP (at time of writing)
 		7777777:   true, // mainnet/zora         MCP (at time of writing)
 		84532:     true, // sepolia/base         MCP (at time of writing)
+		1740:      true, // sepolia/metal        MCP (at time of writing)
 		919:       true, // sepolia/mode         MCP (at time of writing)
 		999999999: true, // sepolia/zora         MCP (at time of writing)
-		1740:      true, // sepolia/metal        MCP (at time of writing)
 		11155421:  true, // sepolia-dev0/oplabs-devnet-0
 		11763072:  true, // sepolia-dev0/base-devnet-0
 	},
 	"Optimism_Portal_2_Params": {
 		8453:      true, // mainnet/base         MCP (at time of writing)
-		957:       true, // mainnet/lyra         MCP (at time of writing)
 		1750:      true, // mainnet/metal        MCP (at time of writing)
 		34443:     true, // mainnet/mode         MCP (at time of writing)
-		291:       true, // mainnet/orderly      MCP (at time of writing)
 		7777777:   true, // mainnet/zora         MCP (at time of writing)
 		84532:     true, // sepolia/base         MCP (at time of writing)
+		1740:      true, // sepolia/metal        MCP (at time of writing)
 		919:       true, // sepolia/mode         MCP (at time of writing)
 		999999999: true, // sepolia/zora         MCP (at time of writing)
-		1740:      true, // sepolia/metal        MCP (at time of writing)
 		11763072:  true, // sepolia-dev0/base-devnet-0
 	},
 }

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -45,6 +45,10 @@ func testUniversal(t *testing.T, chain *ChainConfig) {
 
 // testStandardCandidate applies to Standard and Standard Candidate Chains.
 func testStandardCandidate(t *testing.T, chain *ChainConfig) {
+	// Standard Contract Versions
+	t.Run("Standard Contract Versions", func(t *testing.T) {
+		testContractsMatchATag(t, chain)
+	})
 	// Standard Config Params
 	t.Run("Rollup Config", func(t *testing.T) { testRollupConfig(t, chain) })
 	t.Run("Gas Token", (func(t *testing.T) { testGasToken(t, chain) }))
@@ -57,8 +61,7 @@ func testStandardCandidate(t *testing.T, chain *ChainConfig) {
 	// Standard Config Roles
 	t.Run("L1 Security Config", func(t *testing.T) { testL1SecurityConfig(t, chain.ChainID) })
 	t.Run("L2 Security Config", func(t *testing.T) { testL2SecurityConfig(t, chain) })
-	// Standard Contract Versions
-	t.Run("Standard Contract Versions", func(t *testing.T) { testContractsMatchATag(t, chain) })
+	// Other
 	t.Run("Data Availability Type", func(t *testing.T) { testDataAvailabilityType(t, chain) })
 }
 


### PR DESCRIPTION
Closes #404 

Previously, if on the wrong contract versions, the error message printed was very opaque. With this change, the first failure will look like this:

```
=== RUN   TestValidation/Base_(8453)/Standard_Contract_Versions
    superchain-version_test.go:34: 
                Error Trace:    /Users/georgeknee/code/ethereum-optimism/superchain-registry/validation/superchain-version_test.go:34
                                                        /Users/georgeknee/code/ethereum-optimism/superchain-registry/validation/validation_test.go:58
                Error:          Received unexpected error:
                                contract versions {
                                 "L1CrossDomainMessenger": "2.3.0",
                                 "L1ERC721Bridge": "2.1.0",
                                 "L1StandardBridge": "2.1.0",
                                 "L2OutputOracle": "",
                                 "OptimismMintableERC20Factory": "1.9.0",
                                 "OptimismPortal": "2.5.0",
                                 "SystemConfig": "1.12.0",
                                 "ProtocolVersions": "",
                                 "SuperchainConfig": "",
                                 "AnchorStateRegistry": "",
                                 "DelayedWETH": "",
                                 "DisputeGameFactory": "",
                                 "FaultDisputeGame": "",
                                 "MIPS": "",
                                 "PermissionedDisputeGame": "",
                                 "PreimageOracle": ""
                                } do not match any standard op-contracts tag {
                                 "op-contracts/v1.4.0": {
                                  "L1CrossDomainMessenger": "2.3.0",
                                  "L1ERC721Bridge": "2.1.0",
                                  "L1StandardBridge": "2.1.0",
                                  "L2OutputOracle": "",
                                  "OptimismMintableERC20Factory": "1.9.0",
                                  "OptimismPortal": "3.10.0",
                                  "SystemConfig": "2.2.0",
                                  "ProtocolVersions": "1.0.0",
                                  "SuperchainConfig": "",
                                  "AnchorStateRegistry": "1.0.0",
                                  "DelayedWETH": "1.0.0",
                                  "DisputeGameFactory": "1.0.0",
                                  "FaultDisputeGame": "1.2.0",
                                  "MIPS": "",
                                  "PermissionedDisputeGame": "1.2.0",
                                  "PreimageOracle": ""
                                 }
                                }
                Test:           TestValidation/Base_(8453)/Standard_Contract_Versions
```