### PR TITLE
editorconfig: standardize spacing in files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,14 @@
+root = true
+
+# defaults
 [*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.go]
+indent_size = 2
+indent_style = tab


### PR DESCRIPTION
By specifying standard white space settings we should avoid unnecessarily large diffs where devs with different settings overwrite spacing without changing code