### PR TITLE
validation: update monorepo import, op-program governanceApproved versions

### DIFF
--- a/add-chain/go.mod
+++ b/add-chain/go.mod
@@ -8,7 +8,7 @@ replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth 
 
 require (
 	github.com/BurntSushi/toml v1.4.0
-	github.com/ethereum-optimism/optimism v1.9.5-0.20241021150032-1e59d08322f8
+	github.com/ethereum-optimism/optimism v1.9.5-0.20241023091529-83117192d461
 	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac
 	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20240910145426-b3905c89e8ac
 	github.com/ethereum/go-ethereum v1.14.11

--- a/add-chain/go.sum
+++ b/add-chain/go.sum
@@ -63,8 +63,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 h1:rpfIENRNNilwHwZeG5+P150SMrnN
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/ethereum-optimism/op-geth v1.101408.0-rc.4.0.20240828150145-60038121c757 h1:egacojEWb68ew7vq0eyeOhM7XI2Soit/Xv1jXhVzRho=
 github.com/ethereum-optimism/op-geth v1.101408.0-rc.4.0.20240828150145-60038121c757/go.mod h1:boCyfYcCK/lDcL1JA5daLc2qgvULU1zKcVtUJ605eGc=
-github.com/ethereum-optimism/optimism v1.9.5-0.20241021150032-1e59d08322f8 h1:bhG/9dttuyOPZZUhMb3e5zApDunSAE5a8sy42P/V7sw=
-github.com/ethereum-optimism/optimism v1.9.5-0.20241021150032-1e59d08322f8/go.mod h1:5vH0W+a+76TjhxA//o8jr5d/zouHQaFtspVu0N2jumk=
+github.com/ethereum-optimism/optimism v1.9.5-0.20241023091529-83117192d461 h1:Jz5hzPgRZ6DMy87e6VB8u7/KmnyACvKMPQ93Z0yLL2k=
+github.com/ethereum-optimism/optimism v1.9.5-0.20241023091529-83117192d461/go.mod h1:pA+0LrOL45eGFQeOzkkPDojBPlSRVCXvpx6NsB5Am6M=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac h1:hCIrLuOPV3FJfMDvXeOhCC3uQNvFoMIIlkT2mN2cfeg=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac/go.mod h1:XaVXL9jg8BcyOeugECgIUGa9Y3DjYJj71RHmb5qon6M=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20240910145426-b3905c89e8ac h1:j4mXxx+SFIx7AXLWhRqC5VuSNc39OY8BcPBlMC5qFJs=

--- a/validation/go.mod
+++ b/validation/go.mod
@@ -8,7 +8,7 @@ replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth 
 
 require (
 	github.com/BurntSushi/toml v1.4.0
-	github.com/ethereum-optimism/optimism v1.9.5-0.20241021150032-1e59d08322f8
+	github.com/ethereum-optimism/optimism v1.9.5-0.20241023091529-83117192d461
 	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac
 	github.com/ethereum/go-ethereum v1.14.11
 	github.com/google/go-cmp v0.6.0

--- a/validation/go.sum
+++ b/validation/go.sum
@@ -63,8 +63,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 h1:rpfIENRNNilwHwZeG5+P150SMrnN
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/ethereum-optimism/op-geth v1.101408.0-rc.4.0.20240828150145-60038121c757 h1:egacojEWb68ew7vq0eyeOhM7XI2Soit/Xv1jXhVzRho=
 github.com/ethereum-optimism/op-geth v1.101408.0-rc.4.0.20240828150145-60038121c757/go.mod h1:boCyfYcCK/lDcL1JA5daLc2qgvULU1zKcVtUJ605eGc=
-github.com/ethereum-optimism/optimism v1.9.5-0.20241021150032-1e59d08322f8 h1:bhG/9dttuyOPZZUhMb3e5zApDunSAE5a8sy42P/V7sw=
-github.com/ethereum-optimism/optimism v1.9.5-0.20241021150032-1e59d08322f8/go.mod h1:5vH0W+a+76TjhxA//o8jr5d/zouHQaFtspVu0N2jumk=
+github.com/ethereum-optimism/optimism v1.9.5-0.20241023091529-83117192d461 h1:Jz5hzPgRZ6DMy87e6VB8u7/KmnyACvKMPQ93Z0yLL2k=
+github.com/ethereum-optimism/optimism v1.9.5-0.20241023091529-83117192d461/go.mod h1:pA+0LrOL45eGFQeOzkkPDojBPlSRVCXvpx6NsB5Am6M=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac h1:hCIrLuOPV3FJfMDvXeOhCC3uQNvFoMIIlkT2mN2cfeg=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac/go.mod h1:XaVXL9jg8BcyOeugECgIUGa9Y3DjYJj71RHmb5qon6M=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=


### PR DESCRIPTION
Previous import labelled all op-program prestate releases as governanceApproved. 

See https://github.com/ethereum-optimism/optimism/pull/12552 and https://github.com/ethereum-optimism/optimism/pull/12538 for details