### PR TITLE
superchain: add max_sequencer_drift field to chain configs

### DIFF
--- a/add-chain/config/config.go
+++ b/add-chain/config/config.go
@@ -31,38 +31,23 @@ func ConstructChainConfig(
 	if err != nil {
 		return superchain.ChainConfig{}, fmt.Errorf("error reading file: %w", err)
 	}
-	var jsonConfig superchain.ChainConfig
-	if err = json.Unmarshal(file, &jsonConfig); err != nil {
+	var chainConfig superchain.ChainConfig
+	if err = json.Unmarshal(file, &chainConfig); err != nil {
 		return superchain.ChainConfig{}, fmt.Errorf("error unmarshaling json: %w", err)
 	}
 
-	err = jsonConfig.CheckDataAvailability()
+	err = chainConfig.CheckDataAvailability()
 	if err != nil {
 		return superchain.ChainConfig{}, fmt.Errorf("error with json plasma config: %w", err)
 	}
 
-	chainConfig := superchain.ChainConfig{
-		Name:                   chainName,
-		ChainID:                jsonConfig.ChainID,
-		PublicRPC:              publicRPC,
-		SequencerRPC:           sequencerRPC,
-		Explorer:               explorer,
-		BatchInboxAddr:         jsonConfig.BatchInboxAddr,
-		Genesis:                jsonConfig.Genesis,
-		SuperchainLevel:        superchainLevel,
-		StandardChainCandidate: standardChainCandidate,
-		SuperchainTime:         nil,
-		Plasma:                 jsonConfig.Plasma,
-		HardForkConfiguration: superchain.HardForkConfiguration{
-			CanyonTime:  jsonConfig.CanyonTime,
-			DeltaTime:   jsonConfig.DeltaTime,
-			EcotoneTime: jsonConfig.EcotoneTime,
-			FjordTime:   jsonConfig.FjordTime,
-		},
-		BlockTime:            jsonConfig.BlockTime,
-		SequencerWindowSize:  jsonConfig.SequencerWindowSize,
-		DataAvailabilityType: jsonConfig.DataAvailabilityType,
-	}
+	chainConfig.Name = chainName
+	chainConfig.PublicRPC = publicRPC
+	chainConfig.SequencerRPC = sequencerRPC
+	chainConfig.Explorer = explorer
+	chainConfig.SuperchainLevel = superchainLevel
+	chainConfig.StandardChainCandidate = standardChainCandidate
+	chainConfig.SuperchainTime = nil
 
 	fmt.Printf("Rollup config successfully constructed\n")
 	return chainConfig, nil

--- a/add-chain/testdata/superchain/configs/sepolia/expected_baseline.toml
+++ b/add-chain/testdata/superchain/configs/sepolia/expected_baseline.toml
@@ -9,6 +9,7 @@ canyon_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
 delta_time = 1703203200 # Fri 22 Dec 2023 00:00:00 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/add-chain/testdata/superchain/configs/sepolia/expected_baseline_legacy.toml
+++ b/add-chain/testdata/superchain/configs/sepolia/expected_baseline_legacy.toml
@@ -9,6 +9,7 @@ canyon_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
 delta_time = 1703203200 # Fri 22 Dec 2023 00:00:00 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/add-chain/testdata/superchain/configs/sepolia/expected_faultproofs.toml
+++ b/add-chain/testdata/superchain/configs/sepolia/expected_faultproofs.toml
@@ -10,6 +10,7 @@ canyon_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
 delta_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/add-chain/testdata/superchain/configs/sepolia/expected_plasma.toml
+++ b/add-chain/testdata/superchain/configs/sepolia/expected_plasma.toml
@@ -10,6 +10,7 @@ canyon_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
 delta_time = 1703203200 # Fri 22 Dec 2023 00:00:00 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "alt-da"
 
 [plasma]

--- a/add-chain/testdata/superchain/configs/sepolia/expected_standard-candidate.toml
+++ b/add-chain/testdata/superchain/configs/sepolia/expected_standard-candidate.toml
@@ -10,6 +10,7 @@ canyon_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
 delta_time = 1703203200 # Fri 22 Dec 2023 00:00:00 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/add-chain/testdata/superchain/configs/sepolia/expected_zorasep.toml
+++ b/add-chain/testdata/superchain/configs/sepolia/expected_zorasep.toml
@@ -8,6 +8,7 @@ standard_chain_candidate = true # This is a temporary field which causes most of
 batch_inbox_addr = "0xCd734290E4bd0200dAC631c7D4b9E8a33234e91f"
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/bindings/rust-bindings/etc/configs.toml
+++ b/bindings/rust-bindings/etc/configs.toml
@@ -28,6 +28,7 @@
     fjord_time = 1720627201
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     [superchains.chains.genesis]
       l2_time = 1686068903
@@ -84,6 +85,7 @@
     fjord_time = 1720627201
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     [superchains.chains.genesis]
       l2_time = 1696608227
@@ -138,6 +140,7 @@
     ecotone_time = 0
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     gas_paying_token = "0x04E9D7e336f79Cdab911b06133D3Ca2Cd0721ce3"
     [superchains.chains.genesis]
@@ -195,6 +198,7 @@
     fjord_time = 1720627201
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     [superchains.chains.genesis]
       l2_time = 1700021615
@@ -252,6 +256,7 @@
     fjord_time = 1720627201
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     [superchains.chains.genesis]
       l2_time = 1711563515
@@ -306,6 +311,7 @@
     ecotone_time = 0
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     [superchains.chains.genesis]
       l2_time = 1720421591
@@ -363,6 +369,7 @@
     fjord_time = 1720627201
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     [superchains.chains.genesis]
       l2_time = 1686789347
@@ -420,6 +427,7 @@
     fjord_time = 1720627201
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     [superchains.chains.genesis]
       l2_time = 1700167583
@@ -477,6 +485,7 @@
     fjord_time = 1720627201
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     [superchains.chains.genesis]
       l2_time = 1686693839
@@ -546,6 +555,7 @@
     granite_time = 1723478400
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     [superchains.chains.genesis]
       l2_time = 1687867932
@@ -601,6 +611,7 @@
     ecotone_time = 1708534800
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     [superchains.chains.genesis]
       l2_time = 1708129620
@@ -655,6 +666,7 @@
     ecotone_time = 0
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     [superchains.chains.genesis]
       l2_time = 1719646560
@@ -713,6 +725,7 @@
     granite_time = 1723478400
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     [superchains.chains.genesis]
       l2_time = 1695768288
@@ -770,6 +783,7 @@
     granite_time = 1723478400
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     [superchains.chains.genesis]
       l2_time = 1691802540
@@ -828,6 +842,7 @@
     granite_time = 1723478400
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     [superchains.chains.genesis]
       l2_time = 1698080004
@@ -896,6 +911,7 @@
     granite_time = 1723046400
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     [superchains.chains.genesis]
       l2_time = 1706484048
@@ -953,6 +969,7 @@
     granite_time = 1723046400
     block_time = 2
     seq_window_size = 3600
+    max_sequencer_drift = 600
     data_availability_type = "eth-da"
     [superchains.chains.genesis]
       l2_time = 1695433056

--- a/superchain/configs/mainnet/base.toml
+++ b/superchain/configs/mainnet/base.toml
@@ -13,6 +13,7 @@ ecotone_time = 1710374401 # Thu 14 Mar 2024 00:00:01 UTC
 fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/superchain/configs/mainnet/lyra.toml
+++ b/superchain/configs/mainnet/lyra.toml
@@ -12,6 +12,7 @@ ecotone_time = 1710374401 # Thu 14 Mar 2024 00:00:01 UTC
 fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/superchain/configs/mainnet/metal.toml
+++ b/superchain/configs/mainnet/metal.toml
@@ -13,6 +13,7 @@ ecotone_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
 fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/superchain/configs/mainnet/mode.toml
+++ b/superchain/configs/mainnet/mode.toml
@@ -13,6 +13,7 @@ ecotone_time = 1710374401 # Thu 14 Mar 2024 00:00:01 UTC
 fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/superchain/configs/mainnet/op.toml
+++ b/superchain/configs/mainnet/op.toml
@@ -12,6 +12,7 @@ ecotone_time = 1710374401 # Thu 14 Mar 2024 00:00:01 UTC
 fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/superchain/configs/mainnet/orderly.toml
+++ b/superchain/configs/mainnet/orderly.toml
@@ -12,6 +12,7 @@ ecotone_time = 1710374401 # Thu 14 Mar 2024 00:00:01 UTC
 fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/superchain/configs/mainnet/race.toml
+++ b/superchain/configs/mainnet/race.toml
@@ -10,6 +10,7 @@ delta_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
 ecotone_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/superchain/configs/mainnet/tbn.toml
+++ b/superchain/configs/mainnet/tbn.toml
@@ -10,6 +10,7 @@ delta_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
 ecotone_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 gas_paying_token = "0x04E9D7e336f79Cdab911b06133D3Ca2Cd0721ce3"
 

--- a/superchain/configs/mainnet/zora.toml
+++ b/superchain/configs/mainnet/zora.toml
@@ -13,6 +13,7 @@ ecotone_time = 1710374401 # Thu 14 Mar 2024 00:00:01 UTC
 fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/superchain/configs/sepolia-dev-0/base-devnet-0.toml
+++ b/superchain/configs/sepolia-dev-0/base-devnet-0.toml
@@ -12,6 +12,7 @@ ecotone_time = 1706634000 # Tue 30 Jan 2024 17:00:00 UTC
 fjord_time = 1715961600 # Fri 17 May 2024 16:00:00 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/superchain/configs/sepolia-dev-0/oplabs-devnet-0.toml
+++ b/superchain/configs/sepolia-dev-0/oplabs-devnet-0.toml
@@ -12,6 +12,7 @@ ecotone_time = 1706634000 # Tue 30 Jan 2024 17:00:00 UTC
 fjord_time = 1715961600 # Fri 17 May 2024 16:00:00 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/superchain/configs/sepolia/base.toml
+++ b/superchain/configs/sepolia/base.toml
@@ -13,6 +13,7 @@ ecotone_time = 1708534800 # Wed 21 Feb 2024 17:00:00 UTC
 fjord_time = 1716998400 # Wed 29 May 2024 16:00:00 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/superchain/configs/sepolia/metal.toml
+++ b/superchain/configs/sepolia/metal.toml
@@ -11,6 +11,7 @@ delta_time = 1708385400 # Mon 19 Feb 2024 23:30:00 UTC
 ecotone_time = 1708534800 # Wed 21 Feb 2024 17:00:00 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/superchain/configs/sepolia/mode.toml
+++ b/superchain/configs/sepolia/mode.toml
@@ -13,6 +13,7 @@ ecotone_time = 1708534800 # Wed 21 Feb 2024 17:00:00 UTC
 fjord_time = 1716998400 # Wed 29 May 2024 16:00:00 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/superchain/configs/sepolia/op.toml
+++ b/superchain/configs/sepolia/op.toml
@@ -12,6 +12,7 @@ ecotone_time = 1708534800 # Wed 21 Feb 2024 17:00:00 UTC
 fjord_time = 1716998400 # Wed 29 May 2024 16:00:00 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/superchain/configs/sepolia/race.toml
+++ b/superchain/configs/sepolia/race.toml
@@ -10,6 +10,7 @@ delta_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
 ecotone_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/superchain/configs/sepolia/zora.toml
+++ b/superchain/configs/sepolia/zora.toml
@@ -13,6 +13,7 @@ ecotone_time = 1708534800 # Wed 21 Feb 2024 17:00:00 UTC
 fjord_time = 1716998400 # Wed 29 May 2024 16:00:00 UTC
 block_time = 2
 seq_window_size = 3600
+max_sequencer_drift = 600
 data_availability_type = "eth-da"
 
 [genesis]

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -102,6 +102,7 @@ type ChainConfig struct {
 
 	BlockTime            uint64           `toml:"block_time" json:"block_time"`
 	SequencerWindowSize  uint64           `toml:"seq_window_size" json:"seq_window_size"`
+	MaxSequencerDrift    uint64           `toml:"max_sequencer_drift" json:"max_sequencer_drift"`
 	DataAvailabilityType DataAvailability `toml:"data_availability_type"`
 
 	// Optional feature


### PR DESCRIPTION
Replaces https://github.com/ethereum-optimism/superchain-registry/pull/459

This PR adds the default value to all existing chain configs:
* `max_sequencer_drift = 600`

Complementary monorepo pr: https://github.com/ethereum-optimism/optimism/pull/11459