### PR TITLE
ci: give github action ability to write pr comment

### DIFF
--- a/.github/workflows/diff-workflow.yml
+++ b/.github/workflows/diff-workflow.yml
@@ -20,6 +20,8 @@ on:
 jobs:
   compute-config-diff-and-report-with-pr-comment:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
This github action currently fails because its doesn't have the correct level of perms