### PR TITLE
Update superchain.toml comment for the correct date

### DIFF
--- a/superchain/configs/mainnet/superchain.toml
+++ b/superchain/configs/mainnet/superchain.toml
@@ -6,7 +6,7 @@ canyon_time =  1704992401 # Thu 11 Jan 2024 17:00:01 UTC
 delta_time =   1708560000 # Thu 22 Feb 2024 00:00:00 UTC
 ecotone_time = 1710374401 # Thu 14 Mar 2024 00:00:01 UTC
 fjord_time =   1720627201 # Wed 10 Jul 2024 16:00:01 UTC
-granite_time = 1726070401 # Tue 11 Sep 2024 16:00:01 UTC
+granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
 
 [l1]
   chain_id = 1


### PR DESCRIPTION
# Description

The granite timestamp (`1726070401`) is for Wednesday, not Tuesday. https://www.epochconverter.com/
