### PR TITLE
worldchain is a standard candidate

### DIFF
--- a/superchain/configs/configs.json
+++ b/superchain/configs/configs.json
@@ -362,7 +362,7 @@
           "Explorer": "https://worldchain-mainnet.explorer.alchemy.com/",
           "SuperchainLevel": 0,
           "GovernedByOptimism": false,
-          "StandardChainCandidate": false,
+          "StandardChainCandidate": true,
           "SuperchainTime": null,
           "batch_inbox_address": "0xff00000000000000000000000000000000000480",
           "Superchain": "mainnet",

--- a/superchain/configs/mainnet/worldchain.toml
+++ b/superchain/configs/mainnet/worldchain.toml
@@ -4,6 +4,7 @@ public_rpc = "https://worldchain-mainnet.g.alchemy.com/public"
 sequencer_rpc = "https://worldchain-mainnet-sequencer.g.alchemy.com"
 explorer = "https://worldchain-mainnet.explorer.alchemy.com/"
 superchain_level = 0
+standard_chain_candidate = true # This is a temporary field which causes most of the standard validation checks to run on this chain
 batch_inbox_addr = "0xff00000000000000000000000000000000000480"
 canyon_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
 delta_time = 0 # Thu 1 Jan 1970 00:00:00 UTC


### PR DESCRIPTION
World Chain was erroneously marked as not a standard candidate. This PR fixes that. All the expected validation checks pass.
