### PR TITLE
add-chain: print plasma error message

### DIFF
--- a/add-chain/config/config.go
+++ b/add-chain/config/config.go
@@ -34,6 +34,21 @@ func ConstructChainConfig(
 	if err != nil {
 		return superchain.ChainConfig{}, fmt.Errorf("error reading file: %w", err)
 	}
+
+	// Detect any legacy "plasma" config fields and alert user to adjust their config to match
+	// the new "altda" format
+	var plasmaConfig LegacyPlasma
+	if err = json.Unmarshal(file, &plasmaConfig); err != nil {
+		return superchain.ChainConfig{}, fmt.Errorf("error unmarshaling legacy plasma json: %w", err)
+	}
+	if err = plasmaConfig.CheckNonNilFields(); err != nil {
+		fmt.Printf(
+			"❌ Detected legacy plasma configuration fields in rollup json file.\n" +
+				"❌   - Please follow the guide at the following url to migrate to the new altda format:\n" +
+				"❌   - https://docs.optimism.io/builders/chain-operators/features/alt-da-mode#breaking-changes-renaming-plasma-mode-to-alt-da-mode\n")
+		return superchain.ChainConfig{}, err
+	}
+
 	var chainConfig superchain.ChainConfig
 	if err = json.Unmarshal(file, &chainConfig); err != nil {
 		return superchain.ChainConfig{}, fmt.Errorf("error unmarshaling json: %w", err)
@@ -41,7 +56,7 @@ func ConstructChainConfig(
 
 	err = chainConfig.CheckDataAvailability()
 	if err != nil {
-		return superchain.ChainConfig{}, fmt.Errorf("error with json altDA config: %w", err)
+		return superchain.ChainConfig{}, fmt.Errorf("error with json altda config: %w", err)
 	}
 
 	genesis, err := utils.LoadJSON[core.Genesis](genesisPath)

--- a/add-chain/config/plasma.go
+++ b/add-chain/config/plasma.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/ethereum-optimism/superchain-registry/superchain"
+)
+
+type LegacyPlasma struct {
+	DAChallengeAddress         *superchain.Address `json:"da_challenge_address"`
+	DAChallengeContractAddress *superchain.Address `json:"da_challenge_contract_address"`
+	DACommitmentType           *string             `json:"da_commitment_type"`
+	DAChallengeWindow          *uint64             `json:"da_challenge_window"`
+	DAResolveWindow            *uint64             `json:"da_resolve_window"`
+	UsePlasma                  *bool               `json:"use_plasma"`
+	PlasmaConfig               *interface{}        `json:"plasma_config"`
+}
+
+func (lp *LegacyPlasma) CheckNonNilFields() error {
+	v := reflect.ValueOf(*lp)
+	typeOfT := v.Type()
+
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+
+		if field.Kind() == reflect.Ptr && !field.IsNil() {
+			fieldName := typeOfT.Field(i).Name
+			return fmt.Errorf("field %s is non-nil", fieldName)
+		}
+	}
+
+	return nil
+}

--- a/add-chain/config/plasma.go
+++ b/add-chain/config/plasma.go
@@ -19,13 +19,13 @@ type LegacyPlasma struct {
 
 func (lp *LegacyPlasma) CheckNonNilFields() error {
 	v := reflect.ValueOf(*lp)
-	typeOfT := v.Type()
+	typeOfV := v.Type()
 
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Field(i)
 
 		if field.Kind() == reflect.Ptr && !field.IsNil() {
-			fieldName := typeOfT.Field(i).Name
+			fieldName := typeOfV.Field(i).Name
 			return fmt.Errorf("field %s is non-nil", fieldName)
 		}
 	}

--- a/add-chain/config/plasma_test.go
+++ b/add-chain/config/plasma_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLegacyPlasmaConfig_error(t *testing.T) {
+	jsonData := `{
+		"block_time": 2,
+		"da_commitment_type": "GenericCommitment"
+	}`
+
+	var plasmaConfig LegacyPlasma
+	err := json.Unmarshal([]byte(jsonData), &plasmaConfig)
+	require.NoError(t, err, "Error unmarshaling JSON: %v", err)
+
+	require.Error(t, plasmaConfig.CheckNonNilFields(), "Expected an error due to non-nil fields, but got nil")
+}
+
+func TestLegacyPlasmaConfig_success(t *testing.T) {
+	jsonData := `{
+		"block_time": 2
+	}`
+
+	var plasmaConfig LegacyPlasma
+	err := json.Unmarshal([]byte(jsonData), &plasmaConfig)
+	require.NoError(t, err, "Error unmarshaling JSON: %v", err)
+
+	require.NoError(t, plasmaConfig.CheckNonNilFields(), "Expected no error when checking for non nil plasma fields")
+}

--- a/add-chain/testdata/monorepo/op-node/rollup_faultproofs.json
+++ b/add-chain/testdata/monorepo/op-node/rollup_faultproofs.json
@@ -28,6 +28,5 @@
     "batch_inbox_address": "0xff00000000000000000000000000000011155421",
     "deposit_contract_address": "0x76114bd29dFcC7a9892240D317E6c7C2A281Ffc6",
     "l1_system_config_address": "0xa6b72407e2dc9EBF84b839B69A24C88929cf20F7",
-    "protocol_versions_address": "0x0000000000000000000000000000000000000000",
-    "da_challenge_contract_address": "0x0000000000000000000000000000000000000000"
+    "protocol_versions_address": "0x0000000000000000000000000000000000000000"
 }

--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ test-add-chain:
 	# We separate the first test from the rest because it generates artifacts
 	# Which need to exist before the remaining tests run.
 	TEST_DIRECTORY=./add-chain go run gotest.tools/gotestsum@latest --format testname -- -count=1 -run TestAddChain_Main
-	TEST_DIRECTORY=./add-chain go run gotest.tools/gotestsum@latest --format testname -- -count=1 -run '[^TestAddChain_Main]'
+	TEST_DIRECTORY=./add-chain/... go run gotest.tools/gotestsum@latest --format testname -- -count=1 -run '[^TestAddChain_Main]'
 
 # Test all Go code in the superchain module
 test-superchain: clean-add-chain

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -156,7 +156,8 @@ type AltDAConfig struct {
 	DAChallengeWindow *uint64 `json:"da_challenge_window" toml:"da_challenge_window"`
 	// DA resolve window value set on the DAC contract. Used in altDA mode
 	// to compute when a challenge expires and trigger a reorg if needed.
-	DAResolveWindow *uint64 `json:"da_resolve_window" toml:"da_resolve_window"`
+	DAResolveWindow  *uint64 `json:"da_resolve_window" toml:"da_resolve_window"`
+	DACommitmentType *string `json:"da_commitment_type" toml:"da_commitment_type"`
 }
 
 func (c *ChainConfig) CheckDataAvailability() error {


### PR DESCRIPTION
Fixes https://github.com/ethereum-optimism/superchain-registry/issues/557

Print an error message if any legacy plasma fields are present in the chain's rollup.json when the add-chain command is run. The error message points the user to the docs section that describes how to adjust the rollup.json to use the new `altda` name and config format.
