### PR TITLE
validation: move contract versions code from superchain to validation module

### DIFF
--- a/superchain/address_list.go
+++ b/superchain/address_list.go
@@ -1,0 +1,95 @@
+package superchain
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+type Roles struct {
+	SystemConfigOwner Address `json:"SystemConfigOwner" toml:"SystemConfigOwner"`
+	ProxyAdminOwner   Address `json:"ProxyAdminOwner" toml:"ProxyAdminOwner"`
+	Guardian          Address `json:"Guardian" toml:"Guardian"`
+	Challenger        Address `json:"Challenger" toml:"Challenger"`
+	Proposer          Address `json:"Proposer" toml:"Proposer"`
+	UnsafeBlockSigner Address `json:"UnsafeBlockSigner" toml:"UnsafeBlockSigner"`
+	BatchSubmitter    Address `json:"BatchSubmitter" toml:"BatchSubmitter"`
+}
+
+// AddressList represents the set of network specific contracts and roles for a given network.
+type AddressList struct {
+	Roles                             `json:",inline" toml:",inline"`
+	AddressManager                    Address `json:"AddressManager" toml:"AddressManager"`
+	L1CrossDomainMessengerProxy       Address `json:"L1CrossDomainMessengerProxy" toml:"L1CrossDomainMessengerProxy"`
+	L1ERC721BridgeProxy               Address `json:"L1ERC721BridgeProxy" toml:"L1ERC721BridgeProxy"`
+	L1StandardBridgeProxy             Address `json:"L1StandardBridgeProxy" toml:"L1StandardBridgeProxy"`
+	L2OutputOracleProxy               Address `json:"L2OutputOracleProxy" toml:"L2OutputOracleProxy,omitempty"`
+	OptimismMintableERC20FactoryProxy Address `json:"OptimismMintableERC20FactoryProxy" toml:"OptimismMintableERC20FactoryProxy"`
+	OptimismPortalProxy               Address `json:"OptimismPortalProxy,omitempty" toml:"OptimismPortalProxy,omitempty"`
+	SystemConfigProxy                 Address `json:"SystemConfigProxy" toml:"SystemConfigProxy"`
+	ProxyAdmin                        Address `json:"ProxyAdmin" toml:"ProxyAdmin"`
+	SuperchainConfig                  Address `json:"SuperchainConfig,omitempty" toml:"SuperchainConfig,omitempty"`
+
+	// Fault Proof contracts:
+	AnchorStateRegistryProxy Address `json:"AnchorStateRegistryProxy,omitempty" toml:"AnchorStateRegistryProxy,omitempty"`
+	DelayedWETHProxy         Address `json:"DelayedWETHProxy,omitempty" toml:"DelayedWETHProxy,omitempty"`
+	DisputeGameFactoryProxy  Address `json:"DisputeGameFactoryProxy,omitempty" toml:"DisputeGameFactoryProxy,omitempty"`
+	FaultDisputeGame         Address `json:"FaultDisputeGame,omitempty" toml:"FaultDisputeGame,omitempty"`
+	MIPS                     Address `json:"MIPS,omitempty" toml:"MIPS,omitempty"`
+	PermissionedDisputeGame  Address `json:"PermissionedDisputeGame,omitempty" toml:"PermissionedDisputeGame,omitempty"`
+	PreimageOracle           Address `json:"PreimageOracle,omitempty" toml:"PreimageOracle,omitempty"`
+
+	// AltDA contracts:
+	DAChallengeAddress Address `json:"DAChallengeAddress,omitempty" toml:"DAChallengeAddress,omitempty"`
+}
+
+// AddressFor returns a nonzero address for the supplied name, if it has been specified
+// (and an error otherwise).
+func (a AddressList) AddressFor(name string) (Address, error) {
+	// Use reflection to get the struct value and type
+	v := reflect.ValueOf(a)
+
+	// Try to find the field by name
+	field := v.FieldByName(name)
+	if !field.IsValid() {
+		return Address{}, fmt.Errorf("no such name %s", name)
+	}
+
+	// Check if the field is of type Address
+	if field.Type() != reflect.TypeOf(Address{}) {
+		return Address{}, fmt.Errorf("field %s is not of type Address", name)
+	}
+
+	// Check if the address is a non-zero value
+	address := field.Interface().(Address)
+	if address == (Address{}) {
+		return Address{}, fmt.Errorf("no address or zero address specified for %s", name)
+	}
+
+	return address, nil
+}
+
+// MarshalJSON excludes any addresses set to 0x000...000
+func (a AddressList) MarshalJSON() ([]byte, error) {
+	type AddressList2 AddressList // use another type to prevent infinite recursion later on
+	b := AddressList2(a)
+
+	o, err := json.Marshal(b)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]Address)
+	err = json.Unmarshal(o, &out)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range out {
+		if (v == Address{}) {
+			delete(out, k)
+		}
+	}
+
+	return json.Marshal(out)
+}

--- a/superchain/go.mod
+++ b/superchain/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.28.0
-	golang.org/x/mod v0.21.0
 )
 
 require (

--- a/superchain/go.sum
+++ b/superchain/go.sum
@@ -20,8 +20,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/crypto v0.28.0 h1:GBDwsMXVQi34v5CCYUm2jkJvu4cbtru2U4TN2PSyQnw=
 golang.org/x/crypto v0.28.0/go.mod h1:rmgy+3RHxRZMyY0jjAJShp2zgEdOqj2AO7U0pYmeQ7U=
-golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
-golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
 golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -217,31 +217,6 @@ func (c *ChainConfig) setNilHardforkTimestampsToDefaultOrZero(s *SuperchainConfi
 	}
 }
 
-// MarshalJSON excludes any addresses set to 0x000...000
-func (a AddressList) MarshalJSON() ([]byte, error) {
-	type AddressList2 AddressList // use another type to prevent infinite recursion later on
-	b := AddressList2(a)
-
-	o, err := json.Marshal(b)
-	if err != nil {
-		return nil, err
-	}
-
-	out := make(map[string]Address)
-	err = json.Unmarshal(o, &out)
-	if err != nil {
-		return nil, err
-	}
-
-	for k, v := range out {
-		if (v == Address{}) {
-			delete(out, k)
-		}
-	}
-
-	return json.Marshal(out)
-}
-
 func (c *ChainConfig) GenerateTOMLComments(ctx context.Context) (map[string]string, error) {
 	comments := make(map[string]string)
 
@@ -273,69 +248,6 @@ func (c *ChainConfig) GenerateTOMLComments(ctx context.Context) (map[string]stri
 	}
 
 	return comments, nil
-}
-
-type Roles struct {
-	SystemConfigOwner Address `json:"SystemConfigOwner" toml:"SystemConfigOwner"`
-	ProxyAdminOwner   Address `json:"ProxyAdminOwner" toml:"ProxyAdminOwner"`
-	Guardian          Address `json:"Guardian" toml:"Guardian"`
-	Challenger        Address `json:"Challenger" toml:"Challenger"`
-	Proposer          Address `json:"Proposer" toml:"Proposer"`
-	UnsafeBlockSigner Address `json:"UnsafeBlockSigner" toml:"UnsafeBlockSigner"`
-	BatchSubmitter    Address `json:"BatchSubmitter" toml:"BatchSubmitter"`
-}
-
-// AddressList represents the set of network specific contracts and roles for a given network.
-type AddressList struct {
-	Roles                             `json:",inline" toml:",inline"`
-	AddressManager                    Address `json:"AddressManager" toml:"AddressManager"`
-	L1CrossDomainMessengerProxy       Address `json:"L1CrossDomainMessengerProxy" toml:"L1CrossDomainMessengerProxy"`
-	L1ERC721BridgeProxy               Address `json:"L1ERC721BridgeProxy" toml:"L1ERC721BridgeProxy"`
-	L1StandardBridgeProxy             Address `json:"L1StandardBridgeProxy" toml:"L1StandardBridgeProxy"`
-	L2OutputOracleProxy               Address `json:"L2OutputOracleProxy" toml:"L2OutputOracleProxy,omitempty"`
-	OptimismMintableERC20FactoryProxy Address `json:"OptimismMintableERC20FactoryProxy" toml:"OptimismMintableERC20FactoryProxy"`
-	OptimismPortalProxy               Address `json:"OptimismPortalProxy,omitempty" toml:"OptimismPortalProxy,omitempty"`
-	SystemConfigProxy                 Address `json:"SystemConfigProxy" toml:"SystemConfigProxy"`
-	ProxyAdmin                        Address `json:"ProxyAdmin" toml:"ProxyAdmin"`
-	SuperchainConfig                  Address `json:"SuperchainConfig,omitempty" toml:"SuperchainConfig,omitempty"`
-
-	// Fault Proof contracts:
-	AnchorStateRegistryProxy Address `json:"AnchorStateRegistryProxy,omitempty" toml:"AnchorStateRegistryProxy,omitempty"`
-	DelayedWETHProxy         Address `json:"DelayedWETHProxy,omitempty" toml:"DelayedWETHProxy,omitempty"`
-	DisputeGameFactoryProxy  Address `json:"DisputeGameFactoryProxy,omitempty" toml:"DisputeGameFactoryProxy,omitempty"`
-	FaultDisputeGame         Address `json:"FaultDisputeGame,omitempty" toml:"FaultDisputeGame,omitempty"`
-	MIPS                     Address `json:"MIPS,omitempty" toml:"MIPS,omitempty"`
-	PermissionedDisputeGame  Address `json:"PermissionedDisputeGame,omitempty" toml:"PermissionedDisputeGame,omitempty"`
-	PreimageOracle           Address `json:"PreimageOracle,omitempty" toml:"PreimageOracle,omitempty"`
-
-	// AltDA contracts:
-	DAChallengeAddress Address `json:"DAChallengeAddress,omitempty" toml:"DAChallengeAddress,omitempty"`
-}
-
-// AddressFor returns a nonzero address for the supplied name, if it has been specified
-// (and an error otherwise).
-func (a AddressList) AddressFor(name string) (Address, error) {
-	// Use reflection to get the struct value and type
-	v := reflect.ValueOf(a)
-
-	// Try to find the field by name
-	field := v.FieldByName(name)
-	if !field.IsValid() {
-		return Address{}, fmt.Errorf("no such name %s", name)
-	}
-
-	// Check if the field is of type Address
-	if field.Type() != reflect.TypeOf(Address{}) {
-		return Address{}, fmt.Errorf("field %s is not of type Address", name)
-	}
-
-	// Check if the address is a non-zero value
-	address := field.Interface().(Address)
-	if address == (Address{}) {
-		return Address{}, fmt.Errorf("no address or zero address specified for %s", name)
-	}
-
-	return address, nil
 }
 
 type MappedContractProperties[T string | VersionedContract] struct {

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -24,21 +24,6 @@ func TestAddressFor(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestVersionFor(t *testing.T) {
-	cl := ContractVersions{
-		L1CrossDomainMessenger: VersionedContract{Version: "1.9.9"},
-		OptimismPortal:         VersionedContract{Version: ""},
-	}
-	want := "1.9.9"
-	got, err := cl.VersionFor("L1CrossDomainMessenger")
-	require.NoError(t, err)
-	require.Equal(t, want, got)
-	_, err = cl.VersionFor("OptimismPortal")
-	require.Error(t, err)
-	_, err = cl.VersionFor("Garbage")
-	require.Error(t, err)
-}
-
 func TestChainIds(t *testing.T) {
 	chainIDs := map[uint64]bool{}
 

--- a/validation/standard/init.go
+++ b/validation/standard/init.go
@@ -5,7 +5,6 @@ import (
 	"io/fs"
 
 	"github.com/BurntSushi/toml"
-	"github.com/ethereum-optimism/superchain-registry/superchain"
 )
 
 //go:embed *.toml
@@ -28,8 +27,8 @@ func init() {
 		Config.Params[network] = new(Params)
 		decodeTOMLFileIntoConfig("standard-config-params-"+network+".toml", Config.Params[network])
 
-		var versions VersionTags = VersionTags{
-			Releases: make(map[Tag]superchain.ContractVersions, 0),
+		versions := VersionTags{
+			Releases: make(map[Tag]ContractVersions, 0),
 		}
 
 		decodeTOMLFileIntoConfig("standard-versions-"+network+".toml", &versions)

--- a/validation/standard/versions.go
+++ b/validation/standard/versions.go
@@ -1,12 +1,136 @@
 package standard
 
 import (
+	"errors"
+	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/ethereum-optimism/superchain-registry/superchain"
+	"golang.org/x/mod/semver"
 )
 
 type Tag string
+
+type MappedContractProperties[T string | VersionedContract] struct {
+	L1CrossDomainMessenger       T `toml:"l1_cross_domain_messenger,omitempty"`
+	L1ERC721Bridge               T `toml:"l1_erc721_bridge,omitempty"`
+	L1StandardBridge             T `toml:"l1_standard_bridge,omitempty"`
+	L2OutputOracle               T `toml:"l2_output_oracle,omitempty"`
+	OptimismMintableERC20Factory T `toml:"optimism_mintable_erc20_factory,omitempty"`
+	OptimismPortal               T `toml:"optimism_portal,omitempty"`
+	OptimismPortal2              T `toml:"optimism_portal2,omitempty"`
+	SystemConfig                 T `toml:"system_config,omitempty"`
+	// Superchain-wide contracts:
+	ProtocolVersions T `toml:"protocol_versions,omitempty"`
+	SuperchainConfig T `toml:"superchain_config,omitempty"`
+	// Fault Proof contracts:
+	AnchorStateRegistry     T `toml:"anchor_state_registry,omitempty"`
+	DelayedWETH             T `toml:"delayed_weth,omitempty"`
+	DisputeGameFactory      T `toml:"dispute_game_factory,omitempty"`
+	FaultDisputeGame        T `toml:"fault_dispute_game,omitempty"`
+	MIPS                    T `toml:"mips,omitempty"`
+	PermissionedDisputeGame T `toml:"permissioned_dispute_game,omitempty"`
+	PreimageOracle          T `toml:"preimage_oracle,omitempty"`
+	CannonFaultDisputeGame  T `toml:"cannon_fault_dispute_game,omitempty"`
+}
+
+// ContractBytecodeHashes stores a bytecode hash against each contract
+type ContractBytecodeHashes MappedContractProperties[string]
+
+// VersionedContract represents a contract that has a semantic version.
+type VersionedContract struct {
+	Version string `toml:"version"`
+	// If the contract is a superchain singleton, it will have a static address
+	Address *superchain.Address `toml:"implementation_address,omitempty"`
+	// If the contract is proxied, the implementation will have a static address
+	ImplementationAddress *superchain.Address `toml:"address,omitempty"`
+}
+
+// ContractVersions represents the desired semantic version of the contracts
+// in the superchain. This currently only supports L1 contracts but could
+// represent L2 predeploys in the future.
+type ContractVersions MappedContractProperties[VersionedContract]
+
+// GetNonEmpty returns a slice of contract names, with an entry for each contract
+// in the receiver with a non empty Version property.
+func (c ContractVersions) GetNonEmpty() []string {
+	// Get the value and type of the struct
+	v := reflect.ValueOf(c)
+	t := reflect.TypeOf(c)
+
+	var fieldNames []string
+
+	// Iterate through the struct fields
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		fieldType := t.Field(i)
+
+		// Ensure the field is of type VersionedContract
+		if field.Type() == reflect.TypeOf(VersionedContract{}) {
+			// Get the Version field from the VersionedContract
+			versionField := field.FieldByName("Version")
+
+			// Check if the Version is non-empty
+			if versionField.IsValid() && versionField.String() != "" {
+				fieldNames = append(fieldNames, fieldType.Name)
+			}
+		}
+	}
+
+	return fieldNames
+}
+
+// VersionFor returns the version for the supplied contract name, if it exits
+// (and an error otherwise). Useful for slicing into the struct using a string.
+func (c ContractVersions) VersionFor(contractName string) (string, error) {
+	// Use reflection to get the value of the struct
+	val := reflect.ValueOf(c)
+	// Get the field by name (contractName)
+	field := val.FieldByName(contractName)
+
+	// Check if the field exists and is a struct
+	if !field.IsValid() {
+		return "", errors.New("no such contract name")
+	}
+
+	// Check if the struct contains the "Version" field
+	versionField := field.FieldByName("Version")
+	if !versionField.IsValid() || versionField.String() == "" {
+		return "", errors.New("no version specified")
+	}
+
+	// Return the version if it's a string
+	if versionField.Kind() == reflect.String {
+		return versionField.String(), nil
+	}
+
+	return "", errors.New("version is not a string")
+}
+
+// Check will sanity check the validity of the semantic version strings
+// in the ContractVersions struct. If allowEmptyVersions is true, empty version errors will be ignored.
+func (c ContractVersions) Check(allowEmptyVersions bool) error {
+	val := reflect.ValueOf(c)
+	for i := 0; i < val.NumField(); i++ {
+		field := val.Field(i)
+		vC, ok := field.Interface().(VersionedContract)
+		if !ok {
+			return fmt.Errorf("invalid type for field %s", val.Type().Field(i).Name)
+		}
+		if vC.Version == "" {
+			if allowEmptyVersions {
+				continue // we allow empty strings and rely on tests to assert (or except) a nonempty version
+			}
+			return fmt.Errorf("empty version for field %s", val.Type().Field(i).Name)
+		}
+		vC.Version = CanonicalizeSemver(vC.Version)
+		if !semver.IsValid(vC.Version) {
+			return fmt.Errorf("invalid semver %s for field %s", vC.Version, val.Type().Field(i).Name)
+		}
+	}
+	return nil
+}
 
 // ContractBytecodeImmutables stores the immutable references as a raw stringified JSON string in a TOML config.
 // it is stored this way because it can be plucked out of the contract compilation output as is and pasted into the TOML config file.
@@ -47,18 +171,18 @@ type (
 )
 
 type VersionTags struct {
-	Releases map[Tag]superchain.ContractVersions `toml:"releases"`
+	Releases map[Tag]ContractVersions `toml:"releases"`
 }
 
 var (
 	Release            Tag
-	NetworkVersions                           = make(map[string]VersionTags)
-	BytecodeHashes     BytecodeHashTags       = make(BytecodeHashTags, 0)
-	BytecodeImmutables BytecodeImmutablesTags = make(BytecodeImmutablesTags, 0)
+	NetworkVersions    = make(map[string]VersionTags)
+	BytecodeHashes     = make(BytecodeHashTags, 0)
+	BytecodeImmutables = make(BytecodeImmutablesTags, 0)
 )
 
 // L1ContractBytecodeHashes represents the hash of the contract bytecode (as a hex string) for each L1 contract
-type L1ContractBytecodeHashes superchain.ContractBytecodeHashes
+type L1ContractBytecodeHashes ContractBytecodeHashes
 
 // GetNonEmpty returns a slice of contract name strings, with an entry for each key in the receiver
 // with a non-empty value
@@ -84,4 +208,14 @@ func (bch L1ContractBytecodeHashes) GetNonEmpty() []string {
 	}
 
 	return fieldNames
+}
+
+// CanonicalizeSemver will ensure that the version string has a "v" prefix.
+// This is because the semver library being used requires the "v" prefix,
+// even though
+func CanonicalizeSemver(version string) string {
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+	return version
 }

--- a/validation/standard/versions_test.go
+++ b/validation/standard/versions_test.go
@@ -1,0 +1,22 @@
+package standard
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionFor(t *testing.T) {
+	cl := ContractVersions{
+		L1CrossDomainMessenger: VersionedContract{Version: "1.9.9"},
+		OptimismPortal:         VersionedContract{Version: ""},
+	}
+	want := "1.9.9"
+	got, err := cl.VersionFor("L1CrossDomainMessenger")
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+	_, err = cl.VersionFor("OptimismPortal")
+	require.Error(t, err)
+	_, err = cl.VersionFor("Garbage")
+	require.Error(t, err)
+}

--- a/validation/superchain-version.go
+++ b/validation/superchain-version.go
@@ -256,9 +256,7 @@ func getBytecodeHash(ctx context.Context, chainID uint64, contractName string, t
 
 func requireStandardSemvers(t *testing.T, versions standard.ContractVersions, isTestnet bool, chain *ChainConfig) {
 	standardVersions := standard.NetworkVersions[chain.Superchain].Releases[standard.Release]
-	s := reflect.ValueOf(standardVersions)
-	c := reflect.ValueOf(versions)
-	matches := checkMatchOrTestnet(s, c, isTestnet)
+	matches := checkMatchOrTestnet(standardVersions, versions, isTestnet)
 
 	if !matches {
 		diff := cmp.Diff(standardVersions, versions, cmp.FilterPath(func(p cmp.Path) bool {
@@ -312,8 +310,12 @@ func checkMatch(s, c reflect.Value) bool {
 	return true
 }
 
-// checkMatchOrTestnet returns true if s and c match, OR if the chain is a testnet and s < c
-func checkMatchOrTestnet(s, c reflect.Value, isTestnet bool) bool {
+// checkMatchOrTestnet returns true if one of the following is true:
+//   - standardVersion and currentVersion match for all contracts
+//   - isTestnet == true and currentVersion >= standardVersion for all contracts
+func checkMatchOrTestnet(standardVersions, currentVersions standard.ContractVersions, isTestnet bool) bool {
+	s := reflect.ValueOf(standardVersions)
+	c := reflect.ValueOf(currentVersions)
 	// Iterate over each field of the standard struct
 	for i := 0; i < s.NumField(); i++ {
 

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -4,15 +4,14 @@ import (
 	"reflect"
 	"testing"
 
-	. "github.com/ethereum-optimism/superchain-registry/superchain"
 	"github.com/ethereum-optimism/superchain-registry/validation/standard"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCheckMatchOrTestnet(t *testing.T) {
-	dummyVersions := ContractVersions{
-		OptimismPortal: VersionedContract{Version: "incorrect"},
-		SystemConfig:   VersionedContract{ImplementationAddress: nil},
+	dummyVersions := standard.ContractVersions{
+		OptimismPortal: standard.VersionedContract{Version: "incorrect"},
+		SystemConfig:   standard.VersionedContract{ImplementationAddress: nil},
 	}
 
 	standardVersions := standard.NetworkVersions["mainnet"].Releases[standard.Release]

--- a/validation/superchain-version_test.go
+++ b/validation/superchain-version_test.go
@@ -1,7 +1,6 @@
 package validation
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/ethereum-optimism/superchain-registry/validation/standard"
@@ -9,16 +8,12 @@ import (
 )
 
 func TestCheckMatchOrTestnet(t *testing.T) {
+	standardVersions := standard.NetworkVersions["mainnet"].Releases[standard.Release]
 	dummyVersions := standard.ContractVersions{
 		OptimismPortal: standard.VersionedContract{Version: "incorrect"},
 		SystemConfig:   standard.VersionedContract{ImplementationAddress: nil},
 	}
 
-	standardVersions := standard.NetworkVersions["mainnet"].Releases[standard.Release]
-
-	s := reflect.ValueOf(standardVersions)
-	c := reflect.ValueOf(dummyVersions)
-
-	matches := checkMatchOrTestnet(s, c, false)
+	matches := checkMatchOrTestnet(standardVersions, dummyVersions, false)
 	require.False(t, matches)
 }


### PR DESCRIPTION
The `superchain` module gets imported by `op-geth` and `op-node`, therefore it is advantageous to keep that module as small as possible. The contract versions code lived in the `superchain` module, but was only used by the `validation` module. Therefore it made sense to move this code around and get rid of the indirection

Additional change:
* separated `AddressList` code from `superchain/superchain.go` into its own `superchain/address_list.go` file to make it easier to navigate through the superchain module