### PR TITLE
Grammar Fixes in Documentation Files

### DIFF
--- a/docs/hardfork-activation-inheritance.md
+++ b/docs/hardfork-activation-inheritance.md
@@ -1,6 +1,6 @@
 # Hardfork activation inheritance behavior
 
-This documents specifies how hardfork activations are coordinated between _standard_ chains via the superchain-registry.
+This document specifies how hardfork activations are coordinated between _standard_ chains via the superchain-registry.
 
 Frontier chains can freely choose when to activate hardforks.
 

--- a/validation/standard/readme.md
+++ b/validation/standard/readme.md
@@ -5,5 +5,5 @@ Distinct, named declaration files have been added (where necessary) to allow tes
 
 Parameters may be declared to be equal to a pair of values, meaning that the parameter must be within the bounds defined by those values.
 
-The TOML files are embedded into Go bindings, which are in turn references by the validation checks in the parent directory. The entrypoint for those checks is [`validation_test.go`](../validation_test.go).
+The TOML files are embedded into Go bindings, which are in turn referenced by the validation checks in the parent directory. The entrypoint for those checks is [`validation_test.go`](../validation_test.go).
 


### PR DESCRIPTION
1. In docs/hardfork-activation-inheritance.md:
   "documents" → "document"
Reason: Singular form needed for subject-verb agreement
2. In validation/standard/readme.md:
  "references" → "referenced"
Reason: Past participle form needed for passive voice construction
