### PR TITLE
[funki-testnet] add `pectra_blob_schedule_time` hardfork time

### DIFF
--- a/superchain/configs/sepolia/funki.toml
+++ b/superchain/configs/sepolia/funki.toml
@@ -15,6 +15,7 @@ max_sequencer_drift = 600
   canyon_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   delta_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   ecotone_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
+  pectra_blob_schedule_time = 1744696800 # Tue 15 Apr 2025 06:00:00 UTC
 
 [optimism]
   eip1559_elasticity = 6


### PR DESCRIPTION
# Adding the `pectra_blob_schedule_time` hardfork time for funki testnet

We plan to set the pectra_blob_schedule_time hardfork time to Tue 15 Apr 2025 06:00:00 UTC for funki-tstnet

```toml
pectra_blob_schedule_time = 1744696800 # Tue 15 Apr 2025 06:00:00 UTC
```