### PR TITLE
Use optional fields to track either `implementation_address` or `address` in standard contract versions

### DIFF
--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -402,9 +402,9 @@ type ContractBytecodeHashes struct {
 type VersionedContract struct {
 	Version string `toml:"version"`
 	// If the contract is a superchain singleton, it will have a static address
-	Address Address `toml:"implementation_address,omitempty"`
+	Address *Address `toml:"implementation_address,omitempty"`
 	// If the contract is proxied, the implementation will have a static address
-	ImplementationAddress Address `toml:"address,omitempty"`
+	ImplementationAddress *Address `toml:"address,omitempty"`
 }
 
 // ContractVersions represents the desired semantic version of the contracts

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -400,8 +400,11 @@ type ContractBytecodeHashes struct {
 
 // VersionedContract represents a contract that has a semantic version.
 type VersionedContract struct {
-	Version string  `toml:"version"`
-	Address Address `toml:"address,omitempty"`
+	Version string `toml:"version"`
+	// If the contract is a superchain singleton, it will have a static address
+	Address Address `toml:"implementation_address,omitempty"`
+	// If the contract is proxied, the implementation will have a static address
+	ImplementationAddress Address `toml:"address,omitempty"`
 }
 
 // ContractVersions represents the desired semantic version of the contracts

--- a/validation/standard/standard-versions.toml
+++ b/validation/standard/standard-versions.toml
@@ -2,42 +2,41 @@ standard_release = "op-contracts/v1.6.0"
 
 [releases]
 
+# Contracts which are
+#   * unproxied singletons: specify a standard "address"
+#   * proxied             : specify a standard "implementation_address"
+#   * neither             : specify neither a standard "address" nor "implementation_address"
+
 # Fault Proofs https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.6.0
 [releases."op-contracts/v1.6.0"]
-optimism_portal = { version = "3.10.0", address = "0xe2F826324b2faf99E513D16D266c3F80aE87832B" }
-system_config = { version = "2.2.0", address = "0xF56D96B2535B932656d3c04Ebf51baBff241D886" }
-# anchor state registry has a unique address per chain
+optimism_portal = { version = "3.10.0", implementation_address = "0xe2F826324b2faf99E513D16D266c3F80aE87832B" }
+system_config = { version = "2.2.0", implementation_address = "0xF56D96B2535B932656d3c04Ebf51baBff241D886" }
 anchor_state_registry = { version = "2.0.0" }
-delayed_weth = { version = "1.1.0", address = "0x71e966Ae981d1ce531a7b6d23DC0f27B38409087" }
-dispute_game_factory = { version = "1.0.0", address = "0xc641A33cab81C559F2bd4b21EA34C290E2440C2B" }
-# fault dispute game has a unique address per chain
+delayed_weth = { version = "1.1.0", implementation_address = "0x71e966Ae981d1ce531a7b6d23DC0f27B38409087" }
+dispute_game_factory = { version = "1.0.0", implementation_address = "0xc641A33cab81C559F2bd4b21EA34C290E2440C2B" }
 fault_dispute_game = { version = "1.3.0" }
-# permissioned dispute game has a unique address per chain
 permissioned_dispute_game = { version = "1.3.0" }
 mips = { version = "1.1.0", address = "0x16e83cE5Ce29BF90AD9Da06D2fE6a15d5f344ce4" }
 preimage_oracle = { version = "1.1.2", address = "0x9c065e11870B891D214Bc2Da7EF1f9DDFA1BE277" }
 
 # Fault Proofs https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.4.0
 [releases."op-contracts/v1.4.0"]
-optimism_portal = { version = "3.10.0", address = "0xe2F826324b2faf99E513D16D266c3F80aE87832B" }
-system_config = { version = "2.2.0", address = "0xF56D96B2535B932656d3c04Ebf51baBff241D886" }
-# anchor state registry has a unique address per chain
+optimism_portal = { version = "3.10.0", implementation_address = "0xe2F826324b2faf99E513D16D266c3F80aE87832B" }
+system_config = { version = "2.2.0", implementation_address = "0xF56D96B2535B932656d3c04Ebf51baBff241D886" }
 anchor_state_registry = { version = "1.0.0" }
-delayed_weth = { version = "1.0.0", address = "0x97988d5624F1ba266E1da305117BCf20713bee08" }
-dispute_game_factory = { version = "1.0.0", address = "0xc641A33cab81C559F2bd4b21EA34C290E2440C2B" }
-# fault dispute game has a unique address per chain
+delayed_weth = { version = "1.0.0", implementation_address = "0x97988d5624F1ba266E1da305117BCf20713bee08" }
+dispute_game_factory = { version = "1.0.0", implementation_address = "0xc641A33cab81C559F2bd4b21EA34C290E2440C2B" }
 fault_dispute_game = { version = "1.2.0" }
-# permissioned dispute game has a unique address per chain
 permissioned_dispute_game = { version = "1.2.0" }
 mips = { version = "1.0.1", address = "0x0f8EdFbDdD3c0256A80AD8C0F2560B1807873C9c" }
 preimage_oracle = { version = "1.0.0", address = "0xD326E10B8186e90F4E2adc5c13a2d0C137ee8b34" }
 
 # MCP https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.3.0
 [releases."op-contracts/v1.3.0"]
-l1_cross_domain_messenger = { version = "2.3.0", address = "0xD3494713A5cfaD3F5359379DfA074E2Ac8C6Fd65" }
-l1_erc721_bridge = { version = "2.1.0", address = "0xAE2AF01232a6c4a4d3012C5eC5b1b35059caF10d" }
-l1_standard_bridge = { version = "2.1.0", address = "0x64B5a5Ed26DCb17370Ff4d33a8D503f0fbD06CfF" }
-l2_output_oracle = { version = "1.8.0", address = "0xF243BEd163251380e78068d317ae10f26042B292" }
-optimism_mintable_erc20_factory = { version = "1.9.0", address = "0xE01efbeb1089D1d1dB9c6c8b135C934C0734c846" }
-optimism_portal = { version = "2.5.0", address = "0x2D778797049FE9259d947D1ED8e5442226dFB589" }
-system_config = { version = "1.12.0", address = "0xba2492e52F45651B60B8B38d4Ea5E2390C64Ffb1" }
+l1_cross_domain_messenger = { version = "2.3.0", implementation_address = "0xD3494713A5cfaD3F5359379DfA074E2Ac8C6Fd65" }
+l1_erc721_bridge = { version = "2.1.0", implementation_address = "0xAE2AF01232a6c4a4d3012C5eC5b1b35059caF10d" }
+l1_standard_bridge = { version = "2.1.0", implementation_address = "0x64B5a5Ed26DCb17370Ff4d33a8D503f0fbD06CfF" }
+l2_output_oracle = { version = "1.8.0", implementation_address = "0xF243BEd163251380e78068d317ae10f26042B292" }
+optimism_mintable_erc20_factory = { version = "1.9.0", implementation_address = "0xE01efbeb1089D1d1dB9c6c8b135C934C0734c846" }
+optimism_portal = { version = "2.5.0", implementation_address = "0x2D778797049FE9259d947D1ED8e5442226dFB589" }
+system_config = { version = "1.12.0", implementation_address = "0xba2492e52F45651B60B8B38d4Ea5E2390C64Ffb1" }


### PR DESCRIPTION
⚠️ goes into #520 