### PR TITLE
Modify promotion test notification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,32 @@ jobs:
       - run:
           name: run validation checks
           command: just promotion-test
-      - notify-failures-on-main:
+      - slack/notify:
+          event: always
+          custom: |
+              {
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": ":control_knobs: The daily report on standard candidate chains is ready!"
+                    }
+                  },
+                  {
+                    "type": "divider"
+                  },
+                  {
+                    "type": "context",
+                    "elements": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "👀 Click the link to see what validation checks would fail if all candidate chains were promoted to standard (and exclusions removed)."
+                      }
+                    ]
+                  }
+                ]
+              }
           channel: C07GZVCCUS0 # to slack channel `notify-superchain-promotion-failures`
   publish-bot:
     environment:


### PR DESCRIPTION
The idea here is to stop calling the daily notifications "failures" and start calling them a "report" (to reduce alert fatigue). 

We should rename the slack channel to `notify-superchain-promotion-reports`.
<img width="438" alt="Screenshot 2024-08-27 at 23 10 59" src="https://github.com/user-attachments/assets/b348315d-73c5-47b6-8050-1cd332577b53">
