### PR TITLE
Update Boba Sepolia testnet pectra blob schedule time

### DIFF
--- a/superchain/configs/sepolia/boba.toml
+++ b/superchain/configs/sepolia/boba.toml
@@ -18,6 +18,7 @@ max_sequencer_drift = 600
   fjord_time = 1722297600 # Tue 30 Jul 2024 00:00:00 UTC
   granite_time = 1726470000 # Mon 16 Sep 2024 07:00:00 UTC
   holocene_time = 1736150400 # Mon 6 Jan 2025 08:00:00 UTC
+  pectra_blob_schedule_time = 1743534000 # Tue 1 Apr 2025 19:00:00 UTC
 
 [optimism]
   eip1559_elasticity = 6


### PR DESCRIPTION
This hardfork is already live on our network but was not included in our initial submission of the superchain config.

This simply synchronizes the hard fork time from our forked configuration (in an effort to ultimately remove our fork).