### PR TITLE
validation: get bytecode immutables for implementation contract if contract is a proxy

### DIFF
--- a/validation/immutable-references.go
+++ b/validation/immutable-references.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/ethereum-optimism/superchain-registry/validation/standard"
 )
@@ -24,7 +25,10 @@ type BytecodeAndImmutableReferences struct {
 // initBytecodeImmutableMask returns the struct with coordinates of the immutable references in the deployed bytecode, if present
 func initBytecodeImmutableMask(bytecode []byte, tag standard.Tag, contractName string) (*BytecodeAndImmutableReferences, error) {
 	parsedImmutables := map[string][]ImmutableReference{}
-
+	proxyContract := strings.HasSuffix(contractName, "Proxy")
+	if proxyContract {
+		contractName = strings.TrimSuffix(contractName, "Proxy")
+	}
 	refs, exists := standard.BytecodeImmutables[tag].ForContractWithName(contractName)
 	if exists {
 		err := json.Unmarshal([]byte(refs), &parsedImmutables)

--- a/validation/standard/standard-bytecodes.toml
+++ b/validation/standard/standard-bytecodes.toml
@@ -10,8 +10,8 @@ preimage_oracle = "0x2109eb20fb34703fe7ab0231bf0e93d972fe78423b72e7fb1f797f16821
 permissioned_dispute_game = "0x666d50416294caefc6a0a9c7c3803d75dbb76e9b85384c4aaee5fc35d7b5cb34"       # version "1.2.0"
 # for the contracts below which contain immutables, the hash is calculated from the masked bytecode (not the deployed bytecode as-is).
 # sections of the bytecode that contain the immutables are masked (set to 0) before computing the hash
-anchor_state_registry = "0x0498c48f921116ae0b4e1f8cb2e7aadff89f232a8ee0b636592d4520c1a12608" # version "1.0.0"
-delayed_weth = "0x673e70f6894b78f8c9b53937860851d56984d4d19d073a1325fb1634a80f458f"          # version "1.0.0"
+anchor_state_registry = "0x46e8ecc46fd27f178ada1c5a2168c09512e7ed2f7d4ac9a7c74123af26fd850c" # version "2.0.0"
+delayed_weth = "0xc4fb1a6fa54865937fda773735938b5374d23fcf556bb4c69686f23be96b3f97"          # version "1.0.0"
 mips = "0x8f1cb311156fdc848bd99f26b08d88f0bec2c419bbca97533049907794390b4b"                  # version "1.1.0"
 fault_dispute_game = "0x94ded5b66802fe6287d2105fad9ab6c4c8f25275db55d997e07e2284c830595a"    # version "1.2.0"
 

--- a/validation/standard/standard-immutables.toml
+++ b/validation/standard/standard-immutables.toml
@@ -9,8 +9,8 @@
 # "immutableReferences":{"85798":[{"start":178,"length":32},{"start":1771,"length":32}]}}
 #
 ["op-contracts/v1.6.0"] # Fault Proof Fixes https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.6.0
-anchor_state_registry = '{"105981":[{"start":387,"length":32},{"start":828,"length":32},{"start":2296,"length":32}]}}'
-delayed_weth = '{"110979":[{"start":831,"length":32},{"start":4133,"length":32}]}}'
+anchor_state_registry = '{"105981":[{"start":387,"length":32},{"start":828,"length":32},{"start":2296,"length":32}]}'
+delayed_weth = '{"110979":[{"start":831,"length":32},{"start":4133,"length":32}]}'
 fault_dispute_game = '{"106803":[{"start":1926,"length":32},{"start":12628,"length":32}],"106806":[{"start":2891,"length":32},{"start":7484,"length":32},{"start":7822,"length":32},{"start":11526,"length":32},{"start":11660,"length":32},{"start":12171,"length":32},{"start":12470,"length":32}],"106809":[{"start":2724,"length":32},{"start":7283,"length":32},{"start":7577,"length":32},{"start":8183,"length":32},{"start":12437,"length":32},{"start":14230,"length":32},{"start":16139,"length":32},{"start":17960,"length":32},{"start":18262,"length":32},{"start":18519,"length":32},{"start":18732,"length":32}],"106813":[{"start":2673,"length":32},{"start":3936,"length":32},{"start":7722,"length":32},{"start":8329,"length":32},{"start":8424,"length":32},{"start":11254,"length":32},{"start":11320,"length":32}],"106817":[{"start":1204,"length":32},{"start":7866,"length":32},{"start":12866,"length":32},{"start":13719,"length":32}],"106821":[{"start":2189,"length":32},{"start":9639,"length":32},{"start":14792,"length":32}],"106825":[{"start":1319,"length":32},{"start":6476,"length":32},{"start":9344,"length":32},{"start":10730,"length":32},{"start":15892,"length":32}],"106829":[{"start":1555,"length":32},{"start":6026,"length":32},{"start":9704,"length":32}],"106832":[{"start":2590,"length":32},{"start":14649,"length":32}],"106836":[{"start":1723,"length":32},{"start":8123,"length":32},{"start":8230,"length":32},{"start":8281,"length":32}]}'
 mips = '{"92095":[{"start":178,"length":32},{"start":1771,"length":32}]}'
 


### PR DESCRIPTION
Related to #686.

We are mapping proxies to implementations to query the code from a provider, but we are not performing that mapping when looking up the standard immutables. 