### PR TITLE
feat: Fix PV Owner address

### DIFF
--- a/ops/internal/report/testdata/deployer-state.json
+++ b/ops/internal/report/testdata/deployer-state.json
@@ -7,7 +7,7 @@
     "l1ChainID": 11155111,
     "superchainRoles": {
       "proxyAdminOwner": "0x1eb2ffc903729a0f03966b917003800b145f56e2",
-      "protocolVersionsOwner": "0x79add5713b383daa0a138d3c4780c7a1804a8090",
+      "protocolVersionsOwner": "0xfd1D2e729aE8eEe2E146c033bf4400fE75284301",
       "guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e"
     },
     "fundDevAccounts": false,

--- a/validation/standard/standard-config-roles-sepolia.toml
+++ b/validation/standard/standard-config-roles-sepolia.toml
@@ -1,7 +1,7 @@
 guardian = "0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E"
 challenger = "0xfd1D2e729aE8eEe2E146c033bf4400fE75284301"
 l1ProxyAdminOwner = "0x1Eb2fFc903729a0F03966B917003800b145F56E2"
-protocolVersionsOwner = "0x79add5713b383daa0a138d3c4780c7a1804a8090"
+protocolVersionsOwner = "0xfd1D2e729aE8eEe2E146c033bf4400fE75284301"
 
 # This is the ALIASED address of the L1 2/2 Safe between the Optimism Foundation and the Security Council.
 # To compute the aliased address, add 0x1111000000000000000000000000000000001111


### PR DESCRIPTION
The ProtocolVersions address was mistakenly registered as the ProtocolVersions owner.

The ProtocolVersions address is [0x79ADD5713B383DAa0a138d3C4780C7A1804a8090](https://github.com/ethereum-optimism/superchain-registry/blob/maur/fix-pv-owner/ops/internal/manage/testdata/superchain/configs/sepolia/superchain.toml#L2). 

```
cast call 0x79ADD5713B383DAa0a138d3C4780C7A1804a8090 'owner()(address)' -r $SEPOLIA_RPC_URL
0xfd1D2e729aE8eEe2E146c033bf4400fE75284301
```
