### PR TITLE
ethernity(mainnet): remove placeholder custom gas token address

### DIFF
--- a/chainList.json
+++ b/chainList.json
@@ -48,8 +48,7 @@
     "parent": {
       "type": "L2",
       "chain": "mainnet"
-    },
-    "gasPayingToken": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+    }
   },
   {
     "name": "Lisk",

--- a/chainList.toml
+++ b/chainList.toml
@@ -30,7 +30,6 @@
   explorers = ["https://ernscan.io"]
   superchain_level = 0
   data_availability_type = "eth-da"
-  gas_paying_token = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
   [chains.parent]
     type = "L2"
     chain = "mainnet"

--- a/superchain/configs/configs.json
+++ b/superchain/configs/configs.json
@@ -108,7 +108,7 @@
             "eip1559Denominator": 1000,
             "eip1559DenominatorCanyon": 1000
           },
-          "GasPayingToken": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+          "GasPayingToken": null,
           "genesis": {
             "l1": {
               "hash": "0xbb7ad201b0ab296465865642878e9256e0fa4a3f8d06bca1f3e5c5b54be6be90",

--- a/superchain/configs/mainnet/ethernity.toml
+++ b/superchain/configs/mainnet/ethernity.toml
@@ -15,7 +15,6 @@ block_time = 2
 seq_window_size = 3600
 max_sequencer_drift = 600
 data_availability_type = "eth-da"
-gas_paying_token = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
 
 [optimism]
   eip1559_elasticity = 20


### PR DESCRIPTION
The gas token address stored in Ethernity's chain config was a placeholder and not being used. The chain is not actually configured to use a custom gas token. This pr removes that placeholder