### PR TITLE
CI: Migrate scheduled workflows to scheduled pipeline jobs

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -238,6 +238,11 @@ jobs:
       - run: echo "All golang-validate-genesis-allocs jobs suceeded"
 workflows:
   hourly:
+    # run workflow only when the hourly_build pipeline is triggered
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ hourly_build, << pipeline.schedule.name >> ]
     jobs:
       - golang-validate-all:
           context:
@@ -246,26 +251,17 @@ workflows:
       - golang-test:
           context:
             - slack
-    triggers:
-      - schedule:
-          cron: "0 * * * *"
-          filters:
-            branches:
-              only:
-                - main
   nightly:
+    # run workflow only when the nightly_build pipeline is triggered
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ nightly_build, << pipeline.schedule.name >> ]
     jobs:
       - golang-promotion-test:
           context:
             - slack
             - oplabs-rpc-urls
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
   pr-checks:
     jobs:
       - golang-validate-genesis-allocs:


### PR DESCRIPTION
* CircleCI has two pipeline triggers named `nightly_build` and `hourly_build`.
* Remove workflow triggers and configure jobs to run on scheduled pipeline triggers .

Ref:

* https://circleci.com/docs/migrate-scheduled-workflows-to-scheduled-pipelines/
* https://circleci.com/docs/schedule-pipelines-with-multiple-workflows/

Fixes: https://github.com/ethereum-optimism/superchain-registry/issues/548
