### PR TITLE
[Jovian] Add JovianTime configuration

### DIFF
--- a/superchain/superchain.go
+++ b/superchain/superchain.go
@@ -62,6 +62,7 @@ type HardForkConfiguration struct {
 	GraniteTime  *uint64 `json:"granite_time,omitempty" toml:"granite_time,omitempty"`
 	HoloceneTime *uint64 `json:"holocene_time,omitempty" toml:"holocene_time,omitempty"`
 	IsthmusTime  *uint64 `json:"isthmus_time,omitempty" toml:"isthmus_time,omitempty"`
+	JovianTime   *uint64 `json:"jovian_time,omitempty" toml:"jovian_time,omitempty"`
 }
 
 type SuperchainLevel uint
@@ -268,6 +269,7 @@ func (c *ChainConfig) GenerateTOMLComments(ctx context.Context) (map[string]stri
 	createTimestampComment("granite_time", c.GraniteTime, comments)
 	createTimestampComment("holocene_time", c.HoloceneTime, comments)
 	createTimestampComment("isthmus_time", c.IsthmusTime, comments)
+	createTimestampComment("jovian_time", c.JovianTime, comments)
 
 	if c.StandardChainCandidate {
 		comments["standard_chain_candidate"] = "# This is a temporary field which causes most of the standard validation checks to run on this chain"

--- a/superchain/superchain_test.go
+++ b/superchain/superchain_test.go
@@ -202,6 +202,7 @@ fjord_time = 4
 granite_time = 5
 holocene_time = 6
 isthmus_time = 7
+jovian_time = 8
 
 [l1]
   chain_id = 314
@@ -231,6 +232,7 @@ isthmus_time = 7
 	require.Equal(t, uint64Ptr(uint64(5)), s.hardForkDefaults.GraniteTime)
 	require.Equal(t, uint64Ptr(uint64(6)), s.hardForkDefaults.HoloceneTime)
 	require.Equal(t, uint64Ptr(uint64(7)), s.hardForkDefaults.IsthmusTime)
+	require.Equal(t, uint64Ptr(uint64(8)), s.hardForkDefaults.JovianTime)
 }
 
 func TestHardForkOverridesAndDefaults(t *testing.T) {


### PR DESCRIPTION
Adds the `JovianTime` variable to the superchain config. This unblocks `optimism` monorepo PRs that will be built for the Jovian hardfork.

Required by https://github.com/ethereum-optimism/optimism/pull/13722