### PR TITLE
compute-config-diff-and-report shall not be triggered on schedule

### DIFF
--- a/.circleci/main_config.yml
+++ b/.circleci/main_config.yml
@@ -391,6 +391,9 @@ workflows:
       - check-codegen
 
   compute-config-diff-and-report:
+    when:
+      not:
+        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       - compute-config-diff-and-report-with-pr-comment:
           name: compute-genesis-diff


### PR DESCRIPTION
<!--
This default template is a guide for PRs adding new chains to the registry.
For other types of PRs, please delete this template and write a brief description of your 
code changes and rationale.
 -->

compute-config-diff-and-report shall not be triggered on schedule