### PR TITLE
add-chain: use forge1 as default genesis creation command

### DIFF
--- a/add-chain/main.go
+++ b/add-chain/main.go
@@ -316,7 +316,7 @@ func writeGenesisValidationMetadata(commit string, targetDir string) error {
 	// involving OPLabs engineers after the add-chain command runs.
 	const defaultNodeVersion = "18.12.1"
 	const defaultMonorepoBuildCommand = "pnpm"
-	const defaultGenesisCreationCommand = "opnode2" // See validation/genesis/commands.go
+	const defaultGenesisCreationCommand = "forge1" // See validation/genesis/commands.go
 	vm := genesis.ValidationMetadata{
 		GenesisCreationCommit:  commit,
 		NodeVersion:            defaultNodeVersion,


### PR DESCRIPTION
`forge` is the tool used by `op-deployer` to build the genesis file. We should default to using `forge` in the `validate-genesis-allocs` test, then troubleshoot to find the right command if the chain's genesis predates the usage of `forge`