### PR TITLE
fix(bindings): Rust Crate Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@stable
       - name: Release Crates
         run: |


### PR DESCRIPTION
**Description**

The rust crate release workflow was previously bricked because `just` wasn't installed. This pr fixes the workflow by adding a just install step.