### PR TITLE
fix(CI): install-just to use cargo as its installer instead of apt backed by Prebuilt-MPR

### DIFF
--- a/.circleci/main_config.yml
+++ b/.circleci/main_config.yml
@@ -32,7 +32,8 @@ commands:
           name: "Install just"
           command: |
             curl https://sh.rustup.rs -sSf | sh -s -- -y
-            export PATH="$PATH:$HOME/.cargo/bin"
+            echo 'export PATH="$PATH:$HOME/.cargo/bin"' >> $BASH_ENV
+            source $BASH_ENV
             cargo install just
   install-foundry:
     steps:

--- a/.circleci/main_config.yml
+++ b/.circleci/main_config.yml
@@ -31,10 +31,9 @@ commands:
       - run:
           name: "Install just"
           command: |
-            wget -qO - 'https://proget.makedeb.org/debian-feeds/prebuilt-mpr.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg 1> /dev/null
-            echo "deb [arch=all,$(dpkg --print-architecture) signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.makedeb.org prebuilt-mpr $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/prebuilt-mpr.list
-            sudo apt update
-            sudo apt install just
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            export PATH="$PATH:$HOME/.cargo/bin"
+            cargo install just
   install-foundry:
     steps:
       - run:


### PR DESCRIPTION
makedeb.org is showing 502 gateway errors on its subdomains including `proget.makedeb.org` which backs the installation of "just" currently (a pre-requisite in every "Required" CI check).

This PR shifts that installation to be backed by Cargo instead.

**Tests**

The correctness of this PR can be seen in all the following CI checks being able to install just in their runs now unlike before.