### PR TITLE
pre-sr2: tweak error handling

### DIFF
--- a/validation/genesis/genesis-allocs_test.go
+++ b/validation/genesis/genesis-allocs_test.go
@@ -180,8 +180,8 @@ func testGenesisAllocs(t *testing.T, chain *ChainConfig) {
 	}
 
 	g, err := core.LoadOPStackGenesis(chainId)
-	removeEmptyStorageSlots(g.Alloc, t)
 	require.NoError(t, err)
+	removeEmptyStorageSlots(g.Alloc, t)
 
 	if chainId == uint64(1301) {
 		delete(g.Alloc, common.HexToAddress("0x1f98431c8ad98523631ae4a59f267346ea31f984"))


### PR DESCRIPTION
it's wrong to continue executing when we get the error, since we may get a panic trying to access something which doesn't exist.

