### PR TITLE
Clean up semantics and docs around `superchain_time`

### DIFF
--- a/docs/hardfork-activation-inheritance.md
+++ b/docs/hardfork-activation-inheritance.md
@@ -1,14 +1,9 @@
 # Hardfork activation inheritance behavior
 
-This document specifies how hardfork activations are coordinated between _standard_ chains via the superchain-registry.
-
-Frontier chains can freely choose when to activate hardforks.
-
-If and when a frontier chain becomes a standard chain, a `superchain_time` field is added to that chain's configuration TOML. This field denotes the time after which the chain will receive Superchain upgrades. When that time passes, hardfork activations will be sourced from the chain's `superchain.toml` file. Values are copied from that file into the chain's configuration TOML. This allows a single file to coordinate the hardfork activations of many chains at once.
+There is a mechanism whereby hardfork activation times are set _superchain-wide_ in the `superchain.toml` configuration file present for each superchain target, but then conditionally propagated to all chains in that superchain. This streamlines the process to updated many chains' hardfork activations in synchrony.
 
 For a chain to "receive" a particular default (superchain-wide) hardfork activation time, the following conditions must hold:
-
-* It must have the `superchain_time` set. All superchain-wide hardfork activations will be inherited starting from this timestamp. 
+* It must have the `superchain_time` set. All superchain-wide hardfork activations will be inherited starting from this timestamp.
 * It must not set a non-nil value for this activation time in its individual configuration file
 * The default hardfork activation must be set in the superchain-wide configuration file
 * The hardfork activation time must be equal to or after the `superchain_time`
@@ -20,8 +15,7 @@ At the time of writing, this is implemented for
 * [op-geth](https://docs.optimism.io/builders/node-operators/configuration/base-config#initialization-via-network-flags)
 * [op-node](https://docs.optimism.io/builders/node-operators/configuration/base-config#configuring-op-node)
 
-This implies some more conditions which need to hold for a chain to receive the superchain-wide hardfork activation:
-
+These components load configuration from the superchain registry. This implies some more conditions which need to hold for a chain to receive the superchain-wide hardfork activation:
 * They must be running the above OP Stack software which supports this feature, with the relevant initialization invocations to trigger it
 * The software must be up-to-date enough to embed the latest superchain-wide default hardfork activation times as well as the chain's individual configuration file (complete with `superchain_time` field).
 

--- a/docs/hardfork-activation-inheritance.md
+++ b/docs/hardfork-activation-inheritance.md
@@ -1,6 +1,6 @@
 # Hardfork activation inheritance behavior
 
-There is a mechanism whereby hardfork activation times are set _superchain-wide_ in the `superchain.toml` configuration file present for each superchain target, but then conditionally propagated to all chains in that superchain. This streamlines the process to updated many chains' hardfork activations in synchrony.
+There is a mechanism whereby hardfork activation times are set _superchain-wide_ in the `superchain.toml` configuration file present for each superchain target, but then conditionally propagated to all chains in that superchain. This streamlines the process to update many chains' hardfork activations in synchrony or for chains to opt in to receive hardforks at standard times automatically.
 
 For a chain to "receive" a particular default (superchain-wide) hardfork activation time, the following conditions must hold:
 * It must have the `superchain_time` set. All superchain-wide hardfork activations will be inherited starting from this timestamp.

--- a/ops/cmd/apply_hardforks/main.go
+++ b/ops/cmd/apply_hardforks/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/ethereum-optimism/superchain-registry/ops/internal/config"
@@ -67,10 +66,14 @@ func processSuperchainDir(wd string, superchain config.Superchain) error {
 
 	for _, cfg := range cfgs {
 		chainCfg := cfg.Config
-		if chainCfg.SuperchainTime != nil && int64(*chainCfg.SuperchainTime) < time.Now().Unix() {
-			if err := config.CopyHardforks(&superchainCfg.Hardforks, &chainCfg.Hardforks); err != nil {
-				return fmt.Errorf("error copying hardforks: %w", err)
-			}
+
+		if err := config.CopyHardforks(
+			&superchainCfg.Hardforks,
+			&chainCfg.Hardforks,
+			chainCfg.SuperchainTime,
+			&chainCfg.Genesis.L2Time,
+		); err != nil {
+			return fmt.Errorf("error copying hardforks: %w", err)
 		}
 
 		realCfgData, err := toml.Marshal(chainCfg)

--- a/ops/internal/config/hardforks.go
+++ b/ops/internal/config/hardforks.go
@@ -27,7 +27,6 @@ func (h *HardforkTime) U64Ptr() *uint64 {
 }
 
 func CopyHardforks(src, dst *Hardforks, superchainTime, genesisTime *uint64) error {
-
 	if superchainTime == nil {
 		// No changes if SuperchainTime is unset
 		return nil

--- a/ops/internal/config/hardforks_test.go
+++ b/ops/internal/config/hardforks_test.go
@@ -43,7 +43,6 @@ func TestHardforkTime_MarshalTOML(t *testing.T) {
 }
 
 func TestCopyHardforks(t *testing.T) {
-
 	src := &Hardforks{ // e.g. in superchain.toml
 		CanyonTime: NewHardforkTime(1),
 		DeltaTime:  NewHardforkTime(2),
@@ -70,7 +69,6 @@ func TestCopyHardforks(t *testing.T) {
 }
 
 func TestCopyHardforks2(t *testing.T) {
-
 	canyonAt := func(t uint64) *Hardforks {
 		return &Hardforks{
 			CanyonTime: NewHardforkTime(t),

--- a/ops/internal/config/hardforks_test.go
+++ b/ops/internal/config/hardforks_test.go
@@ -43,18 +43,80 @@ func TestHardforkTime_MarshalTOML(t *testing.T) {
 }
 
 func TestCopyHardforks(t *testing.T) {
-	src := &Hardforks{
+
+	src := &Hardforks{ // e.g. in superchain.toml
 		CanyonTime: NewHardforkTime(1),
 		DeltaTime:  NewHardforkTime(2),
 	}
-	dest := &Hardforks{
+	dest := &Hardforks{ // e.g in individual chain config
 		CanyonTime: NewHardforkTime(0),
 	}
 
-	require.NoError(t, CopyHardforks(src, dest))
+	two := uint64(2)
+	zero := uint64(0)
+
+	require.NoError(t,
+		CopyHardforks(
+			src,
+			dest,
+			&two,  // superchainTime
+			&zero, // genesisTime
+		))
 
 	require.Equal(t, &Hardforks{
 		CanyonTime: NewHardforkTime(0),
 		DeltaTime:  NewHardforkTime(2),
 	}, dest)
+}
+
+func TestCopyHardforks2(t *testing.T) {
+
+	canyonAt := func(t uint64) *Hardforks {
+		return &Hardforks{
+			CanyonTime: NewHardforkTime(t),
+		}
+	}
+	nilCanyon := func() *Hardforks {
+		return &Hardforks{
+			CanyonTime: nil,
+		}
+	}
+
+	genesisAt := func(t uint64) *uint64 {
+		h := uint64(t)
+		return &h
+	}
+	superchainTimeAt := genesisAt
+
+	type testCase struct {
+		name           string
+		src            *Hardforks
+		dest           *Hardforks
+		superchainTime *uint64
+		genesisTime    *uint64
+		expectedDest   *Hardforks
+	}
+
+	testCases := []testCase{
+		{"src+dest(nil_superchain_time)=dest", canyonAt(8), canyonAt(3), nil, genesisAt(0), canyonAt(3)},
+		{"src(nil)+dest=dest", nilCanyon(), canyonAt(8), nil, genesisAt(0), canyonAt(8)},
+		{"src(nil,nil_superchain_time)+dest=dest", nilCanyon(), canyonAt(8), superchainTimeAt(0), genesisAt(0), canyonAt(8)},
+		{"src(after_superchain_time)+dest(nil)=src", canyonAt(3), nilCanyon(), superchainTimeAt(2), genesisAt(0), canyonAt(3)},
+		{"src(after_zero_superchain_time)+dest(nil)=src", canyonAt(3), nilCanyon(), superchainTimeAt(0), genesisAt(0), canyonAt(3)},
+		{"src(before_superchain_time)+dest(nil)=dest", canyonAt(3), nilCanyon(), superchainTimeAt(10), genesisAt(0), nilCanyon()},
+		{"src(after_superchain_time_before_genesis)+dest(nil)=0", canyonAt(3), nilCanyon(), superchainTimeAt(1), genesisAt(4), canyonAt(0)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t,
+				CopyHardforks(
+					tc.src,
+					tc.dest,
+					tc.superchainTime,
+					tc.genesisTime,
+				))
+			require.Equal(t, tc.expectedDest, tc.dest)
+		})
+	}
 }

--- a/ops/internal/config/hardforks_test.go
+++ b/ops/internal/config/hardforks_test.go
@@ -68,7 +68,7 @@ func TestCopyHardforks(t *testing.T) {
 	}, dest)
 }
 
-func TestCopyHardforks2(t *testing.T) {
+func TestCopyHardforksActivationSemantics(t *testing.T) {
 	canyonAt := func(t uint64) *Hardforks {
 		return &Hardforks{
 			CanyonTime: NewHardforkTime(t),


### PR DESCRIPTION
The SCR 2.0 migration has changed the semantics of `superchain_time`. I believe this was unintentional, this PR puts it back to where it was. 