### PR TITLE
fix(bindings): No Release Confirmation Prompt

### DIFF
--- a/bindings/rust-bindings/justfile
+++ b/bindings/rust-bindings/justfile
@@ -58,4 +58,4 @@ test-docs:
 
 # Release the crate
 release:
-  cargo release publish --execute
+  cargo release publish --execute --no-confirm

--- a/bindings/rust-primitives/justfile
+++ b/bindings/rust-primitives/justfile
@@ -58,4 +58,4 @@ test-docs:
 
 # Release the crate
 release:
-  cargo release publish --execute
+  cargo release publish --execute --no-confirm


### PR DESCRIPTION
**Description**

Removes the confirmation prompt when releasing rust crates using the `--no-confirm` cli flag.