### PR TITLE
feat(validation/genesis): improve error messages

### DIFF
--- a/validation/genesis/genesis-allocs_test.go
+++ b/validation/genesis/genesis-allocs_test.go
@@ -140,7 +140,7 @@ func testGenesisAllocs(t *testing.T, chain *ChainConfig) {
 
 	stderrPipe, err := cmd.StderrPipe()
 	require.NoError(t, err, "Failed to get stderr pipe")
-	
+
 	// Stream the command's stdout and stderr to the test logger
 	go streamOutputToLogger(stdoutPipe, t)
 	go streamOutputToLogger(stderrPipe, t)
@@ -155,7 +155,7 @@ func testGenesisAllocs(t *testing.T, chain *ChainConfig) {
 		expectedData, err = os.ReadFile(path.Join(contractsDir, "statedump.json"))
 		require.NoError(t, err)
 		allocs := types.GenesisAlloc{}
-		
+
 		err = json.Unmarshal(expectedData, &allocs)
 		removeEmptyStorageSlots(allocs, t)
 		require.NoError(t, err)
@@ -206,11 +206,11 @@ func testGenesisAllocs(t *testing.T, chain *ChainConfig) {
 	  special handling of weth9 for op-sepolia at the validated commit
 	  We've observed that the contract [metadata hash](https://docs.soliditylang.org/en/latest/metadata.html)
 	  does not match for the bytecode that is generated and what's in the superchain-registry.
-	  
+
 	  The issue is likely a difference in compiler settings when the contract artifacts were generated and
 	  stored in the superchain registry. To account for this, we trim the metadata hash portion of the
 	  weth9 contract bytecode before writing to file/comparing the outputs
-	 
+
 	  For extra safety, we allow this type of check only at the commit hash we know has this issue.
 	  In other instances, the metadata may have optionally been excluded from the bytecode in the registry,
 	  in which case we ought to check for a complete match.

--- a/validation/genesis/genesis-allocs_test.go
+++ b/validation/genesis/genesis-allocs_test.go
@@ -35,12 +35,15 @@ func TestMain(m *testing.M) {
 	thisDir := filepath.Dir(filename)
 	temporaryOptimismDir = path.Join(thisDir, "../../../optimism-temporary")
 
-	// Clone the repo if the folder doesn't exist
+	// Clone the repo if the folder doesn't exist, otherwise pull the latest changes
 	_, err := os.Stat(temporaryOptimismDir)
 	needToClone := os.IsNotExist(err)
 	if needToClone {
 		mustExecuteCommandInDir(thisDir,
 			exec.Command("git", "clone", "--recurse-submodules", "https://github.com/ethereum-optimism/optimism.git", temporaryOptimismDir))
+	} else {
+		mustExecuteCommandInDir(thisDir,
+			exec.Command("git", "pull", temporaryOptimismDir))
 	}
 
 	// Run tests

--- a/validation/genesis/genesis-allocs_test.go
+++ b/validation/genesis/genesis-allocs_test.go
@@ -237,7 +237,7 @@ func testGenesisAllocs(t *testing.T, chain *ChainConfig) {
 	require.NoError(t, err)
 
 	l2Time := chain.Genesis.L2Time
-	require.Equal(t, string(expectedData), string(gotData), "regenerated alloc does not match registry alloc; this may have been caused by using the wrong `genesis_creation_commit`. You must specify the commit at which you deployed your contracts; to find an appropriate commit, use this command: `git rev-list --before=%d HEAD`", l2Time)
+	require.Equal(t, string(expectedData), string(gotData), "regenerated alloc does not match registry alloc; this may have been caused by using the wrong `genesis_creation_commit`. You must specify the commit at which you deployed your contracts; to find an appropriate commit, run this command against the `optimism` repository: `git rev-list --before=%d HEAD`", l2Time)
 }
 
 // This function removes empty storage slots as we know declaring empty slots is functionally equivalent to not declaring them.


### PR DESCRIPTION
### Description

This PR improves validation failure error messages for several cases when running `just validate-genesis-allocs`, as suggested by [this comment](https://github.com/ethereum-optimism/superchain-registry/issues/691#issuecomment-2531963645).
