### PR TITLE
chore: Release SCR Bindings

### DIFF
--- a/bindings/rust-bindings/Cargo.lock
+++ b/bindings/rust-bindings/Cargo.lock
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "superchain-registry"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-primitives",
  "hashbrown",

--- a/bindings/rust-bindings/Cargo.toml
+++ b/bindings/rust-bindings/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "superchain-registry"
 description = "Bindings for the Superchain Registry"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT"
 authors = ["OP Contributors"]

--- a/bindings/rust-bindings/README.md
+++ b/bindings/rust-bindings/README.md
@@ -4,7 +4,7 @@ This package provides Rust bindings for the Superchain Registry configuration.
 
 ## Usage
 
-Add this to your `Cargo.toml`:
+Add the following to your `Cargo.toml`.
 
 ```toml
 [dependencies]

--- a/bindings/rust-bindings/justfile
+++ b/bindings/rust-bindings/justfile
@@ -12,13 +12,13 @@ default:
 ci: fmt lint tests
 
 # Run all tests
-tests: test test-docs
+tests: test test-features test-docs
 
 # Formats
 fmt: fmt-fix fmt-check
 
 # Lint the workspace for all available targets
-lint: lint-source lint-docs
+lint: lint-source lint-source-features lint-docs
 
 # Build for the native target
 build *args='':
@@ -34,14 +34,22 @@ fmt-check:
 
 # Lint the workspace
 lint-source: fmt-check
+  cargo +nightly clippy --all --all-targets -- -D warnings
+
+# Lint the workspace
+lint-source-features: fmt-check
   cargo +nightly clippy --all --all-features --all-targets -- -D warnings
 
 # Lint the Rust documentation
 lint-docs:
   RUSTDOCFLAGS="-D warnings" cargo doc --all --no-deps --document-private-items
 
-# Test for the native target with all features
+# Test without features
 test *args='':
+  cargo nextest run --all $@
+
+# Test for the native target with all features
+test-features *args='':
   cargo nextest run --all --all-features $@
 
 # Test the Rust documentation

--- a/bindings/rust-bindings/src/superchain.rs
+++ b/bindings/rust-bindings/src/superchain.rs
@@ -1,6 +1,7 @@
 //! Contains the full superchain data.
 
 use super::{Chain, ChainConfig, ChainList, HashMap, RollupConfig, Superchain};
+use alloc::vec::Vec;
 
 /// A list of Hydrated Superchain Configs.
 #[derive(Debug, Clone, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/bindings/rust-primitives/README.md
+++ b/bindings/rust-primitives/README.md
@@ -8,20 +8,16 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-superchain-primitives = "0.1.0"
+superchain-primitives = "0.2"
 ```
 
 ## Example
 
 ```rust
-use alloy_primitives::b256;
-use superchain_primitives::BlockID;
+use superchain_primitives::rollup_config_from_chain_id;
 
-let block_id = BlockID {
-    hash: b256!("0000000000000000000000000000000000000000000000000000000000000000"),
-    number: 0u64,
-};
-println!("Block ID: {block_id}");
+let op_mainnet_rollup_config = rollup_config_from_chain_id(10).unwrap();
+println!("OP Mainnet Rollup Config:\n{op_mainnet_rollup_config:?}");
 ```
 
 ## Feature Flags

--- a/bindings/rust-primitives/justfile
+++ b/bindings/rust-primitives/justfile
@@ -12,13 +12,13 @@ default:
 ci: fmt lint tests
 
 # Run all tests
-tests: test test-docs
+tests: test test-features test-docs
 
 # Formats
 fmt: fmt-fix fmt-check
 
 # Lint the workspace for all available targets
-lint: lint-source lint-docs
+lint: lint-source lint-source-features lint-docs
 
 # Build for the native target
 build *args='':
@@ -34,14 +34,22 @@ fmt-check:
 
 # Lint the workspace
 lint-source: fmt-check
+  cargo +nightly clippy --all --all-targets -- -D warnings
+
+# Lint the workspace
+lint-source-features: fmt-check
   cargo +nightly clippy --all --all-features --all-targets -- -D warnings
 
 # Lint the Rust documentation
 lint-docs:
   RUSTDOCFLAGS="-D warnings" cargo doc --all --no-deps --document-private-items
 
-# Test for the native target with all features
+# Test without features
 test *args='':
+  cargo nextest run --all $@
+
+# Test for the native target with all features
+test-features *args='':
   cargo nextest run --all --all-features $@
 
 # Test the Rust documentation


### PR DESCRIPTION
**Description**

Publishes `v0.2.2` version of the `superchain-registry` crate (in `bindings/rust-bindings`).