### PR TITLE
updating Ethernity to match ethereum-lists

### DIFF
--- a/chainList.json
+++ b/chainList.json
@@ -34,7 +34,7 @@
     }
   },
   {
-    "name": "Ethernity Mainnet",
+    "name": "Ethernity",
     "identifier": "mainnet/ethernity",
     "chainId": 183,
     "rpc": [

--- a/chainList.toml
+++ b/chainList.toml
@@ -23,7 +23,7 @@
     chain = "mainnet"
 
 [[chains]]
-  name = "Ethernity Mainnet"
+  name = "Ethernity"
   identifier = "mainnet/ethernity"
   chain_id = 183
   rpc = ["https://mainnet.ethernitychain.io"]

--- a/superchain/configs/configs.json
+++ b/superchain/configs/configs.json
@@ -83,7 +83,7 @@
           }
         },
         {
-          "Name": "Ethernity Mainnet",
+          "Name": "Ethernity",
           "l2_chain_id": 183,
           "PublicRPC": "https://mainnet.ethernitychain.io",
           "SequencerRPC": "https://mainnet.ethernitychain.io",

--- a/superchain/configs/mainnet/ethernity.toml
+++ b/superchain/configs/mainnet/ethernity.toml
@@ -1,4 +1,4 @@
-name = "Ethernity Mainnet"
+name = "Ethernity"
 chain_id = 183
 public_rpc = "https://mainnet.ethernitychain.io"
 sequencer_rpc = "https://mainnet.ethernitychain.io"


### PR DESCRIPTION
<!--
This default template is a guide for PRs adding new chains to the registry.
For other types of PRs, please delete this template and write a brief description of your 
code changes and rationale.
 -->

# Description

Currently the CI is [failing](https://app.circleci.com/pipelines/github/ethereum-optimism/superchain-registry/8542/workflows/0d9e2c64-8122-4b79-8ebb-299db164099a/jobs/32464) because the name of the chain does not match what is in [ethereum-lists](https://github.com/ethereum-lists/chains/blob/4228c3fc7fc806f8385db4fab3f4e0564d3b8233/_data/chains/eip155-183.json#L4).

I've updated the chain name from "Ethernity Mainnet" to "Ethernity" for consistency and so the CI validation passes.
