### PR TITLE
Use `op-contracts/v1.3.0` ABI for pre fault proofs validation

### DIFF
--- a/validation/security-configs_test.go
+++ b/validation/security-configs_test.go
@@ -44,7 +44,7 @@ var checkResolutions = func(t *testing.T, r standard.Resolutions, chainID uint64
 			got, err := getAddress(method, contractAddress, client)
 			require.NoErrorf(t, err, "problem calling %s.%s (%s)", contract, method, contractAddress)
 
-			// Use assert.True here for a concise output of failures, since failure info is sent to a slack channel
+			// Use t.Errorf here for a concise output of failures, since failure info is sent to a slack channel
 			if want != got {
 				t.Errorf("%s.%s = %s, expected %s (%s)", contract, method, got, want, output)
 			}

--- a/validation/standard/standard-config-roles-mainnet.toml
+++ b/validation/standard/standard-config-roles-mainnet.toml
@@ -1,6 +1,6 @@
 [l1.nonFaultProofs]
-OptimismPortalProxy."GUARDIAN()" = "0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2"
-L2OutputOracleProxy."CHALLENGER()" = "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A"
+OptimismPortalProxy."guardian()" = "0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2"
+L2OutputOracleProxy."challenger()" = "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A"
 
 [l1.FaultProofs]
 OptimismPortalProxy."guardian()" = "0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2"

--- a/validation/standard/standard-config-roles-sepolia.toml
+++ b/validation/standard/standard-config-roles-sepolia.toml
@@ -1,6 +1,6 @@
 [l1.nonFaultProofs]
-OptimismPortalProxy."GUARDIAN()" = "0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E"
-L2OutputOracleProxy."CHALLENGER()" = "0xfd1D2e729aE8eEe2E146c033bf4400fE75284301"
+OptimismPortalProxy."guardian()" = "0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E"
+L2OutputOracleProxy."challenger()" = "0xfd1D2e729aE8eEe2E146c033bf4400fE75284301"
 
 [l1.FaultProofs]
 OptimismPortalProxy."guardian()" = "0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E"

--- a/validation/standard/standard-config-roles-universal.toml
+++ b/validation/standard/standard-config-roles-universal.toml
@@ -19,12 +19,12 @@ SystemConfigProxy."batcherHash()" = "BatchSubmitter"
 
 
 [l1.nonFaultProofs]
-OptimismPortalProxy."GUARDIAN()" = "Guardian"
-OptimismPortalProxy."SYSTEM_CONFIG()" = "SystemConfigProxy"
-OptimismPortalProxy."L2_ORACLE()" = "L2OutputOracleProxy"
+OptimismPortalProxy."guardian()" = "Guardian"
+OptimismPortalProxy."systemConfig()" = "SystemConfigProxy"
+OptimismPortalProxy."l2Oracle()" = "L2OutputOracleProxy"
 L2OutputOracleProxy."admin()" = "ProxyAdmin"
-L2OutputOracleProxy."CHALLENGER()" = "Challenger"
-L2OutputOracleProxy."PROPOSER()" = "Proposer"
+L2OutputOracleProxy."challenger()" = "Challenger"
+L2OutputOracleProxy."proposer()" = "Proposer"
 
 [l1.FaultProofs]
 DisputeGameFactoryProxy."admin()" = "ProxyAdmin"

--- a/validation/superchain-config_test.go
+++ b/validation/superchain-config_test.go
@@ -23,5 +23,7 @@ func testSuperchainConfig(t *testing.T, chain *ChainConfig) {
 	got, err := getAddress("superchainConfig()", opp, client)
 	require.NoError(t, err)
 
-	require.Equal(t, *expected, got)
+	if *expected != got {
+		t.Errorf("incorrect OptimismPortal.superchainConfig() address: got %s, wanted %s", *expected, got)
+	}
 }

--- a/validation/superchain-config_test.go
+++ b/validation/superchain-config_test.go
@@ -24,6 +24,6 @@ func testSuperchainConfig(t *testing.T, chain *ChainConfig) {
 	require.NoError(t, err)
 
 	if *expected != got {
-		t.Errorf("incorrect OptimismPortal.superchainConfig() address: got %s, wanted %s",  got, *expected)
+		t.Errorf("incorrect OptimismPortal.superchainConfig() address: got %s, wanted %s", got, *expected)
 	}
 }

--- a/validation/superchain-config_test.go
+++ b/validation/superchain-config_test.go
@@ -24,6 +24,6 @@ func testSuperchainConfig(t *testing.T, chain *ChainConfig) {
 	require.NoError(t, err)
 
 	if *expected != got {
-		t.Errorf("incorrect OptimismPortal.superchainConfig() address: got %s, wanted %s", *expected, got)
+		t.Errorf("incorrect OptimismPortal.superchainConfig() address: got %s, wanted %s",  got, *expected)
 	}
 }


### PR DESCRIPTION
And some other driveby improvements. This should allow more tests to pass on PRs like this one #514 