### PR TITLE
minato-sepolia: update chain name to match chainid.network

### DIFF
--- a/chainList.json
+++ b/chainList.json
@@ -560,7 +560,7 @@
     }
   },
   {
-    "name": "Minato",
+    "name": "Soneium Testnet Minato",
     "identifier": "sepolia/minato",
     "chainId": 1946,
     "rpc": [

--- a/chainList.toml
+++ b/chainList.toml
@@ -404,7 +404,7 @@
     chain = "sepolia"
 
 [[chains]]
-  name = "Minato"
+  name = "Soneium Testnet Minato"
   identifier = "sepolia/minato"
   chain_id = 1946
   rpc = ["https://rpc.minato.soneium.org"]

--- a/superchain/configs/configs.json
+++ b/superchain/configs/configs.json
@@ -1893,7 +1893,7 @@
           }
         },
         {
-          "Name": "Minato",
+          "Name": "Soneium Testnet Minato",
           "l2_chain_id": 1946,
           "PublicRPC": "https://rpc.minato.soneium.org",
           "SequencerRPC": "https://rpc.minato.soneium.org",

--- a/superchain/configs/sepolia/minato.toml
+++ b/superchain/configs/sepolia/minato.toml
@@ -1,4 +1,4 @@
-name = "Minato"
+name = "Soneium Testnet Minato"
 chain_id = 1946
 public_rpc = "https://rpc.minato.soneium.org"
 sequencer_rpc = "https://rpc.minato.soneium.org"


### PR DESCRIPTION
Validation checks were failing for this chain. Testing this change locally via the following command and got it to pass. Soneium must have changed their chain name at chainid.network.
```
just validate 1946
```