### PR TITLE
feat: expanding the allowed block time range for mainnet from 2,2 to 1,2.

### DIFF
--- a/validation/standard/standard-config-params-mainnet.toml
+++ b/validation/standard/standard-config-params-mainnet.toml
@@ -2,7 +2,7 @@
 [rollup_config]
 # alt_da must be nil
 seq_window_size = [3600, 3600]
-block_time = [2, 2]
+block_time = [1, 2]
 
 [optimism_portal_2]
 proof_maturity_delay_seconds = [604800, 604800]        # 7 days


### PR DESCRIPTION
As per mainnet testing in this [pr](https://github.com/ethereum-optimism/superchain-registry/pull/651/files#diff-7f4b8430f708ffe952268c328a5e100b1ddcc168b92c8bcb4322561c3196fa21), we discovered that the superchain-registry requires the allowed block times for mainnet to be expanded from 2,2 to 1,2 (`lower_bound`,`upper_bound` respectively). 