### PR TITLE
Add silence for OP Mainnet Optimism_Portal_2_Params

### DIFF
--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -18,6 +18,9 @@ func skipIfExcluded(t *testing.T, chainID uint64) {
 		if matches && exclusions[pattern][chainID] {
 			t.Skip("Excluded!")
 		}
+		if matches && silences[pattern][chainID].After(time.Now()) {
+			t.Skipf("Silenced until %s", silences[pattern][chainID].String())
+		}
 	}
 }
 
@@ -56,15 +59,14 @@ var exclusions = map[string]map[uint64]bool{
 		11763072: true, // sepolia-dev0/base-devnet-0
 	},
 	"Optimism_Portal_2_Params": {
-		10:       true, // mainnet/op (Permissioned Dispute Game enabled, silenced until Tue 11 Sep 2024 16:00:01 UTC)
 		11763072: true, // sepolia-dev0/base-devnet-0
 	},
 }
 
-func TestSilences(t *testing.T) {
-	if exclusions["Optimism_Portal_2_Params"][10] && time.Now().After(time.Unix(1726070401, 0)) {
-		t.Fatal("OP Mainnet exclusion expired")
-	}
+var silences = map[string]map[uint64]time.Time{
+	"Optimism_Portal_2_Params": {
+		10: time.Unix(1726070401, 0), // mainnet/op silenced until Tue 11 Sep 2024 16:00:01 UTC
+	},
 }
 
 func TestExclusions(t *testing.T) {

--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func skipIfExcluded(t *testing.T, chainID uint64) {
-
 	for pattern := range exclusions {
 		matches, err := regexp.Match(pattern, []byte(t.Name()))
 		if err != nil {

--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func skipIfExcluded(t *testing.T, chainID uint64) {
+
 	for pattern := range exclusions {
 		matches, err := regexp.Match(pattern, []byte(t.Name()))
 		if err != nil {
@@ -65,7 +66,7 @@ var exclusions = map[string]map[uint64]bool{
 
 var silences = map[string]map[uint64]time.Time{
 	"Optimism_Portal_2_Params": {
-		10: time.Unix(1726070401, 0), // mainnet/op silenced until Tue 11 Sep 2024 16:00:01 UTC
+		10: time.Unix(int64(*superchain.OPChains[10].HardForkConfiguration.GraniteTime), 0), // mainnet/op silenced until Granite activates
 	},
 }
 

--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/ethereum-optimism/superchain-registry/superchain"
 	"github.com/stretchr/testify/require"
@@ -55,8 +56,15 @@ var exclusions = map[string]map[uint64]bool{
 		11763072: true, // sepolia-dev0/base-devnet-0
 	},
 	"Optimism_Portal_2_Params": {
+		10:       true, // mainnet/op (Permissioned Dispute Game enabled, silenced until )
 		11763072: true, // sepolia-dev0/base-devnet-0
 	},
+}
+
+func TestSilences(t *testing.T) {
+	if exclusions["Optimism_Portal_2_Params"][10] && time.Now().After(time.Unix(1726070401, 0)) {
+		t.Fatal("OP Mainnet exclusion expired")
+	}
 }
 
 func TestExclusions(t *testing.T) {

--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -56,7 +56,7 @@ var exclusions = map[string]map[uint64]bool{
 		11763072: true, // sepolia-dev0/base-devnet-0
 	},
 	"Optimism_Portal_2_Params": {
-		10:       true, // mainnet/op (Permissioned Dispute Game enabled, silenced until )
+		10:       true, // mainnet/op (Permissioned Dispute Game enabled, silenced until Tue 11 Sep 2024 16:00:01 UTC)
 		11763072: true, // sepolia-dev0/base-devnet-0
 	},
 }


### PR DESCRIPTION
Our validation suite is currently failing because of the fallback to the permissioned dispute game type on OP Mainnet. We only see this on the hourly `validate-all` job and also on any PR which touches the `op.toml` file. 

Rather than demote or permanently exclude OP Mainnet, here I am silencing it until the Granite upgrade happens. 