### PR TITLE
ci: Change executor to alpine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,15 +8,29 @@ orbs:
 
 jobs:
   setup-genesis-allocs-validation:
-    macos:
-      xcode: 14.2.0
-    resource_class: macos.m1.medium.gen1
+    docker:
+      - image: alpine:latest
     steps:
       - checkout
       - run:
+          name: Install Git, yq, and jq
+          command: |
+            apk add --no-cache git jq curl
+            curl -sLo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+            chmod +x /usr/local/bin/yq
+      - run:
+          name: Verify Git
+          command: git --version
+      - run:
+          name: Verify yq
+          command: yq --version
+      - run:
+          name: Verify jq
+          command: jq --version
+      - run:
           name: Generate list of chainids and insert into  continue_config.yml file
           command: |
-            bash validation/genesis/validation-inputs/generate-test-config.sh
+            sh validation/genesis/validation-inputs/generate-test-config.sh
       - continuation/continue:
           configuration_path: .circleci/continue_config.yml
           parameters: '{}'

--- a/validation/genesis/validation-inputs/generate-test-config.sh
+++ b/validation/genesis/validation-inputs/generate-test-config.sh
@@ -34,9 +34,6 @@ prependedTargets=${prependedTargets%,}
 # Wrap in square brackets
 prependedTargets="[$prependedTargets]"
 
-# Install yq
-brew install yq
-
 # Use yq to replace the target-version   key
 yq e ".workflows.pr-checks.jobs[0].golang-validate-genesis-allocs.matrix.parameters.chainid = $targets" -i .circleci/continue_config.yml
 yq e ".workflows.pr-checks.jobs[1].genesis-allocs-all-ok.requires = $prependedTargets" -i .circleci/continue_config.yml


### PR DESCRIPTION
We're seeing the `setup` CI job (which launches the rest of the CI jobs using circleCI's continue feature https://circleci.com/docs/using-dynamic-configuration/) fail on some homebrew installation step.

This PR moves to a more minimal and robust executor.