### PR TITLE
sepolia-dev-0: Move pectra blob schedule fix activation forward to 3/11

### DIFF
--- a/superchain/configs/sepolia-dev-0/base-devnet-0.toml
+++ b/superchain/configs/sepolia-dev-0/base-devnet-0.toml
@@ -19,7 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 1715961600 # Fri 17 May 2024 16:00:00 UTC
   granite_time = 1723046400 # Wed 7 Aug 2024 16:00:00 UTC
   holocene_time = 1731682800 # Fri 15 Nov 2024 15:00:00 UTC
-  pectra_blob_schedule_time = 1742486400 # Thu 20 Mar 2025 16:00:00 UTC
+  pectra_blob_schedule_time = 1741687200 # Tue 11 Mar 2025 10:00:00 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/sepolia-dev-0/oplabs-devnet-0.toml
+++ b/superchain/configs/sepolia-dev-0/oplabs-devnet-0.toml
@@ -19,7 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 1715961600 # Fri 17 May 2024 16:00:00 UTC
   granite_time = 1723046400 # Wed 7 Aug 2024 16:00:00 UTC
   holocene_time = 1731682800 # Fri 15 Nov 2024 15:00:00 UTC
-  pectra_blob_schedule_time = 1742486400 # Thu 20 Mar 2025 16:00:00 UTC
+  pectra_blob_schedule_time = 1741687200 # Tue 11 Mar 2025 10:00:00 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/sepolia-dev-0/superchain.toml
+++ b/superchain/configs/sepolia-dev-0/superchain.toml
@@ -9,8 +9,7 @@ ecotone_time = 1706634000 # Tue 30 Jan 2024 17:00:00 UTC
 fjord_time = 1715961600   # Fri May 17 2024 16:00:00 UTC
 granite_time = 1723046400 # Wed Aug 7 16:00:00 UTC 2024
 holocene_time = 1731682800 # Fri Nov 15 15:00:00 UTC 2024
-
-pectra_blob_schedule_time = 1742486400 # Thu Mar 20 16:00:00 UTC 2025
+pectra_blob_schedule_time = 1741687200 # Tue Mar 11 10:00:00 UTC 2025
 
 [l1]
   chain_id = 11155111


### PR DESCRIPTION
...so we can test the fix activation on our devnets before the Sepolia Superchain activates next week 3/20.

New timestamp: 1741687200 `Tue 11 Mar 2025 10:00:00 UTC`