### PR TITLE
Revert "Add new value for EIP-1559 elasticity for WorldChain Sepolia and Mainnet"

### DIFF
--- a/superchain/configs/mainnet/worldchain.toml
+++ b/superchain/configs/mainnet/worldchain.toml
@@ -20,7 +20,7 @@ max_sequencer_drift = 1800
   holocene_time = 1738238400 # Thu 30 Jan 2025 12:00:00 UTC
 
 [optimism]
-  eip1559_elasticity = 2
+  eip1559_elasticity = 10
   eip1559_denominator = 50
   eip1559_denominator_canyon = 250
 

--- a/superchain/configs/sepolia/worldchain.toml
+++ b/superchain/configs/sepolia/worldchain.toml
@@ -21,7 +21,7 @@ max_sequencer_drift = 1800
   pectra_blob_schedule_time = 1742486400 # Thu 20 Mar 2025 16:00:00 UTC
 
 [optimism]
-  eip1559_elasticity = 2
+  eip1559_elasticity = 10
   eip1559_denominator = 50
   eip1559_denominator_canyon = 250
 


### PR DESCRIPTION
Reverts ethereum-optimism/superchain-registry#922

The elasticity parameters in the chain config must not be changed when they are dynamically changed later. These values must reflect the static config that was present pre-Holocene.

In a follow up, we'll move the `[optimism]` section into the `[genesis]` section to avoid this footgun (https://github.com/ethereum-optimism/superchain-registry/issues/969).