### PR TITLE
ops: Write report even if no perms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,10 @@ jobs:
       - run:
           name: Run staging report
           command: |
+            export SEPOLIA_RPC_URL="https://ci-mainnet-l1.optimism.io"
+            export MAINNET_RPC_URL="https://ci-sepolia-l1.optimism.io"
+            export GITHUB_REPO="ethereum-optimism/superchain-registry"
+
             cd ops
             go run ./cmd/print_staging_report/main.go
 


### PR DESCRIPTION
Report PRs are failing because the GITHUB_TOKEN env var is being suppressed by CircleCI on forked PRs. While I work on a different solution here, I've updated the report tool to dump the report to the console in CI so we can still review it.
