### PR TITLE
ci: reroute golang-test failures to #notify-superchain-validation-failures

### DIFF
--- a/.circleci/main_config.yml
+++ b/.circleci/main_config.yml
@@ -122,8 +122,10 @@ jobs:
           name: run ops module unit tests
           command: just test-ops
       - notify-failures-on-main:
-          channel: C03N11M0BBN # to slack channel `notify-ci-failures`
-          # TODO this should also be filtered on modified chains
+          channel: C07GQQZDW1G # to slack channel `notify-superchain-validation-failures`
+      #- notify-failures-on-main:
+          #channel: C03N11M0BBN # to slack channel `notify-ci-failures`
+          ## TODO this should also be filtered on modified chains
   golang-validate-modified:
     circleci_ip_ranges: true
     shell: /bin/bash -eo pipefail


### PR DESCRIPTION
Reduce noise in #notify-ci-failures channel so that superchain-registry failures do not hide failures from other test suites. SRC 2.0 is refactoring the entire codebase, including golang tests, so it makes more sense to implement this stopgap than to spend time fixing the existing flakes.