### PR TITLE
Add exclusions for GenesisAllocsMetadataTest

### DIFF
--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -30,6 +30,10 @@ var exclusions = map[string]map[uint64]bool{
 		// OP Mainnet has a pre-bedrock genesis (with an empty allocs object stored in the registry), so we exclude it from this check.")
 		10: true,
 	},
+	GenesisAllocsMetadataTest: {
+		10:       true, // op-mainnet
+		11155420: true, // op-sepolia
+	},
 	ChainIDRPCTest: {
 		11155421: true, // sepolia-dev-0/oplabs-devnet-0   No Public RPC declared
 		11763072: true, // sepolia-dev-0/base-devnet-0     No Public RPC declared

--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -63,8 +63,8 @@ var silences = map[string]map[uint64]time.Time{
 func TestExclusions(t *testing.T) {
 	for name, v := range exclusions {
 		for k := range v {
-			if k == 10 && (name == GenesisHashTest || name == GenesisAllocsMetadataTest) {
-				// This is the sole standard chain validation check exclusion
+			if (k == 10 || k == 11155420) && (name == GenesisHashTest || name == GenesisAllocsMetadataTest) {
+				// This are the sole standard chain validation check exclusions
 				continue
 			}
 			if v[k] {

--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -63,7 +63,7 @@ var silences = map[string]map[uint64]time.Time{
 func TestExclusions(t *testing.T) {
 	for name, v := range exclusions {
 		for k := range v {
-			if k == 10 && name == GenesisHashTest {
+			if k == 10 && (name == GenesisHashTest || name == GenesisAllocsMetadataTest) {
 				// This is the sole standard chain validation check exclusion
 				continue
 			}

--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -32,6 +32,7 @@ var exclusions = map[string]map[uint64]bool{
 	},
 	GenesisAllocsMetadataTest: {
 		10:       true, // op-mainnet
+		1740:     true, // metal-sepolia
 		11155420: true, // op-sepolia
 	},
 	ChainIDRPCTest: {

--- a/validation/exclusions_test.go
+++ b/validation/exclusions_test.go
@@ -64,7 +64,7 @@ func TestExclusions(t *testing.T) {
 	for name, v := range exclusions {
 		for k := range v {
 			if (k == 10 || k == 11155420) && (name == GenesisHashTest || name == GenesisAllocsMetadataTest) {
-				// This are the sole standard chain validation check exclusions
+				// These are the sole standard chain validation check exclusions
 				continue
 			}
 			if v[k] {

--- a/validation/genesis-allocs_test.go
+++ b/validation/genesis-allocs_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func testGenesisAllocsMetadata(t *testing.T, chain *ChainConfig) {
+	skipIfExcluded(t, chain.ChainID)
 	// This tests asserts that the a genesis creation commit is stored for
 	// the chain. It does not perform full genesis allocs validation.
 	// Full genesis allocs validation is run as a one-off requirement when

--- a/validation/genesis-allocs_test.go
+++ b/validation/genesis-allocs_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func testGenesisAllocsMetadata(t *testing.T, chain *ChainConfig) {
-	skipIfExcluded(t, chain.ChainID)
 	// This tests asserts that the a genesis creation commit is stored for
 	// the chain. It does not perform full genesis allocs validation.
 	// Full genesis allocs validation is run as a one-off requirement when


### PR DESCRIPTION
This prevents the hourly validation job from failing. 

See https://app.circleci.com/pipelines/github/ethereum-optimism/superchain-registry/7332/workflows/2e8e2850-ab71-480e-bbc9-ee2152c0bcfb/jobs/22265