### PR TITLE
CI: remove step to install gotestsum

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,9 +75,6 @@ jobs:
       - checkout
       - install-just
       - run:
-          name: Install gotestsum
-          command: go install gotest.tools/gotestsum@latest
-      - run:
           # need foundry to execute 'cast call' within add-chain script
           name: Install foundry
           command: |


### PR DESCRIPTION
This is not really necessary as Go will download it on-the-fly when it needs to (and then cache it). It also makes it seem like we need to add a dependency for users to install, when in fact we do not. 