### PR TITLE
docs: add descriptive header to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,7 @@
+# This is the main justfile for the Superchain Registry project.
+# It contains common development commands for testing, linting, and managing the codebase.
+# For more information about the just command runner, visit: https://github.com/casey/just
+
 set positional-arguments := true
 set dotenv-load := true
 


### PR DESCRIPTION
Add a descriptive header to the justfile that explains:
- The purpose of the file in the project
- What kind of commands it contains
- A link to the just command runner documentation

This helps new contributors better understand the purpose of the justfile
and where to find more information about the tool being used.