### PR TITLE
chore: more verbose just download

### DIFF
--- a/.circleci/main_config.yml
+++ b/.circleci/main_config.yml
@@ -31,7 +31,7 @@ commands:
       - run:
           name: "Install just"
           command: |
-            wget -qO - 'https://proget.makedeb.org/debian-feeds/prebuilt-mpr.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg 1> /dev/null
+            wget -O - 'https://proget.makedeb.org/debian-feeds/prebuilt-mpr.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg 1> /dev/null
             echo "deb [arch=all,$(dpkg --print-architecture) signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.makedeb.org prebuilt-mpr $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/prebuilt-mpr.list
             sudo apt update
             sudo apt install just


### PR DESCRIPTION
<!--
This default template is a guide for PRs adding new chains to the registry.
For other types of PRs, please delete this template and write a brief description of your 
code changes and rationale.
 -->

Helps better spot any issues with downloading with just.

Motivation is the numerous "gpg: no valid OpenPGP data found."  errors happened in CI when "installing just"

PS: all the following CI errors are expected.