### PR TITLE
Regenerated genesis bug

### DIFF
--- a/validation/genesis/genesis-allocs_test.go
+++ b/validation/genesis/genesis-allocs_test.go
@@ -159,6 +159,21 @@ func testGenesisAllocs(t *testing.T, chain *ChainConfig) {
 		require.NoError(t, err)
 		allocs := types.GenesisAlloc{}
 		err = json.Unmarshal(expectedData, &allocs)
+		for _, account := range allocs {
+			toDelete := make([]common.Hash, 0)
+
+			for slot, value := range account.Storage {
+				if value == (common.Hash{}) {
+					toDelete = append(toDelete, slot)
+				}
+			}
+
+			for _, slot := range toDelete {
+				delete(account.Storage, slot)
+				t.Log("Removed empty storage slot: ", slot.Hex())
+			}
+		}
+
 		require.NoError(t, err)
 		expectedData, err = json.MarshalIndent(allocs, "", " ")
 		require.NoError(t, err)

--- a/validation/genesis/genesis-allocs_test.go
+++ b/validation/genesis/genesis-allocs_test.go
@@ -221,17 +221,11 @@ func testGenesisAllocs(t *testing.T, chain *ChainConfig) {
 // This function removes empty storage slots as we know declaring empty slots is functionally equivalent to not declaring them.
 func removeEmptyStorageSlots(allocs types.GenesisAlloc, t *testing.T) {
 	for _, account := range allocs {
-		toDelete := make([]common.Hash, 0)
-
 		for slot, value := range account.Storage {
 			if value == (common.Hash{}) {
-				toDelete = append(toDelete, slot)
+				delete(account.Storage, slot)
+				t.Log("Removed empty storage slot: ", slot.Hex())
 			}
-		}
-
-		for _, slot := range toDelete {
-			delete(account.Storage, slot)
-			t.Log("Removed empty storage slot: ", slot.Hex())
 		}
 	}
 }


### PR DESCRIPTION
Discoverd in this [pr](https://github.com/ethereum-optimism/superchain-registry/pull/648), we found that the regenerated genesis contains storage allocations that have zero as the value field. This causes the genesis allocs test to fail because op-deployer doesn't do this, nor should it. 

