### PR TITLE
Move version checks from standard candidate to standard

### DIFF
--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -51,27 +51,11 @@ var exclusions = map[string]map[uint64]bool{
 		1740:      true, // metal-sepolia
 	},
 	"Standard_Contract_Versions": {
-		8453:      true, // mainnet/base         MCP (at time of writing)
-		1750:      true, // mainnet/metal        MCP (at time of writing)
-		34443:     true, // mainnet/mode         MCP (at time of writing)
-		7777777:   true, // mainnet/zora         MCP (at time of writing)
-		84532:     true, // sepolia/base         MCP (at time of writing)
-		1740:      true, // sepolia/metal        MCP (at time of writing)
-		919:       true, // sepolia/mode         MCP (at time of writing)
-		999999999: true, // sepolia/zora         MCP (at time of writing)
-		11155421:  true, // sepolia-dev0/oplabs-devnet-0
-		11763072:  true, // sepolia-dev0/base-devnet-0
+		11155421: true, // sepolia-dev0/oplabs-devnet-0
+		11763072: true, // sepolia-dev0/base-devnet-0
 	},
 	"Optimism_Portal_2_Params": {
-		8453:      true, // mainnet/base         MCP (at time of writing)
-		1750:      true, // mainnet/metal        MCP (at time of writing)
-		34443:     true, // mainnet/mode         MCP (at time of writing)
-		7777777:   true, // mainnet/zora         MCP (at time of writing)
-		84532:     true, // sepolia/base         MCP (at time of writing)
-		1740:      true, // sepolia/metal        MCP (at time of writing)
-		919:       true, // sepolia/mode         MCP (at time of writing)
-		999999999: true, // sepolia/zora         MCP (at time of writing)
-		11763072:  true, // sepolia-dev0/base-devnet-0
+		11763072: true, // sepolia-dev0/base-devnet-0
 	},
 }
 

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -45,14 +45,9 @@ func testUniversal(t *testing.T, chain *ChainConfig) {
 
 // testStandardCandidate applies to Standard and Standard Candidate Chains.
 func testStandardCandidate(t *testing.T, chain *ChainConfig) {
-	// Standard Contract Versions
-	t.Run("Standard Contract Versions", func(t *testing.T) {
-		testContractsMatchATag(t, chain)
-	})
 	// Standard Config Params
 	t.Run("Rollup Config", func(t *testing.T) { testRollupConfig(t, chain) })
 	t.Run("Gas Token", (func(t *testing.T) { testGasToken(t, chain) }))
-	t.Run("Optimism Portal 2 Params", func(t *testing.T) { testOptimismPortal2Params(t, chain) })
 	t.Run("Resource Config", func(t *testing.T) { testResourceConfig(t, chain) })
 	t.Run("Gas Limit", func(t *testing.T) { testGasLimit(t, chain) })
 	t.Run("GPO Params", func(t *testing.T) { testGasPriceOracleParams(t, chain) })
@@ -68,5 +63,12 @@ func testStandardCandidate(t *testing.T, chain *ChainConfig) {
 // testStandard should be applied only to a fully Standard Chain,
 // i.e. not to a Standard Candidate Chain.
 func testStandard(t *testing.T, chain *ChainConfig) {
+	// Standard Contract Versions
+	t.Run("Standard Contract Versions", func(t *testing.T) {
+		testContractsMatchATag(t, chain)
+	})
+	// Standard Config Params
+	t.Run("Optimism Portal 2 Params", func(t *testing.T) { testOptimismPortal2Params(t, chain) })
+	// Standard Config Roles
 	t.Run("Key Handover Check", func(t *testing.T) { testKeyHandover(t, chain.ChainID) })
 }


### PR DESCRIPTION
We want to admit standard candidate chains without requiring them to be on fault proofs yet. 