### PR TITLE
CI: Restore the slack notification trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
     steps:
       - slack/notify:
           channel: << parameters.channel >>
-          event: pass
+          event: fail
           template: basic_fail_1
           branch_pattern: main
   install-just:


### PR DESCRIPTION
remove the erroneous tag which was used for testing

reference: tag introduced in https://github.com/ethereum-optimism/superchain-registry/pull/464 needs to be pulled, as it's purpose was just to test whether slack notification goes out to the newly created channel.