### PR TITLE
validation: Bump rc in sepolia standard-releases

### DIFF
--- a/validation/standard/standard-versions-sepolia.toml
+++ b/validation/standard/standard-versions-sepolia.toml
@@ -5,8 +5,8 @@
 #   * proxied             : specify a standard "implementation_address"
 #   * neither             : specify neither a standard "address" nor "implementation_address"
 
-# Holocene https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.8.0-rc.3
-[releases."op-contracts/v1.8.0-rc.3"]
+# Holocene https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.8.0-rc.4
+[releases."op-contracts/v1.8.0-rc.4"]
 # Updated in this release
 system_config = { version = "2.3.0", implementation_address = "0x33b83E4C305c908B2Fc181dDa36e230213058d7d" } # UPDATED IN THIS RELEASE
 fault_dispute_game = { version = "1.3.1" }                                                                   # UPDATED IN THIS RELEASE


### PR DESCRIPTION
Tag `op-contracts/v1.8.0-rc.4` [exists](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.8.0-rc.4) with latest script improvements, so bumping the rc in the SCR. Since all script runs should reference this new rc from now on, decided to just bump the rc instead of copying it to a new entry, to avoid cluttering the releases toml file.