### PR TITLE
feat: support loading config externally

### DIFF
--- a/superchain/init.go
+++ b/superchain/init.go
@@ -1,7 +1,9 @@
 package superchain
 
 import (
+	"embed"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"strings"
@@ -25,53 +27,7 @@ func init() {
 		}
 
 		// Load superchain-target config
-		superchainConfigData, err := superchainFS.ReadFile(path.Join("configs", s.Name(), "superchain.toml"))
-		if err != nil {
-			panic(fmt.Errorf("failed to read superchain config: %w", err))
-		}
-		var superchainEntry Superchain
-		if err := unMarshalSuperchainConfig(superchainConfigData, &superchainEntry.Config); err != nil {
-			panic(fmt.Errorf("failed to decode superchain config: %w", err))
-		}
-		superchainEntry.Superchain = s.Name()
-
-		// iterate over the chains of this superchain-target
-		chainEntries, err := superchainFS.ReadDir(path.Join("configs", s.Name()))
-		if err != nil {
-			panic(fmt.Errorf("failed to read superchain dir: %w", err))
-		}
-		for _, c := range chainEntries {
-			if !isConfigFile(c) {
-				continue
-			}
-			// load chain config
-			chainConfigData, err := superchainFS.ReadFile(path.Join("configs", s.Name(), c.Name()))
-			if err != nil {
-				panic(fmt.Errorf("failed to read superchain config %s/%s: %w", s.Name(), c.Name(), err))
-			}
-			var chainConfig ChainConfig
-
-			if err := toml.Unmarshal(chainConfigData, &chainConfig); err != nil {
-				panic(fmt.Errorf("failed to decode chain config %s/%s: %w", s.Name(), c.Name(), err))
-			}
-			chainConfig.Chain = strings.TrimSuffix(c.Name(), ".toml")
-
-			(&chainConfig).setNilHardforkTimestampsToDefaultOrZero(&superchainEntry.Config)
-
-			MustBeValidSuperchainLevel(chainConfig)
-
-			chainConfig.Superchain = s.Name()
-			if other, ok := OPChains[chainConfig.ChainID]; ok {
-				panic(fmt.Errorf("found chain config %q in superchain target %q with chain ID %d "+
-					"conflicts with chain %q in superchain %q and chain ID %d",
-					chainConfig.Name, chainConfig.Superchain, chainConfig.ChainID,
-					other.Name, other.Superchain, other.ChainID))
-			}
-			superchainEntry.ChainIDs = append(superchainEntry.ChainIDs, chainConfig.ChainID)
-			OPChains[chainConfig.ChainID] = &chainConfig
-			Addresses[chainConfig.ChainID] = &chainConfig.Addresses
-			GenesisSystemConfigs[chainConfig.ChainID] = &chainConfig.Genesis.SystemConfig
-		}
+		superchainEntry := LoadSuperchain(superchainFS, s)
 
 		// Impute endpoints only if we're not in codegen mode.
 		if os.Getenv("CODEGEN") == "" {
@@ -90,6 +46,58 @@ func init() {
 
 		Superchains[superchainEntry.Superchain] = &superchainEntry
 	}
+}
+
+// Load superchain-target config and all configs of the chains in the superchain-target.
+func LoadSuperchain(superchainFS embed.FS, s fs.DirEntry) Superchain {
+	superchainConfigData, err := superchainFS.ReadFile(path.Join("configs", s.Name(), "superchain.toml"))
+	if err != nil {
+		panic(fmt.Errorf("failed to read superchain config: %w", err))
+	}
+	var superchainEntry Superchain
+	if err := unMarshalSuperchainConfig(superchainConfigData, &superchainEntry.Config); err != nil {
+		panic(fmt.Errorf("failed to decode superchain config: %w", err))
+	}
+	superchainEntry.Superchain = s.Name()
+
+	// iterate over the chains of this superchain-target
+	chainEntries, err := superchainFS.ReadDir(path.Join("configs", s.Name()))
+	if err != nil {
+		panic(fmt.Errorf("failed to read superchain dir: %w", err))
+	}
+	for _, c := range chainEntries {
+		if !isConfigFile(c) {
+			continue
+		}
+
+		chainConfigData, err := superchainFS.ReadFile(path.Join("configs", s.Name(), c.Name()))
+		if err != nil {
+			panic(fmt.Errorf("failed to read superchain config %s/%s: %w", s.Name(), c.Name(), err))
+		}
+		var chainConfig ChainConfig
+
+		if err := toml.Unmarshal(chainConfigData, &chainConfig); err != nil {
+			panic(fmt.Errorf("failed to decode chain config %s/%s: %w", s.Name(), c.Name(), err))
+		}
+		chainConfig.Chain = strings.TrimSuffix(c.Name(), ".toml")
+
+		(&chainConfig).setNilHardforkTimestampsToDefaultOrZero(&superchainEntry.Config)
+
+		MustBeValidSuperchainLevel(chainConfig)
+
+		chainConfig.Superchain = s.Name()
+		if other, ok := OPChains[chainConfig.ChainID]; ok {
+			panic(fmt.Errorf("found chain config %q in superchain target %q with chain ID %d "+
+				"conflicts with chain %q in superchain %q and chain ID %d",
+				chainConfig.Name, chainConfig.Superchain, chainConfig.ChainID,
+				other.Name, other.Superchain, other.ChainID))
+		}
+		superchainEntry.ChainIDs = append(superchainEntry.ChainIDs, chainConfig.ChainID)
+		OPChains[chainConfig.ChainID] = &chainConfig
+		Addresses[chainConfig.ChainID] = &chainConfig.Addresses
+		GenesisSystemConfigs[chainConfig.ChainID] = &chainConfig.Genesis.SystemConfig
+	}
+	return superchainEntry
 }
 
 func MustBeValidSuperchainLevel(chainConfig ChainConfig) {


### PR DESCRIPTION
Move the config loading code to a public function so that the external repo (e.g., optimism) can load a custom chain config locally (e.g., a devnet config or a custom rollup config loaded in op-program).
