### PR TITLE
fix(ci): add missing environment for go-lint-test-ops

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,15 @@ parameters:
   default_docker_image:
     type: string
     default: cimg/base:2024.01
+  sepolia_rpc_url:
+    type: string
+    default: https://ci-sepolia-l1.optimism.io
+  mainnet_rpc_url:
+    type: string
+    default: https://ci-mainnet-l1.optimism.io
+  github_repo:
+    type: string
+    default: ethereum-optimism/superchain-registry
 
 jobs:
   go-lint-test:
@@ -33,6 +42,9 @@ jobs:
           name: Run tests
           command: gotestsum --format testname --junitfile test-results.xml --packages=./... -- --coverprofile coverage.out
           working_directory: << parameters.package >>
+          environment:
+            SEPOLIA_RPC_URL: << pipeline.parameters.sepolia_rpc_url >>
+            MAINNET_RPC_URL: << pipeline.parameters.mainnet_rpc_url >>
       - store_test_results:
           path: << parameters.package >>/test-results.xml
       - codecov/upload:
@@ -104,11 +116,11 @@ jobs:
             fi
       - run:
           name: Run staging report
+          environment:
+            SEPOLIA_RPC_URL: << pipeline.parameters.sepolia_rpc_url >>
+            MAINNET_RPC_URL: << pipeline.parameters.mainnet_rpc_url >>
+            GITHUB_REPO: << pipeline.parameters.github_repo >>
           command: |
-            export SEPOLIA_RPC_URL="https://ci-mainnet-l1.optimism.io"
-            export MAINNET_RPC_URL="https://ci-sepolia-l1.optimism.io"
-            export GITHUB_REPO="ethereum-optimism/superchain-registry"
-
             cd ops
             go run ./cmd/print_staging_report/main.go
 


### PR DESCRIPTION
Set the environment properly this the go-lint-test-ops job, which requires some RPC URLs to be set.

Also centralize the definition of those endpoints, and fix
run-staging-report, which was inverting sepolia and mainnet!
