### PR TITLE
validation: retry search for batcher txs

### DIFF
--- a/validation/data-availability-type_test.go
+++ b/validation/data-availability-type_test.go
@@ -37,7 +37,7 @@ func testDataAvailabilityType(t *testing.T, chain *ChainConfig) {
 	depth := chain.SequencerWindowSize
 	require.NotZero(t, depth)
 
-	blockNum, found, err := retry.Do2(context.Background(), 3, retry.Exponential(), func() (uint64, bool, error) {
+	blockNum, found, err := retry.Do2(context.Background(), DefaultMaxRetries, retry.Exponential(), func() (uint64, bool, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
 		defer cancel()
 		// First attempt without needing an archive node

--- a/validation/data-availability-type_test.go
+++ b/validation/data-availability-type_test.go
@@ -51,7 +51,7 @@ func testDataAvailabilityType(t *testing.T, chain *ChainConfig) {
 			blockNum, found, err = eth.CheckRecentTxs(ctx, client, int(depth), common.Address(batchSubmitterAddress))
 		}
 
-		return blockNum, found, nil
+		return blockNum, found, err
 	})
 	require.NoErrorf(t, err, "failed when checking chain for recent batcher txs from %s", batchSubmitterAddress)
 	require.True(t, found, "failed to find recent batcher tx")

--- a/validation/data-availability-type_test.go
+++ b/validation/data-availability-type_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/superchain-registry/superchain"
 	. "github.com/ethereum-optimism/superchain-registry/superchain"
 	"github.com/stretchr/testify/require"
@@ -33,22 +34,25 @@ func testDataAvailabilityType(t *testing.T, chain *ChainConfig) {
 	batchInboxAddress := chain.BatchInboxAddr
 	require.NotZero(t, batchInboxAddress)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
 	depth := chain.SequencerWindowSize
 	require.NotZero(t, depth)
 
-	// First attempt without needing an archive node
-	//  - full nodes keep the last 128 blocks but we use 120 to give a buffer
-	nonArchivalDepth := 120
-	blockNum, found, err := eth.CheckRecentTxs(ctx, client, nonArchivalDepth, common.Address(batchSubmitterAddress))
-	if !found {
-		if err != nil {
-			t.Log("failed to check recent batcher txs, will attempt retry")
+	blockNum, found, err := retry.Do2(context.Background(), 3, retry.Exponential(), func() (uint64, bool, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+		defer cancel()
+		// First attempt without needing an archive node
+		//  - full nodes keep the last 128 blocks but we use 120 to give a buffer
+		nonArchivalDepth := 120
+		blockNum, found, err := eth.CheckRecentTxs(ctx, client, nonArchivalDepth, common.Address(batchSubmitterAddress))
+		if !found {
+			if err != nil {
+				t.Log("failed to check recent batcher txs, will attempt retry")
+			}
+			blockNum, found, err = eth.CheckRecentTxs(ctx, client, int(depth), common.Address(batchSubmitterAddress))
 		}
-		blockNum, found, err = eth.CheckRecentTxs(ctx, client, int(depth), common.Address(batchSubmitterAddress))
-	}
+
+		return blockNum, found, nil
+	})
 	require.NoErrorf(t, err, "failed when checking chain for recent batcher txs from %s", batchSubmitterAddress)
 	require.True(t, found, "failed to find recent batcher tx")
 

--- a/validation/retry.go
+++ b/validation/retry.go
@@ -6,10 +6,11 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 )
 
+const DefaultMaxRetries = 3
+
 func Retry[S, T any](fn func(S) (T, error)) func(S) (T, error) {
-	const maxAttempts = 3
 	return func(s S) (T, error) {
-		return retry.Do(context.Background(), maxAttempts, retry.Exponential(), func() (T, error) {
+		return retry.Do(context.Background(), DefaultMaxRetries, retry.Exponential(), func() (T, error) {
 			return fn(s)
 		})
 	}


### PR DESCRIPTION
Adds retries and extends timeout for search for recent batcher txs (part of data-availability validation tests).

Should help with this sort of failure: https://oplabs-pbc.slack.com/archives/C07GQQZDW1G/p1731460421066029