### PR TITLE
add button with link to just-promotion-test slack message

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,29 +131,38 @@ jobs:
       - slack/notify:
           event: always
           custom: |
-              {
-                "blocks": [
-                  {
-                    "type": "section",
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":control_knobs: The daily report on standard candidate chains is ready!"
+                  },
+                  "accessory": {
+                    "type": "button",
                     "text": {
-                      "type": "mrkdwn",
-                      "text": ":control_knobs: The daily report on standard candidate chains is ready!"
-                    }
-                  },
-                  {
-                    "type": "divider"
-                  },
-                  {
-                    "type": "context",
-                    "elements": [
-                      {
-                        "type": "mrkdwn",
-                        "text": "👀 Click the link to see what validation checks would fail if all candidate chains were promoted to standard (and exclusions removed)."
-                      }
-                    ]
+                      "type": "plain_text",
+                      "text": "👀 View Report",
+                      "emoji": true
+                    },
+                    "url": "${CIRCLE_BUILD_URL}"
                   }
-                ]
-              }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "Click the link to see what validation checks would fail if all candidate chains were promoted to standard (and exclusions removed)."
+                    }
+                  ]
+                }
+              ]
+            }
           channel: C07GZVCCUS0 # to slack channel `notify-superchain-promotion-failures`
   publish-bot:
     environment:


### PR DESCRIPTION

Currently there is no link to follow to get to the report. 
<img width="840" alt="Screenshot 2024-08-29 at 09 34 07" src="https://github.com/user-attachments/assets/33d169fd-7190-4859-9892-e7e39e09d13a">

this Pr fixes that: 

<img width="840" alt="Screenshot 2024-08-29 at 09 32 42" src="https://github.com/user-attachments/assets/20036c16-84b1-4013-961c-49418be30bfc">
