### PR TITLE
remove _proxy_ from opcm key name

### DIFF
--- a/ops/internal/manage/testdata/superchain/configs/sepolia/superchain.toml
+++ b/ops/internal/manage/testdata/superchain/configs/sepolia/superchain.toml
@@ -1,7 +1,7 @@
 name = "Sepolia"
 protocol_versions_addr = "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
 superchain_config_addr = "0xC2Be75506d5724086DEB7245bd260Cc9753911Be"
-op_contracts_manager_proxy_addr = "0xF564eEA7960EA244bfEbCBbB17858748606147bf"
+op_contracts_manager_addr = "0xF564eEA7960EA244bfEbCBbB17858748606147bf"
 
 [hardforks]
 canyon_time =  1699981200 # Tue 14 Nov 2023 17:00:00 UTC

--- a/superchain/configs/mainnet/superchain.toml
+++ b/superchain/configs/mainnet/superchain.toml
@@ -1,7 +1,7 @@
 name = "Mainnet"
 protocol_versions_addr = "0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935"
 superchain_config_addr = "0x95703e0982140D16f8ebA6d158FccEde42f04a4C"
-op_contracts_manager_proxy_addr = "0x18CeC91779995AD14c880e4095456B9147160790"
+op_contracts_manager_addr = "0x18CeC91779995AD14c880e4095456B9147160790"
 
 [hardforks]
 canyon_time =  1704992401 # Thu 11 Jan 2024 17:00:01 UTC

--- a/superchain/configs/sepolia/superchain.toml
+++ b/superchain/configs/sepolia/superchain.toml
@@ -1,7 +1,7 @@
 name = "Sepolia"
 protocol_versions_addr = "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
 superchain_config_addr = "0xC2Be75506d5724086DEB7245bd260Cc9753911Be"
-op_contracts_manager_proxy_addr = "0xF564eEA7960EA244bfEbCBbB17858748606147bf"
+op_contracts_manager_addr = "0xF564eEA7960EA244bfEbCBbB17858748606147bf"
 
 [hardforks]
 canyon_time =  1699981200 # Tue 14 Nov 2023 17:00:00 UTC


### PR DESCRIPTION
The OPCM is no longer proxied. This just changes the name of the the key from `op_contracts_manager_proxy_addr` to `op_contracts_manager_addr`.

No idea what this might break, hoping to find out here.