### PR TITLE
Fix grammar and spelling in code comments and error messages

### DIFF
--- a/superchain/internal/codegen/main.go
+++ b/superchain/internal/codegen/main.go
@@ -67,7 +67,7 @@ func main() {
 			case Frontier:
 				frontierChains = append(frontierChains, chainEntry)
 			default:
-				panic(fmt.Sprintf("unknown SuperchanLevel %d", chain.SuperchainLevel))
+				panic(fmt.Sprintf("unknown SuperchainLevel %d", chain.SuperchainLevel))
 			}
 		}
 		allChains = append(allChains, standardChains...)

--- a/validation/genesis/genesis-allocs_test.go
+++ b/validation/genesis/genesis-allocs_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 	thisDir := filepath.Dir(filename)
 	temporaryOptimismDir = path.Join(thisDir, "../../../optimism-temporary")
 
-	// Clone the repo if it the folder doesn't exist
+	// Clone the repo if the folder doesn't exist
 	_, err := os.Stat(temporaryOptimismDir)
 	needToClone := os.IsNotExist(err)
 	if needToClone {

--- a/validation/superchain-version.go
+++ b/validation/superchain-version.go
@@ -48,7 +48,7 @@ func checkForStandardVersions(t *testing.T, chain *ChainConfig) {
 	}
 }
 
-// getContractVersionsFromChain pulls the appropriate contract versions from chain
+// getContractVersionsFromChain pulls the appropriate contract versions from the chain
 // using the supplied client (calling the version() method for each contract). It does this concurrently.
 func getContractVersionsFromChain(list AddressList, client *ethclient.Client, chain *ChainConfig) (ContractVersions, error) {
 	// Prepare a concurrency-safe object to store version information in, and
@@ -237,7 +237,7 @@ func getBytecodeHash(ctx context.Context, chainID uint64, contractName string, t
 		return "", fmt.Errorf("%s: %w", addrToCheck, err)
 	}
 
-	// if the contract is known to have immutables, setup the filterer to mask the bytes which contain the variable's value
+	// if the contract is known to have immutables, set up the filterer to mask the bytes which contain the variable's value
 	tag := standard.Release
 	bytecodeImmutableFilterer, err := initBytecodeImmutableMask(code, tag, contractName)
 	// error indicates that the contract _does_ have immutables, but we weren't able to determine the coordinates of the immutables in the bytecode


### PR DESCRIPTION
1. In `validation/superchain-version.go`:
- Added missing article "the" in comments:
  - "from chain" -> "from the chain"
  (Added "the" for proper English grammar with specific nouns)
- Fixed phrasal verb usage:
  - "setup the filterer" -> "set up the filterer"
  ("set up" is the correct verb form, while "setup" is a noun)

2. In `superchain/internal/codegen/main.go`:
- Fixed capitalization in error message:
  - "SuperchainLevel" -> "SuperchainLevel"

3. In `validation/genesis/genesis-allocs_test.go`:
- Fixed grammar in comment:
  - "if it the folder" -> "if the folder"