### PR TITLE
add chain id argument and support for multiple chains in state.json

### DIFF
--- a/justfile
+++ b/justfile
@@ -49,7 +49,7 @@ check-genesis-integrity: (_run_ops_bin 'check_genesis_integrity')
 
 codegen: (_run_ops_bin 'codegen')
 
-create-config SHORTNAME FILENAME:
-	@just _run_ops_bin "create_config" "--shortname {{SHORTNAME}} --state-filename $(realpath {{FILENAME}})"
+create-config SHORTNAME FILENAME CHAINID='':
+	just _run_ops_bin "create_config" '--shortname {{SHORTNAME}} --state-filename $(realpath {{FILENAME}}) {{ if CHAINID != "" { "--chain-id " + CHAINID } else { "" } }}'
 
 check-chainlist: (_run_ops_bin 'check_chainlist')

--- a/ops/cmd/create_config/main.go
+++ b/ops/cmd/create_config/main.go
@@ -26,6 +26,11 @@ var (
 		Required: true,
 		Value:    "newchain",
 	}
+	ChainID = &cli.Int64Flag{
+		Name:     "chain-id",
+		Usage:    "Override the chain ID from the state file.",
+		Required: false,
+	}
 )
 
 func main() {
@@ -35,6 +40,7 @@ func main() {
 		Flags: []cli.Flag{
 			StateFilename,
 			Shortname,
+			ChainID,
 		},
 		Action: action,
 	}
@@ -58,7 +64,14 @@ func action(cliCtx *cli.Context) error {
 	}
 
 	output.WriteOK("inflating chain config")
-	cfg, err := manage.InflateChainConfig(&st)
+
+	var chainID uint64
+	if cliCtx.IsSet(ChainID.Name) {
+		chainID = uint64(cliCtx.Int64(ChainID.Name))
+		output.WriteStderr("overriding chain ID to %d", chainID)
+	}
+
+	cfg, err := manage.InflateChainConfig(&st, chainID)
 	if err != nil {
 		return fmt.Errorf("failed to inflate chain config: %w", err)
 	}


### PR DESCRIPTION
This modifies the justfile and create_config command to optionally accept a chain id. This is useful in cases where there are more than one L2 in the state.json file.

Making the command optional should ensure that the change is non breaking for users.