### PR TITLE
validation: unmarshal standard release into exported struct member

### DIFF
--- a/validation/standard/init.go
+++ b/validation/standard/init.go
@@ -42,10 +42,13 @@ func init() {
 	// Get the single standard release Tag (universal across superchain targets)
 	// and store in the standard.Release
 	temp := new(struct {
-		sr Tag `toml:"standard_release,omitempty"`
+		Sr string `toml:"standard_release"`
 	})
 	decodeTOMLFileIntoConfig("standard-releases.toml", temp)
-	Release = temp.sr
+	Release = Tag(temp.Sr)
+	if Release == "" {
+		panic("empty standard release")
+	}
 }
 
 func decodeTOMLFileIntoConfig[


### PR DESCRIPTION
and panic if we get an empty string.

This fixes a bug where the effective standard contract versions were not bound to the TOML files properly. This was causing contract version validation to **always pass** regardless of the contract versions used by any particular chain. 

