### PR TITLE
circleci: use context to pass rpc urls

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -270,10 +270,16 @@ workflows:
           matrix:
             parameters:
               chainid: [] # This list will be replaced by the generate_test_config.sh script
+          context:
+            - oplabs-rpc-urls
       - genesis-allocs-all-ok:
           requires: [] # This list will be replaced by the generate_test_config.sh script
+          context:
+            - oplabs-rpc-urls
       - golang-lint
       - golang-modules-tidy
       - golang-test
-      - golang-validate-modified
+      - golang-validate-modified:
+          context:
+            - oplabs-rpc-urls
       - check-codegen

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -242,6 +242,7 @@ workflows:
       - golang-validate-all:
           context:
             - slack
+            - oplabs-rpc-urls
       - golang-test:
           context:
             - slack
@@ -257,6 +258,7 @@ workflows:
       - golang-promotion-test:
           context:
             - slack
+            - oplabs-rpc-urls
     triggers:
       - schedule:
           cron: "0 0 * * *"


### PR DESCRIPTION
### Description
Fixes an issue where forked pull requests cannot use rpc endpoints stored as project level env vars in circle ci. Instead we use a context to store the same env vars. Contexts can be accessed by forked prs