### PR TITLE
CI: New job to run periodic chain validation and minor refactoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ commands:
     parameters:
       channel:
         type: string
-        default: C03N11M0BBN
+        default: C03N11M0BBN # to slack channel `notify-ci-failures`
     steps:
       - slack/notify:
           channel: << parameters.channel >>
@@ -24,7 +24,7 @@ commands:
     parameters:
       channel:
         type: string
-        default: C03N11M0BBN # TODO - modify this to a new slack channel
+        default: C07GQQZDW1G # to slack channel `notify-superchain-validation-failures`
     steps:
       - slack/notify:
           channel: << parameters.channel >>
@@ -124,9 +124,6 @@ jobs:
     steps:
       - checkout
       - install-just
-      - run:
-          name: Install gotestsum
-          command: go install gotest.tools/gotestsum@latest
       - install-foundry
       - run:
           name: run validation checks
@@ -140,9 +137,6 @@ jobs:
     steps:
       - checkout
       - install-just
-      - run:
-          name: Install gotestsum
-          command: go install gotest.tools/gotestsum@latest
       - install-foundry
       - run:
           name: run validation checks on all chains
@@ -213,6 +207,9 @@ workflows:
   hourly:
     jobs:
       - golang-validate-all:
+          context:
+            - slack
+      - golang-test:
           context:
             - slack
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
     steps:
       - slack/notify:
           channel: << parameters.channel >>
-          event: fail
+          event: pass
           template: basic_fail_1
           branch_pattern: main
   install-just:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,23 @@ orbs:
 
 commands:
   notify-failures-on-main:
-    description: "Notify Slack"
+    description: "Notify Slack for CI job failures"
     parameters:
       channel:
         type: string
         default: C03N11M0BBN
+    steps:
+      - slack/notify:
+          channel: << parameters.channel >>
+          event: fail
+          template: basic_fail_1
+          branch_pattern: main
+  notify-failures-on-validate-all:
+    description: "Notify Slack on any chain validation failures"
+    parameters:
+      channel:
+        type: string
+        default: C03N11M0BBN # TODO - modify this to a new slack channel
     steps:
       - slack/notify:
           channel: << parameters.channel >>
@@ -42,6 +54,25 @@ commands:
           name: "Install toolchain"
           command: |
             rustup install nightly-x86_64-unknown-linux-gnu
+  install-foundry:
+    description: "Installs foundry"
+    steps:
+      - run:
+          # need foundry to execute 'cast call' within add-chain script
+          name: Install foundry
+          command: |
+            echo "SHELL=$SHELL"
+            # Set up directory structure
+            mkdir -p $HOME/.foundry/bin
+            echo 'export PATH="$HOME/.foundry/bin:$PATH"' >> $BASH_ENV
+            source $BASH_ENV
+
+            # Download foundryup and make it executable
+            curl -sSL "https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/foundryup" -o $HOME/.foundry/bin/foundryup
+            chmod +x $HOME/.foundry/bin/foundryup
+
+            $HOME/.foundry/bin/foundryup
+            forge --version
 
 jobs:
   golang-lint:
@@ -74,22 +105,7 @@ jobs:
     steps:
       - checkout
       - install-just
-      - run:
-          # need foundry to execute 'cast call' within add-chain script
-          name: Install foundry
-          command: |
-            echo "SHELL=$SHELL"
-            # Set up directory structure
-            mkdir -p $HOME/.foundry/bin
-            echo 'export PATH="$HOME/.foundry/bin:$PATH"' >> $BASH_ENV
-            source $BASH_ENV
-
-            # Download foundryup and make it executable
-            curl -sSL "https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/foundryup" -o $HOME/.foundry/bin/foundryup
-            chmod +x $HOME/.foundry/bin/foundryup
-
-            $HOME/.foundry/bin/foundryup
-            forge --version
+      - install-foundry
       - run:
           name: run superchain module unit tests
           command: just test-superchain
@@ -99,10 +115,39 @@ jobs:
       - run:
           name: run add-chain module unit tests
           command: just test-add-chain
+      - notify-failures-on-main
+  golang-validate-modified:
+    shell: /bin/bash -eo pipefail
+    executor:
+      name: go/default  # is based on cimg/go
+      tag: '1.21'
+    steps:
+      - checkout
+      - install-just
+      - run:
+          name: Install gotestsum
+          command: go install gotest.tools/gotestsum@latest
+      - install-foundry
       - run:
           name: run validation checks
           command: just validate-modified-chains main # TODO ideally this is the base branch
       - notify-failures-on-main
+  golang-validate-all:
+    shell: /bin/bash -eo pipefail
+    executor:
+      name: go/default  # is based on cimg/go
+      tag: '1.21'
+    steps:
+      - checkout
+      - install-just
+      - run:
+          name: Install gotestsum
+          command: go install gotest.tools/gotestsum@latest
+      - install-foundry
+      - run:
+          name: run validation checks on all chains
+          command: just validate ""
+      - notify-failures-on-validate-all
   publish-bot:
     environment:
       NODE_AUTH_TOKEN: $NPM_TOKEN  # Use NPM_TOKEN as the auth token
@@ -167,7 +212,7 @@ jobs:
 workflows:
   hourly:
     jobs:
-      - golang-test:
+      - golang-validate-all:
           context:
             - slack
     triggers:
@@ -182,6 +227,7 @@ workflows:
       - golang-lint
       - golang-modules-tidy
       - golang-test
+      - golang-validate-modified
       - check-codegen
       - cargo-tests
       - cargo-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,6 @@ jobs:
       - run:
           name: run validation checks
           command: just validate-modified-chains main # TODO ideally this is the base branch
-      - notify-failures-on-main
   golang-validate-all:
     shell: /bin/bash -eo pipefail
     executor:


### PR DESCRIPTION
**Description**

* Add a new job and slack notification target to run validation of all chains on a periodic basis.
* Move the step to validate modified chains into it's own job and add that job to the `pr-checks` list.
* Alter existing cron job to run this new job instead of golang-test, which runs all unit tests.

**Tests**

No new tests are being added/removed in this change.

**Additional context**

This is a follow up to the changes introduced in https://github.com/ethereum-optimism/superchain-registry/pull/453.

**Metadata**

[Reference issue](https://github.com/ethereum-optimism/superchain-registry/issues/428)
