### PR TITLE
ci: fix generate-test-config script for linux

### DIFF
--- a/validation/genesis/validation-inputs/generate-test-config.sh
+++ b/validation/genesis/validation-inputs/generate-test-config.sh
@@ -12,7 +12,7 @@ if [ -z "$targetList" ]; then
 fi
 
 # Process the targetList to extract directory names and then the base names
-targetList=$(echo "$targetList" | xargs dirname | xargs basename | sort -u)
+targetList=$(echo "$targetList" | xargs -n1 dirname | xargs -n1 basename | sort -u)
 
 # Join the array elements with commas and wrap each element in quotes
 targets=$(echo "$targetList" | sed 's/.*/"&"/' | tr '\n' ',')


### PR DESCRIPTION
There was an issue running the previous version of `generate-test-config.sh` on linux based ci machines (previously we used an osx machine for ci). The updated version of this script can now run on both os types.

## Tests

Pushed a test commit (which was removed by force-push) which modified two chains' `validation/genesis/validation-inputs` and confirmed the script operated as expected by triggering a `validate-genesis-allocs` job for each.

Can also see on the current version of this pr that ci properly handled the case where no `validation/genesis/validation-inputs` are modified