### PR TITLE
ci: use proxy for l1 rpc urls

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -92,6 +92,7 @@ jobs:
           name: check git tree is clean
           command: git diff --exit-code
   golang-test:
+    circleci_ip_ranges: true
     shell: /bin/bash -eo pipefail
     executor:
       name: go/default # is based on cimg/go

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -247,7 +247,6 @@ workflows:
       - golang-validate-all:
           context:
             - slack
-            - oplabs-rpc-urls
       - golang-test:
           context:
             - slack
@@ -261,23 +260,16 @@ workflows:
       - golang-promotion-test:
           context:
             - slack
-            - oplabs-rpc-urls
   pr-checks:
     jobs:
       - golang-validate-genesis-allocs:
           matrix:
             parameters:
               chainid: [] # This list will be replaced by the generate_test_config.sh script
-          context:
-            - oplabs-rpc-urls
       - genesis-allocs-all-ok:
           requires: [] # This list will be replaced by the generate_test_config.sh script
-          context:
-            - oplabs-rpc-urls
       - golang-lint
       - golang-modules-tidy
       - golang-test
-      - golang-validate-modified:
-          context:
-            - oplabs-rpc-urls
+      - golang-validate-modified
       - check-codegen

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -114,6 +114,7 @@ jobs:
           channel: C03N11M0BBN # to slack channel `notify-ci-failures`
           # TODO this should also be filtered on modified chains
   golang-validate-modified:
+    circleci_ip_ranges: true
     shell: /bin/bash -eo pipefail
     executor:
       name: go/default # is based on cimg/go
@@ -126,6 +127,7 @@ jobs:
           name: run validation checks
           command: just validate-modified-chains main # TODO ideally this is the base branch
   golang-validate-all:
+    circleci_ip_ranges: true
     shell: /bin/bash -eo pipefail
     executor:
       name: go/default # is based on cimg/go
@@ -140,6 +142,7 @@ jobs:
       - notify-failures-on-main:
           channel: C07GQQZDW1G # to slack channel `notify-superchain-validation-failures`
   golang-promotion-test:
+    circleci_ip_ranges: true
     shell: /bin/bash -eo pipefail
     executor:
       name: go/default # is based on cimg/go
@@ -216,6 +219,7 @@ jobs:
           name: check git tree is clean
           command: git diff --exit-code
   golang-validate-genesis-allocs:
+    circleci_ip_ranges: true
     docker:
       - image: cimg/go:1.21.12-node
     resource_class: medium

--- a/superchain/init.go
+++ b/superchain/init.go
@@ -73,17 +73,20 @@ func init() {
 			GenesisSystemConfigs[chainConfig.ChainID] = &chainConfig.Genesis.SystemConfig
 		}
 
-		runningInCI := os.Getenv("CI")
-		switch superchainEntry.Superchain {
-		case "mainnet":
-			if runningInCI == "true" {
-				fmt.Println("Using ci mainnet rpc")
-				superchainEntry.Config.L1.PublicRPC = "https://ci-mainnet-l1-archive.optimism.io"
-			}
-		case "sepolia", "sepolia-dev-0":
-			if runningInCI == "true" {
-				fmt.Println("Using ci sepolia rpc")
-				superchainEntry.Config.L1.PublicRPC = "https://ci-sepolia-l1-archive.optimism.io"
+		// Impute endpoints only if we're not in codegen mode.
+		if os.Getenv("CODEGEN") == "" {
+			runningInCI := os.Getenv("CI")
+			switch superchainEntry.Superchain {
+			case "mainnet":
+				if runningInCI == "true" {
+					fmt.Println("Using ci mainnet rpc")
+					superchainEntry.Config.L1.PublicRPC = "https://ci-mainnet-l1-archive.optimism.io"
+				}
+			case "sepolia", "sepolia-dev-0":
+				if runningInCI == "true" {
+					fmt.Println("Using ci sepolia rpc")
+					superchainEntry.Config.L1.PublicRPC = "https://ci-sepolia-l1-archive.optimism.io"
+				}
 			}
 		}
 

--- a/superchain/init.go
+++ b/superchain/init.go
@@ -73,22 +73,17 @@ func init() {
 			GenesisSystemConfigs[chainConfig.ChainID] = &chainConfig.Genesis.SystemConfig
 		}
 
-		// Impute endpoints only if we're not in codegen mode.
-		if os.Getenv("CODEGEN") == "" {
-			ciMainnetRPC := os.Getenv("CI_MAINNET_RPC")
-			ciSepoliaRPC := os.Getenv("CI_SEPOLIA_RPC")
-
-			switch superchainEntry.Superchain {
-			case "mainnet":
-				if ciMainnetRPC != "" {
-					fmt.Println("Using env var for mainnet rpc")
-					superchainEntry.Config.L1.PublicRPC = ciMainnetRPC
-				}
-			case "sepolia", "sepolia-dev-0":
-				if ciSepoliaRPC != "" {
-					fmt.Println("Using env var for sepolia rpc")
-					superchainEntry.Config.L1.PublicRPC = ciSepoliaRPC
-				}
+		runningInCI := os.Getenv("CI")
+		switch superchainEntry.Superchain {
+		case "mainnet":
+			if runningInCI == "true" {
+				fmt.Println("Using ci mainnet rpc")
+				superchainEntry.Config.L1.PublicRPC = "https://ci-mainnet-l1-archive.optimism.io"
+			}
+		case "sepolia", "sepolia-dev-0":
+			if runningInCI == "true" {
+				fmt.Println("Using ci sepolia rpc")
+				superchainEntry.Config.L1.PublicRPC = "https://ci-sepolia-l1-archive.optimism.io"
 			}
 		}
 


### PR DESCRIPTION
Use the proxy urls instead of secrets stored in ci so that ci can securely access the endpoints for the validation jobs that require archive nodes