### PR TITLE
docs: Fixed missing article Update README.MD

### DIFF
--- a/superchain/extra/README.MD
+++ b/superchain/extra/README.MD
@@ -3,5 +3,5 @@
 This is a collection of extra configuration data because not all address and system-config information is available through L1 for some chains.
 
 - [addresses.json](./addresses/addresses.json): L1 Smart Contract addresses for each network.
-- [bytecodes](./bytecodes/): The full bytecode that is factored out of compressed genesis system configuration file. Not designed for human consumption.
+- [bytecodes](./bytecodes/): The full bytecode that is factored out of the compressed genesis system configuration file. Not designed for human consumption.
 - [genesis](./genesis/): Compressed genesis system configuration data. Not designed for human consumption.


### PR DESCRIPTION
## Description
The phrase "compressed genesis system configuration file" was missing the article "the" before "compressed".
Now it correctly reads "the compressed genesis system configuration file."

## Checklist
- [x] I have declared the chain at the appropriate [Superchain Level](../docs/glossary.md#superchain-level-and-rollup-stage).
- [x] I have run `just validate <chain-id>` locally to ensure all local validation checks pass. 
- [x] I have run `just codegen` to ensure that the chainlist and other generated files are up-to-date and include my chain.
