### PR TITLE
mainnet: Schedule Isthmus hardfork on Mainnet Superchain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,11 @@ jobs:
             CHANGED_FILE_COUNT=0
 
             for file in $CHANGED_FILES; do
+              # If the file is the superchain.toml file, skip it
+              if [[ "$file" == *"superchain.toml" ]]; then
+                continue
+              fi
+
               CHANGED_FILE_COUNT=$((CHANGED_FILE_COUNT + 1))
               # Use yq to extract chain_id from TOML
               CHAIN_ID=$(yq -p=toml -o=json '.chain_id' "$file" | grep -v "null" | tr -d '"')

--- a/superchain/configs/mainnet/arena-z.toml
+++ b/superchain/configs/mainnet/arena-z.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   granite_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 20

--- a/superchain/configs/mainnet/base.toml
+++ b/superchain/configs/mainnet/base.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/bob.toml
+++ b/superchain/configs/mainnet/bob.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/ethernity.toml
+++ b/superchain/configs/mainnet/ethernity.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 20

--- a/superchain/configs/mainnet/ink.toml
+++ b/superchain/configs/mainnet/ink.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   granite_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   holocene_time = 1742396400 # Wed 19 Mar 2025 15:00:00 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/lisk.toml
+++ b/superchain/configs/mainnet/lisk.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 20

--- a/superchain/configs/mainnet/lyra.toml
+++ b/superchain/configs/mainnet/lyra.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/metal.toml
+++ b/superchain/configs/mainnet/metal.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/mint.toml
+++ b/superchain/configs/mainnet/mint.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/mode.toml
+++ b/superchain/configs/mainnet/mode.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/op.toml
+++ b/superchain/configs/mainnet/op.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/orderly.toml
+++ b/superchain/configs/mainnet/orderly.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/polynomial.toml
+++ b/superchain/configs/mainnet/polynomial.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/snax.toml
+++ b/superchain/configs/mainnet/snax.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/soneium.toml
+++ b/superchain/configs/mainnet/soneium.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   granite_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   holocene_time = 1738573200 # Mon 3 Feb 2025 09:00:00 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/superchain.toml
+++ b/superchain/configs/mainnet/superchain.toml
@@ -8,7 +8,8 @@ delta_time =   1708560000 # Thu 22 Feb 2024 00:00:00 UTC
 ecotone_time = 1710374401 # Thu 14 Mar 2024 00:00:01 UTC
 fjord_time =   1720627201 # Wed 10 Jul 2024 16:00:01 UTC
 granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
-holocene_time = 1736445601 # Thu 09 Jan 2025 18:00:01 UTC
+holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [l1]
   chain_id = 1

--- a/superchain/configs/mainnet/tbn.toml
+++ b/superchain/configs/mainnet/tbn.toml
@@ -20,6 +20,7 @@ gas_paying_token = "0x04E9D7e336f79Cdab911b06133D3Ca2Cd0721ce3"
   fjord_time = 1725536344 # Thu 5 Sep 2024 11:39:04 UTC
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/unichain.toml
+++ b/superchain/configs/mainnet/unichain.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   granite_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/zora.toml
+++ b/superchain/configs/mainnet/zora.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   fjord_time = 1720627201 # Wed 10 Jul 2024 16:00:01 UTC
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6


### PR DESCRIPTION
* Fri 9 May 2025 16:00:01 UTC
* unix timestamp 1746806401

Included chains (`grep -l isthmus_time *`):
```
arena-z.toml
base.toml
bob.toml
ethernity.toml
ink.toml
lisk.toml
lyra.toml
metal.toml
mint.toml
mode.toml
op.toml
orderly.toml
polynomial.toml
snax.toml
soneium.toml
tbn.toml
unichain.toml
zora.toml
```
excluded chains (`grep -L isthmus_time *`):
```
automata.toml
cyber.toml
funki.toml
hashkeychain.toml
race.toml
redstone.toml
settlus-mainnet.toml
shape.toml
sseed.toml
swan.toml
swell.toml
worldchain.toml
xterio-eth.toml
```