### PR TITLE
Add fields for the new Isthmus system config

### DIFF
--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -52,6 +52,8 @@ type SystemConfig struct {
 	GasLimit          uint64  `json:"gasLimit" toml:"gasLimit"`
 	BaseFeeScalar     *uint64 `json:"baseFeeScalar,omitempty" toml:"baseFeeScalar,omitempty"`
 	BlobBaseFeeScalar *uint64 `json:"blobBaseFeeScalar,omitempty" toml:"blobBaseFeeScalar,omitempty"`
+	DepositNonce      uint64  `json:"depositNonce" toml:"depositNonce"`
+	ConfigUpdateNonce uint64  `json:"configUpdateNonce" toml:"configUpdateNonce"`
 }
 
 type HardForkConfiguration struct {


### PR DESCRIPTION
Adds new SystemConfig fields for the Isthmus hardfork, for https://github.com/ethereum-optimism/optimism/pull/13539.