### PR TITLE
fix(bindings): Disable Default Features in superchain dep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,3 +23,6 @@ jobs:
       - name: Release superchain-registry crate
         run: just bindings/rust-bindings/release
         continue-on-error: true
+      - name: Release superchain crate
+        run: just bindings/superchain/release
+        continue-on-error: true

--- a/bindings/rust-bindings/Cargo.lock
+++ b/bindings/rust-bindings/Cargo.lock
@@ -667,7 +667,6 @@ dependencies = [
  "hashbrown",
  "lazy_static",
  "serde",
- "serde_repr",
  "superchain-primitives",
  "toml",
 ]

--- a/bindings/rust-bindings/Cargo.toml
+++ b/bindings/rust-bindings/Cargo.toml
@@ -19,7 +19,6 @@ superchain-primitives = { path = "../rust-primitives", version = "0.2.2", defaul
 # Serialization
 serde = { version = "1.0.203", default-features = false, features = ["derive", "alloc"] }
 toml = { version = "0.8.14" }
-serde_repr = "0.1"
 
 [dev-dependencies]
 alloy-primitives = { version = "0.7.1", default-features = false }

--- a/bindings/rust-bindings/src/lib.rs
+++ b/bindings/rust-bindings/src/lib.rs
@@ -2,6 +2,7 @@
 #![warn(missing_debug_implementations, missing_docs, rustdoc::all)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/bindings/rust-primitives/src/lib.rs
+++ b/bindings/rust-primitives/src/lib.rs
@@ -2,6 +2,7 @@
 #![warn(missing_debug_implementations, missing_docs, rustdoc::all)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/bindings/superchain/Cargo.lock
+++ b/bindings/superchain/Cargo.lock
@@ -666,7 +666,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "superchain"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "superchain-primitives",
  "superchain-registry",
@@ -693,7 +693,6 @@ dependencies = [
  "hashbrown",
  "lazy_static",
  "serde",
- "serde_repr",
  "superchain-primitives",
  "toml",
 ]

--- a/bindings/superchain/Cargo.toml
+++ b/bindings/superchain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "superchain"
 description = "The Superchain Registry"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 authors = ["OP Contributors"]
@@ -17,7 +17,7 @@ superchain-primitives = { path = "../rust-primitives", version = "0.2.2", defaul
 
 # `serde` is optional, but enabled by default
 # Since superchain-registry requires `serde`, we mark it as optional
-superchain-registry = { path = "../rust-bindings", version = "0.2.6", optional = true, default-feature = false }
+superchain-registry = { path = "../rust-bindings", version = "0.2.6", optional = true, default-features = false }
 
 [features]
 default = ["serde", "std"]

--- a/justfile
+++ b/justfile
@@ -1,8 +1,8 @@
 set positional-arguments
-alias t := cargo-tests
-alias l := cargo-lint
-alias f := cargo-format
-alias b := cargo-build
+alias ct := cargo-tests
+alias cl := cargo-lint
+alias cf := cargo-format
+alias cb := cargo-build
 
 # Adding a chain
 add-chain:

--- a/justfile
+++ b/justfile
@@ -1,4 +1,8 @@
 set positional-arguments
+alias t := cargo-tests
+alias l := cargo-lint
+alias f := cargo-format
+alias b := cargo-build
 
 # Adding a chain
 add-chain:
@@ -82,6 +86,12 @@ cargo-tests:
   just bindings/rust-primitives/tests
   just bindings/rust-bindings/tests
   just bindings/superchain/tests
+
+# Run cargo format
+cargo-format:
+  just bindings/rust-primitives/fmt
+  just bindings/rust-bindings/fmt
+  just bindings/superchain/fmt
 
 # Run cargo lints
 cargo-lint:


### PR DESCRIPTION
### Description

Disables default-features typo in the `superchain-registry` dep in `superchain`.

Also adds unused dep warnings to both `superchain-registry` and `superchain-primitives`.