### PR TITLE
Upload chain artifacts without commit hash subdirectory

### DIFF
--- a/.github/workflows/upload-chain-artifacts.yml
+++ b/.github/workflows/upload-chain-artifacts.yml
@@ -44,6 +44,12 @@ jobs:
         working-directory: validation
         run: |
           gsutil cp ./generate-genesis/output-${{ env.COMMIT_HASH }}/${{ github.event.inputs.chain }}.json \
+            gs://${{ secrets.GCS_BUCKET }}/chains/${{ github.event.inputs.chain }}/genesis.json
+          gsutil cp ./generate-rollup-config/output-${{ env.COMMIT_HASH }}/${{ github.event.inputs.chain }}.json \
+            gs://${{ secrets.GCS_BUCKET }}/chains/${{ github.event.inputs.chain }}/rollup.json
+
+          # Upload with commit hash for history record
+          gsutil cp ./generate-genesis/output-${{ env.COMMIT_HASH }}/${{ github.event.inputs.chain }}.json \
             gs://${{ secrets.GCS_BUCKET }}/chains/${{ github.event.inputs.chain }}/${{ env.COMMIT_HASH }}/genesis.json
           gsutil cp ./generate-rollup-config/output-${{ env.COMMIT_HASH }}/${{ github.event.inputs.chain }}.json \
             gs://${{ secrets.GCS_BUCKET }}/chains/${{ github.event.inputs.chain }}/${{ env.COMMIT_HASH }}/rollup.json


### PR DESCRIPTION
**Description**

Follow-up PR for https://github.com/ethereum-optimism/superchain-registry/pull/435
Upload artifacts without commit hash subdirectory. Keep the existing subdirectory for the record.

