### PR TITLE
validation: check all contracts for correct superchainConfig()

### DIFF
--- a/add-chain/main.go
+++ b/add-chain/main.go
@@ -90,7 +90,6 @@ func entrypoint(ctx *cli.Context) error {
 	sequencerRPC := ctx.String(flags.SequencerRpcFlag.Name)
 	explorer := ctx.String(flags.ExplorerFlag.Name)
 	superchainTarget := ctx.String(flags.SuperchainTargetFlag.Name)
-	monorepoDir := ctx.String(flags.MonorepoDirFlag.Name)
 
 	chainName := ctx.String(flags.ChainNameFlag.Name)
 	rollupConfigPath := ctx.String(flags.RollupConfigFlag.Name)
@@ -114,7 +113,6 @@ func entrypoint(ctx *cli.Context) error {
 	fmt.Printf("Chain Short Name:               %s\n", chainShortName)
 	fmt.Printf("Superchain target:              %s\n", superchainTarget)
 	fmt.Printf("Superchain-registry repo dir:   %s\n", superchainRepoRoot)
-	fmt.Printf("Monorepo dir:                   %s\n", monorepoDir)
 	fmt.Printf("Deployments directory:          %s\n", deploymentsDir)
 	fmt.Printf("Rollup config filepath:         %s\n", rollupConfigPath)
 	fmt.Printf("Genesis filepath:               %s\n", genesisPath)

--- a/add-chain/main.go
+++ b/add-chain/main.go
@@ -90,6 +90,7 @@ func entrypoint(ctx *cli.Context) error {
 	sequencerRPC := ctx.String(flags.SequencerRpcFlag.Name)
 	explorer := ctx.String(flags.ExplorerFlag.Name)
 	superchainTarget := ctx.String(flags.SuperchainTargetFlag.Name)
+	monorepoDir := ctx.String(flags.MonorepoDirFlag.Name)
 
 	chainName := ctx.String(flags.ChainNameFlag.Name)
 	rollupConfigPath := ctx.String(flags.RollupConfigFlag.Name)
@@ -113,6 +114,7 @@ func entrypoint(ctx *cli.Context) error {
 	fmt.Printf("Chain Short Name:               %s\n", chainShortName)
 	fmt.Printf("Superchain target:              %s\n", superchainTarget)
 	fmt.Printf("Superchain-registry repo dir:   %s\n", superchainRepoRoot)
+	fmt.Printf("Monorepo dir:                   %s\n", monorepoDir)
 	fmt.Printf("Deployments directory:          %s\n", deploymentsDir)
 	fmt.Printf("Rollup config filepath:         %s\n", rollupConfigPath)
 	fmt.Printf("Genesis filepath:               %s\n", genesisPath)

--- a/validation/superchain-config_test.go
+++ b/validation/superchain-config_test.go
@@ -20,12 +20,27 @@ func testSuperchainConfig(t *testing.T, chain *ChainConfig) {
 
 	client, err := ethclient.Dial(rpcEndpoint)
 	require.NoErrorf(t, err, "could not dial rpc endpoint %s", rpcEndpoint)
-	opp := Addresses[chain.ChainID].OptimismPortalProxy
 
-	got, err := getAddress("superchainConfig()", opp, client)
+	checkSuperchainConfig(t, client, Addresses[chain.ChainID].OptimismPortalProxy, *expected)
+	checkSuperchainConfig(t, client, Addresses[chain.ChainID].AnchorStateRegistryProxy, *expected)
+	checkSuperchainConfig(t, client, Addresses[chain.ChainID].L1CrossDomainMessengerProxy, *expected)
+	checkSuperchainConfig(t, client, Addresses[chain.ChainID].L1ERC721BridgeProxy, *expected)
+	checkSuperchainConfig(t, client, Addresses[chain.ChainID].L1StandardBridgeProxy, *expected)
+
+	// DelayedWETHProxy uses a different method name, so it is broken out here
+	delayedWETHAddress := Addresses[chain.ChainID].DelayedWETHProxy
+	got, err := getAddress("config()", delayedWETHAddress, client)
+	require.NoError(t, err)
+	if *expected != got {
+		t.Errorf("incorrect config() address: got %s, wanted %s (queried %s)", got, expected, delayedWETHAddress)
+	}
+}
+
+func checkSuperchainConfig(t *testing.T, client *ethclient.Client, targetContract Address, expected Address) {
+	got, err := getAddress("superchainConfig()", targetContract, client)
 	require.NoError(t, err)
 
-	if *expected != got {
-		t.Errorf("incorrect OptimismPortal.superchainConfig() address: got %s, wanted %s", got, *expected)
+	if expected != got {
+		t.Errorf("incorrect superchainConfig() address: got %s, wanted %s (queried %s)", got, expected, targetContract)
 	}
 }


### PR DESCRIPTION
Updates the `testSuperchainConfig` to ensure that the following contracts are all pointed at the standard superchain-wide `SuperchainConfig` contract.
```
* AnchorStateRegistry
* DelayedWETH
* L1CrossDomainMessenger
* L1ERC721Bridge
* L1StandardBridge
* OptimismPortal
```
Previously we were only checking the OptimismPortal contract

### Tests
I manually ran the following to ensure our existing standard chains pass this test:
```
just validate 10 // op-mainnet
just validate 11155420 // op-sepolia
```