### PR TITLE
Remove println statement

### DIFF
--- a/superchain/init.go
+++ b/superchain/init.go
@@ -79,12 +79,10 @@ func init() {
 			switch superchainEntry.Superchain {
 			case "mainnet":
 				if runningInCI == "true" {
-					fmt.Println("Using ci mainnet rpc")
 					superchainEntry.Config.L1.PublicRPC = "https://ci-mainnet-l1-archive.optimism.io"
 				}
 			case "sepolia", "sepolia-dev-0":
 				if runningInCI == "true" {
-					fmt.Println("Using ci sepolia rpc")
 					superchainEntry.Config.L1.PublicRPC = "https://ci-sepolia-l1-archive.optimism.io"
 				}
 			}


### PR DESCRIPTION
They break op-geth CI by printing during op-geth startup (when run in CI). e.g. https://app.circleci.com/pipelines/github/ethereum-optimism/op-geth/2205/workflows/730cd501-b6ba-46a3-825c-b9fbcb2a8354/jobs/6810

```
--- FAIL: TestT9n (0.04s)
    t8n_test.go:516: args:
         go run . t9n --input.txs ./testdata/15/signed_txs.rlp --state.fork Homestead
    t8n_test.go:527: Using ci mainnet rpc
        Using ci sepolia rpc
        Using ci sepolia rpc
        [
          {
            "error": "transaction type not supported",
            "hash": "0xa98a24882ea90916c6a86da650fbc6b14238e46f0af04a131ce92be897507476"
          },
          {
            "error": "transaction type not supported",
            "hash": "0x36bad80acce7040c45fd32764b5c2b2d2e6f778669fb41791f73f546d56e739a"
          }
        ]
    t8n_test.go:528: test 0, json parsing failed: invalid character 'U' looking for beginning of value
```

It does seem very odd that these URLs are being hard coded as part of the `init` which runs in every program that imports the bindings. I suspect they should be set as env vars in the CI config (not as secrets - can just be set directly in the CircleCI `config.yaml`).