### PR TITLE
validation: make eth_chainId req instead of net_version

### DIFF
--- a/validation/chainid-rpc_test.go
+++ b/validation/chainid-rpc_test.go
@@ -16,7 +16,7 @@ func testChainIDFromRPC(t *testing.T, chain *ChainConfig) {
 	defer client.Close()
 
 	// Fetch the chain ID
-	chainID, err := Retry(client.NetworkID)(context.Background())
+	chainID, err := Retry(client.ChainID)(context.Background())
 
 	require.NoError(t, err, "Failed to fetch the chain ID")
 	require.Equal(t, chain.ChainID, chainID.Uint64(), "Declared a chainId of %s, but RPC returned ID %s", chain.ChainID, chainID.Uint64())


### PR DESCRIPTION
`eth_chainId` is the preferred rpc request for modern ethereum chains instead of the legacy `net_version`