### PR TITLE
chore: update default genesis commit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,9 +32,9 @@ SCR_DEPLOY_CONFIG=${SCR_MONOREPO_DIR}/packages/contracts-bedrock/deploy-config/g
 # This is the commit in the https://github.com/ethereum-optimism/optimism/ repo
 # at which the chain's genesis was created. This is necessary to have our validation checks
 # recreate the genesis file using identical source code. By default the commit for tag
-# op-contracts/1.6.0 is used below, but can be changed if the contracts were deployed from
-# a different commit.
-SCR_GENESIS_CREATION_COMMIT="33f06d2d5e4034125df02264a5ffe84571bd0359"
+# op-contracts/v1.7.0-beta.1+l2-contracts is used below, but can be changed if the contracts
+# were deployed from a different commit.
+SCR_GENESIS_CREATION_COMMIT="5e14a61547a45eef2ebeba677aee4a049f106ed8"
 
 # Your chain's endpoint for ETHEREUM JSON-RPC requests
 SCR_PUBLIC_RPC="http://awe.some.rpc" # new OP Stack L2 RPC URL


### PR DESCRIPTION
[`op-contracts/v1.7.0-beta.1+l2-contracts`](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv.1.7.0-beta.1%2Bl2-contracts) is currently the version that new standard chains should use for the L2 contracts in genesis (`op-contracts/v1.6.0` is still the version used for L1 contracts)