### PR TITLE
feat: Add mise support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,70 @@
 version: 2.1
 
-orbs:
-  codecov: codecov/codecov@5.0.3
+parameters:
+  default_docker_image:
+    type: string
+    default: cimg/base:2024.01
+
+commands:
+  checkout-with-mise:
+    steps:
+      - checkout
+      - run:
+          name: Initialize mise environment
+          command: |
+            # This is used to create a per-user cache key to preserve permissions across different
+            # executor types.
+            user=$(whoami)
+            echo "$user" > .executor-user
+            echo "Set executor user to $user."
+
+            if [[ "$user" == "root" ]]; then
+              # Self-hosted runners will persist this cache between runs. Cleaning it up means that we
+              # preserve the semantics of the cache regardless of executor type. It's also much faster
+              # to delete the cache and recreate it than it is to overwrite it in place.
+              rm -rf /data/mise-data
+              echo "Cleaned up cache data."
+
+              mkdir -p /data/mise-data
+              echo "Created Mise data dir."
+              mkdir -p ~/.cache
+              echo "Created Mise cache dir."
+            else
+              sudo rm -rf /data/mise-data
+              echo "Cleaned up cache data."
+              sudo mkdir -p /data/mise-data
+              sudo chown -R "$user:$user" /data/mise-data
+              echo "Created Mise data dir."
+              sudo mkdir -p ~/.cache
+              sudo chown -R "$user:$user" ~/.cache
+              echo "Created Mise cache dir."
+            fi
+      - restore_cache:
+          name: Restore mise cache
+          keys:
+            - mise-v5-{{ checksum ".executor-user" }}-{{ checksum "mise.toml" }}
+      - run:
+          name: Install mise
+          command: |
+            if command -v mise &> /dev/null; then
+              echo "mise already installed at $(command -v mise)"
+            else
+              curl https://mise.run | sh
+            fi
+
+            echo "export PATH=\"$HOME/.local/bin:\$PATH\"" >> "$BASH_ENV"
+            echo "export MISE_DATA_DIR=/data/mise-data" >> "$BASH_ENV"
+            echo "export MISE_JOBS=$(nproc)" >> "$BASH_ENV"
+            echo "eval \"\$($HOME/.local/bin/mise activate --shims)\"" >> "$BASH_ENV"
+      - run:
+          name: Install mise deps
+          command: |
+            mise install -v -y
+      - save_cache:
+          name: Save mise cache
+          key: mise-v5-{{ checksum ".executor-user" }}-{{ checksum "mise.toml" }}
+          paths:
+            - /data/mise-data
 
 jobs:
   go-lint-test:
@@ -9,9 +72,9 @@ jobs:
       package:
         type: string
     docker:
-      - image: cimg/go:1.23.1
+      - image: <<pipeline.parameters.default_docker_image>>
     steps:
-      - checkout
+      - checkout-with-mise
       - run:
           name: Tidy mod
           command: |
@@ -43,9 +106,9 @@ jobs:
         type: boolean
         default: false
     docker:
-      - image: cimg/go:1.23.1
+      - image: <<pipeline.parameters.default_docker_image>>
     steps:
-      - checkout
+      - checkout-with-mise
       - run:
           name: Run tool
           command: go run ./cmd/<< parameters.tool >>/main.go << parameters.args >>
@@ -59,9 +122,9 @@ jobs:
 
   check-staging-empty:
     docker:
-      - image: cimg/go:1.23.1
+      - image: <<pipeline.parameters.default_docker_image>>
     steps:
-      - checkout
+      - checkout-with-mise
       - run:
           name: Check staging is empty
           command: |
@@ -85,9 +148,9 @@ jobs:
   run-staging-report:
     circleci_ip_ranges: true
     docker:
-      - image: cimg/go:1.23.1
+      - image: <<pipeline.parameters.default_docker_image>>
     steps:
-      - checkout
+      - checkout-with-mise
       - run:
           name: Check if PR
           command: |
@@ -103,9 +166,9 @@ jobs:
 
   check-addresses:
     docker:
-      - image: cimg/go:1.23.1
+      - image: <<pipeline.parameters.default_docker_image>>
     steps:
-      - checkout
+      - checkout-with-mise
       - run:
           name: Check if addresses.json has changed
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,8 +114,10 @@ jobs:
 workflows:
   scheduled-check-addresses:
     when:
-      and:
-        - equal: ["hourly_build", << pipeline.schedule.name >>]
+      or:
+        # Trigger on new commits
+        - equal: [webhook, << pipeline.trigger_source >>]
+        - equal: ["hourly_build", <<pipeline.schedule.name>>]
     jobs:
       - check-addresses
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,23 +167,13 @@ jobs:
             cd ops
             go run ./cmd/print_staging_report/main.go
 
-  check-codegen-changes:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    steps:
-      - checkout-with-mise
-      - run:
-          name: Checks if running codegen causes changes
-          command: |
-            just check-for-codegen-changes
-
 workflows:
-  scheduled-check-codegen-changes:
+  scheduled-check-onchain-changes:
     when:
       and:
         - equal: ["hourly_build", <<pipeline.schedule.name>>]
     jobs:
-      - check-codegen-changes
+      - echo "Check for implementation changes onchain" # TODO: Implement this & add slack notif
 
   main:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,13 +168,6 @@ jobs:
             go run ./cmd/print_staging_report/main.go
 
 workflows:
-  scheduled-check-onchain-changes:
-    when:
-      and:
-        - equal: ["hourly_build", <<pipeline.schedule.name>>]
-    jobs:
-      - echo "Check for implementation changes onchain" # TODO: Implement this & add slack notif
-
   main:
     jobs:
       - go-lint-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,24 +167,23 @@ jobs:
             cd ops
             go run ./cmd/print_staging_report/main.go
 
-  check-addresses:
+  check-codegen-changes:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
       - checkout-with-mise
       - run:
-          name: Check if addresses.json has changed
+          name: Checks if running codegen causes changes
           command: |
-            just check-for-new-addresses
+            just check-for-codegen-changes
 
 workflows:
-  scheduled-check-addresses:
+  scheduled-check-codegen-changes:
     when:
       and:
-        # Trigger on new commits
         - equal: ["hourly_build", <<pipeline.schedule.name>>]
     jobs:
-      - check-addresses
+      - check-codegen-changes
 
   main:
     jobs:
@@ -216,5 +215,4 @@ workflows:
           tool: check_chainlist
       - run-staging-report:
           name: run-staging-report
-      - check-addresses
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,9 +114,8 @@ jobs:
 workflows:
   scheduled-check-addresses:
     when:
-      or:
+      and:
         # Trigger on new commits
-        - equal: [webhook, << pipeline.trigger_source >>]
         - equal: ["hourly_build", <<pipeline.schedule.name>>]
     jobs:
       - check-addresses
@@ -151,4 +150,5 @@ workflows:
           tool: check_chainlist
       - run-staging-report:
           name: run-staging-report
+      - check-addresses
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  codecov: codecov/codecov@5.0.3
+
 parameters:
   default_docker_image:
     type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,24 @@ jobs:
             cd ops
             go run ./cmd/print_staging_report/main.go
 
+  check-addresses:
+    docker:
+      - image: cimg/go:1.23.1
+    steps:
+      - checkout
+      - run:
+          name: Check if addresses.json has changed
+          command: |
+            just check-for-new-addresses
+
 workflows:
+  scheduled-check-addresses:
+    when:
+      and:
+        - equal: ["hourly_build", << pipeline.schedule.name >>]
+    jobs:
+      - check-addresses
+
   main:
     jobs:
       - go-lint-test:

--- a/justfile
+++ b/justfile
@@ -54,22 +54,5 @@ create-config SHORTNAME FILENAME:
 
 check-chainlist: (_run_ops_bin 'check_chainlist')
 
-check-for-codegen-changes:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if ! git diff-index --quiet HEAD --; then
-        echo -e "\033[31mError: Working directory is not clean. Please commit or stash your changes before checking for codegen changes.\033[0m"
-        exit 1
-    fi
-    just codegen
-    if ! git diff --quiet --exit-code; then
-        echo -e "\033[31m\nError: Code generation produced changes. Please commit them.\033[0m\n"
-        echo -e "\033[31mFiles changed:\033[0m"
-        git status --porcelain
-        exit 1
-    else
-        echo -e "\033[32mNo changes detected after running codegen.\033[0m"
-    fi
-
 
 

--- a/justfile
+++ b/justfile
@@ -57,17 +57,13 @@ check-chainlist: (_run_ops_bin 'check_chainlist')
 check-for-codegen-changes:
     #!/usr/bin/env bash
     set -euo pipefail
-    root_dir=$(git rev-parse --show-toplevel)
-    addresses_path=$root_dir/superchain/extra/addresses/addresses.json
-    hash_before=$(sha256sum $addresses_path)
     just codegen
-    hash_after=$(sha256sum $addresses_path)
-    if [ "$hash_before" != "$hash_after" ]; then
-        echo -e "\033[31m\nError: $addresses_path has changed, please commit codegen changes.\033[0m\n"
+    if ! git diff --quiet --exit-code; then
+        echo -e "\033[31m\nError: Code generation produced changes. Please commit them.\033[0m\n"
         echo -e "\033[31mFiles changed:\033[0m"
         git status --porcelain
+        exit 1
     fi
-    git diff --quiet --exit-code
 
 
 

--- a/justfile
+++ b/justfile
@@ -67,6 +67,8 @@ check-for-codegen-changes:
         echo -e "\033[31mFiles changed:\033[0m"
         git status --porcelain
         exit 1
+    else
+        echo -e "\033[32mNo changes detected after running codegen.\033[0m"
     fi
 
 

--- a/justfile
+++ b/justfile
@@ -53,3 +53,20 @@ create-config SHORTNAME FILENAME:
 	@just _run_ops_bin "create_config" "--shortname {{SHORTNAME}} --state-filename $(realpath {{FILENAME}})"
 
 check-chainlist: (_run_ops_bin 'check_chainlist')
+
+check-for-new-addresses:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    root_dir=$(git rev-parse --show-toplevel)
+    addresses_path=$root_dir/superchain/extra/addresses/addresses.json
+    hash_before=$(sha256sum $addresses_path)
+    just codegen
+    hash_after=$(sha256sum $addresses_path)
+    if [ "$hash_before" != "$hash_after" ]; then
+        echo -e "\033[31m\nError: $addresses_path has changed, please commit the new addresses.json file.\033[0m\n"
+        echo -e "\033[31mFiles changed:\033[0m"
+        git status --porcelain
+        exit 1
+    fi
+
+

--- a/justfile
+++ b/justfile
@@ -57,6 +57,10 @@ check-chainlist: (_run_ops_bin 'check_chainlist')
 check-for-codegen-changes:
     #!/usr/bin/env bash
     set -euo pipefail
+    if ! git diff-index --quiet HEAD --; then
+        echo -e "\033[31mError: Working directory is not clean. Please commit or stash your changes before checking for codegen changes.\033[0m"
+        exit 1
+    fi
     just codegen
     if ! git diff --quiet --exit-code; then
         echo -e "\033[31m\nError: Code generation produced changes. Please commit them.\033[0m\n"

--- a/justfile
+++ b/justfile
@@ -53,6 +53,3 @@ create-config SHORTNAME FILENAME:
 	@just _run_ops_bin "create_config" "--shortname {{SHORTNAME}} --state-filename $(realpath {{FILENAME}})"
 
 check-chainlist: (_run_ops_bin 'check_chainlist')
-
-
-

--- a/justfile
+++ b/justfile
@@ -54,7 +54,7 @@ create-config SHORTNAME FILENAME:
 
 check-chainlist: (_run_ops_bin 'check_chainlist')
 
-check-for-new-addresses:
+check-for-codegen-changes:
     #!/usr/bin/env bash
     set -euo pipefail
     root_dir=$(git rev-parse --show-toplevel)
@@ -63,10 +63,11 @@ check-for-new-addresses:
     just codegen
     hash_after=$(sha256sum $addresses_path)
     if [ "$hash_before" != "$hash_after" ]; then
-        echo -e "\033[31m\nError: $addresses_path has changed, please commit the new addresses.json file.\033[0m\n"
+        echo -e "\033[31m\nError: $addresses_path has changed, please commit codegen changes.\033[0m\n"
         echo -e "\033[31mFiles changed:\033[0m"
         git status --porcelain
-        exit 1
     fi
+    git diff --quiet --exit-code
+
 
 

--- a/mise.toml
+++ b/mise.toml
@@ -7,3 +7,6 @@ just = "1.37.0"
 
 # Go dependencies
 "go:github.com/golangci/golangci-lint/cmd/golangci-lint" = "1.61.0"
+
+[settings]
+experimental = true

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,6 @@
+[tools]
+
+# Core dependencies
+go = "1.23.1"
+just = "1.37.0"
+

--- a/mise.toml
+++ b/mise.toml
@@ -4,8 +4,8 @@
 go = "1.23.1"
 just = "1.37.0"
 
-
 # Go dependencies
+"go:gotest.tools/gotestsum" = "1.12.0"
 "go:github.com/golangci/golangci-lint/cmd/golangci-lint" = "1.61.0"
 
 [settings]

--- a/mise.toml
+++ b/mise.toml
@@ -4,3 +4,6 @@
 go = "1.23.1"
 just = "1.37.0"
 
+
+# Go dependencies
+"go:github.com/golangci/golangci-lint/cmd/golangci-lint" = "1.61.0"


### PR DESCRIPTION
This adds mise to the superchain-registry.

~EDIT: As part of this PR I added `mise` so that I could run `just` commands from the `config.yml` file.~

~As discussed in [discord](https://discord.com/channels/1244729134312198194/1335009077117456394/1336084466833293443), we need this to make sure that `addresses.json` is always up to date. The build should fail if the codegen job creates changes that aren't yet commited to the main branch.~

~I've put this on an hourly trigger that already existed in the superchain-registry configuration settings.~