### PR TITLE
perf: optimize Hash.UnmarshalText with direct byte comparison

### DIFF
--- a/validation/types.go
+++ b/validation/types.go
@@ -1,7 +1,6 @@
 package validation
 
 import (
-	"bytes"
 	"encoding/hex"
 	"fmt"
 )
@@ -47,7 +46,7 @@ func (h *Hash) UnmarshalText(text []byte) error {
 		return nil
 	}
 
-	if len(text) < 2 || !bytes.HasPrefix(text, []byte("0x")) {
+	if len(text) < 2 || text[0] != '0' || text[1] != 'x' {
 		return fmt.Errorf("hex string must have 0x prefix")
 	}
 


### PR DESCRIPTION
Replaced bytes.HasPrefix() with direct byte comparison in Hash.UnmarshalText, removing unnecessary allocation and function call. This change simplifies the code while maintaining identical behavior and removing an unused import.