### PR TITLE
Add upload chain artifacts workflow

### DIFF
--- a/.github/workflows/upload-chain-artifacts.yml
+++ b/.github/workflows/upload-chain-artifacts.yml
@@ -7,6 +7,10 @@ on:
         description: 'The name of the target chain (e.g. op-mainnet)'
         required: true
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   upload-chain-artifacts:
     runs-on: ubuntu-latest
@@ -17,7 +21,8 @@ jobs:
       - name: Google cloud auth
         uses: 'google-github-actions/auth@v2'
         with:
-          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+          workload_identity_provider: ${{ secrets.GCP_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up GCP SDK
         uses: 'google-github-actions/setup-gcloud@v2'

--- a/.github/workflows/upload-chain-artifacts.yml
+++ b/.github/workflows/upload-chain-artifacts.yml
@@ -1,0 +1,45 @@
+name: Upload Chain Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      chain:
+        description: 'The name of the target chain (e.g. op-mainnet)'
+        required: true
+
+jobs:
+  upload-chain-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Google cloud auth
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
+      - name: Set up GCP SDK
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: Get current commit hash
+        run: echo "COMMIT_HASH=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+      - name: Generate genesis file
+        working-directory: validation
+        run: |
+          go run generate-genesis/main.go ${{ env.COMMIT_HASH }}
+
+      - name: Generate rollup config
+        working-directory: validation
+        run: |
+          go run generate-rollup-config/main.go ${{ env.COMMIT_HASH }}
+
+      - name: Upload artifacts
+        working-directory: validation
+        run: |
+          gsutil cp ./generate-genesis/output-${{ env.COMMIT_HASH }}/${{ github.event.inputs.chain }}.json \
+            gs://${{ secrets.GCS_BUCKET }}/chains/${{ github.event.inputs.chain }}/${{ env.COMMIT_HASH }}/genesis.json
+          gsutil cp ./generate-rollup-config/output-${{ env.COMMIT_HASH }}/${{ github.event.inputs.chain }}.json \
+            gs://${{ secrets.GCS_BUCKET }}/chains/${{ github.event.inputs.chain }}/${{ env.COMMIT_HASH }}/rollup.json
+

--- a/validation/generate-genesis/main.go
+++ b/validation/generate-genesis/main.go
@@ -34,7 +34,7 @@ func main() {
 			}
 		}
 
-		err = os.WriteFile(path.Join(dirPath, chain.Superchain+"-"+chain.Name+".json"), j, os.FileMode(0o644))
+		err = os.WriteFile(path.Join(dirPath, chain.Chain+"-"+chain.Superchain+".json"), j, os.FileMode(0o644))
 		if err != nil {
 			panic(err)
 		}

--- a/validation/generate-rollup-config/main.go
+++ b/validation/generate-rollup-config/main.go
@@ -33,7 +33,7 @@ func main() {
 			}
 		}
 
-		err = os.WriteFile(path.Join(dirPath, chain.Superchain+"-"+chain.Name+".json"), j, os.FileMode(0o644))
+		err = os.WriteFile(path.Join(dirPath, chain.Chain+"-"+chain.Superchain+".json"), j, os.FileMode(0o644))
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add a new Github Actions workflow: `Upload Chain Artifacts`.
This is for new chains that are in the superchain registry but not merged into the op-node & op-geth yet.
I added the commit hash into the uploaded file paths to let us know when the artifacts have been created, because they have network upgrade timestamps and they could be changed.

For consistency, I changed the name of the output files of generating artifact scripts into the same name as op-node & op-geth are using (e.g. `op-mainnet`, `base-sepolia`, etc) I believe that this does not affect anything including validation workflows, but please double check this.

To run this workflow, the Github repository secrets must be set: 
- ~~`GCP_CREDENTIALS`: The credentials of the service account that has permission to upload artifacts to the cloud storage.~~
- `GCP_IDENTITY_PROVIDER`: GCP Identity provider ID
- `GCP_SERVICE_ACCOUNT`: GCP Service account email address
- `GCS_BUCKET`: The target google cloud storage bucket name.

I tested this workflow in our forked repository and cloud storage bucket: ~~https://github.com/testinprod-io/superchain-registry/actions/runs/10223078078/job/28288830511~~ https://github.com/testinprod-io/superchain-registry/actions/runs/10292445282
