### PR TITLE
fix(ci): Crate Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@stable
-      - name: Release Crates
-        run: |
-          cargo install cargo-release
-          cargo login $CARGO_REGISTRY_TOKEN
-          just release
+      - name: Install cargo release
+        run: cargo install cargo-release
+      - name: Login to cargo
+        run: cargo login $CARGO_REGISTRY_TOKEN
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Release superchain-primitives crate
+        run: just bindings/rust-primitives/release
+        continue-on-error: true
+      - name: Release superchain-registry crate
+        run: just bindings/rust-bindings/release
+        continue-on-error: true


### PR DESCRIPTION
**Description**

Fixes the crate release workflow so it doesn't fail if a crate version is already published.

If we bump the version of the `superchain-registry` crate in `bindings/rust-bindings` this workflow would previously fail if the primitives crate version _hadn't_ changed since the release fails if the version is the same as already published.

Now the step will fail silently which is intended behavior since the workflow is a manual trigger.