### PR TITLE
fix(ci): refine conditions for compute-config-diff workflows in Circeci

### DIFF
--- a/.circleci/main_config.yml
+++ b/.circleci/main_config.yml
@@ -411,7 +411,10 @@ workflows:
 
   compute-config-diff-and-report:
     when:
-      not: << pipeline.parameters.is_forked_pull_request >>
+      and:
+        - not:
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - not: << pipeline.parameters.is_forked_pull_request >>
     jobs:
       - compute-config-diff:
           name: compute-genesis-diff
@@ -437,7 +440,11 @@ workflows:
           requires: [compute-rollup-config-diff]
 
   compute-config-diff-only:
-    when: << pipeline.parameters.is_forked_pull_request >>
+    when:
+      and:
+        - not:
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - << pipeline.parameters.is_forked_pull_request >>
     jobs:
       - compute-config-diff:
           name: compute-genesis-diff


### PR DESCRIPTION
This pull request includes changes to the `.circleci/main_config.yml` file to refine the conditions for when certain jobs should run in the workflows. The modifications ensure that jobs are not triggered for scheduled pipelines and provide more precise control over job execution.

Changes to workflow job conditions:

* [`.circleci/main_config.yml`](diffhunk://#diff-a7236285ae969f09dbccee34ec0fa1ea2646f33fed37fb1d4ba5e03e66510619L414-R417): Updated `compute-config-diff-and-report` workflow to include an additional condition that prevents execution if the pipeline is triggered by a scheduled event.
* [`.circleci/main_config.yml`](diffhunk://#diff-a7236285ae969f09dbccee34ec0fa1ea2646f33fed37fb1d4ba5e03e66510619L440-R447): Modified `compute-config-diff-only` workflow to include an additional condition that prevents execution if the pipeline is triggered by a scheduled event.