### PR TITLE
fix: updating generate-test-config.sh to use main_config.yml instead contine_config.yaml

### DIFF
--- a/validation/genesis/validation-inputs/generate-test-config.sh
+++ b/validation/genesis/validation-inputs/generate-test-config.sh
@@ -35,5 +35,5 @@ prependedTargets=${prependedTargets%,}
 prependedTargets="[$prependedTargets]"
 
 # Use yq to replace the target-version   key
-yq e ".workflows.pr-checks.jobs[0].golang-validate-genesis-allocs.matrix.parameters.chainid = $targets" -i .circleci/continue_config.yml
-yq e ".workflows.pr-checks.jobs[1].genesis-allocs-all-ok.requires = $prependedTargets" -i .circleci/continue_config.yml
+yq e ".workflows.pr-checks.jobs[0].golang-validate-genesis-allocs.matrix.parameters.chainid = $targets" -i .circleci/main_config.yml
+yq e ".workflows.pr-checks.jobs[1].genesis-allocs-all-ok.requires = $prependedTargets" -i .circleci/main_config.yml


### PR DESCRIPTION
# Description
* There appears to be a typo in the generate-test-config.sh script. In [PR-700](https://github.com/ethereum-optimism/superchain-registry/pull/700), the .circle_ci/continue_config.yml was renamed to .circle_ci/main_config.yaml, this fix updates generate-test-config.sh to target the updated script.

 * Please see test [PR-746](https://github.com/ethereum-optimism/superchain-registry/pull/746), which incorporates these changes, and has the PR checks running.

## Checklist
- [ ] I have declared the chain at the appropriate [Superchain Level](../docs/glossary.md#superchain-level-and-rollup-stage).
- [ ] I have run `just validate <chain-id>` locally to ensure all local validation checks pass. 
- [ ] I have run `just codegen` to ensure that the chainlist and other generated files are up-to-date and include my chain.
