### PR TITLE
Removing superchain_time from chains not on the latest releases

### DIFF
--- a/superchain/configs/mainnet/arena-z.toml
+++ b/superchain/configs/mainnet/arena-z.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://rpc.arena-z.gg"
 explorer = "https://explorer.arena-z.gg"
 superchain_level = 1
 governed_by_optimism = true
-superchain_time = 1736445601
 data_availability_type = "eth-da"
 chain_id = 7897
 batch_inbox_addr = "0x00f9BCEe08DCe4F0e7906c1f6cFb10c77802EEd0"

--- a/superchain/configs/mainnet/bob.toml
+++ b/superchain/configs/mainnet/bob.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://rpc.gobob.xyz"
 explorer = "https://explorer.gobob.xyz"
 superchain_level = 0
 governed_by_optimism = false
-superchain_time = 0
 data_availability_type = "eth-da"
 chain_id = 60808
 batch_inbox_addr = "0x3A75346f81302aAc0333FB5DCDD407e12A6CfA83"

--- a/superchain/configs/mainnet/ethernity.toml
+++ b/superchain/configs/mainnet/ethernity.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://mainnet.ethernitychain.io"
 explorer = "https://ernscan.io"
 superchain_level = 1
 governed_by_optimism = false
-superchain_time = 0
 data_availability_type = "eth-da"
 chain_id = 183
 batch_inbox_addr = "0xfF00000000000000000000000000000000000183"

--- a/superchain/configs/mainnet/lisk.toml
+++ b/superchain/configs/mainnet/lisk.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://rpc.api.lisk.com"
 explorer = "https://blockscout.lisk.com"
 superchain_level = 1
 governed_by_optimism = false
-superchain_time = 0
 data_availability_type = "eth-da"
 chain_id = 1135
 batch_inbox_addr = "0xFf00000000000000000000000000000000001135"

--- a/superchain/configs/mainnet/lyra.toml
+++ b/superchain/configs/mainnet/lyra.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://rpc.lyra.finance"
 explorer = "https://explorer.lyra.finance"
 superchain_level = 0
 governed_by_optimism = false
-superchain_time = 0
 data_availability_type = "alt-da"
 chain_id = 957
 batch_inbox_addr = "0x5f7f7f6DB967F0ef10BdA0678964DBA185d16c50"

--- a/superchain/configs/mainnet/metal.toml
+++ b/superchain/configs/mainnet/metal.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://rpc.metall2.com"
 explorer = "https://explorer.metall2.com"
 superchain_level = 1
 governed_by_optimism = true
-superchain_time = 0
 data_availability_type = "eth-da"
 chain_id = 1750
 batch_inbox_addr = "0xc83f7D9F2D4A76E81145849381ABA02602373723"

--- a/superchain/configs/mainnet/mint.toml
+++ b/superchain/configs/mainnet/mint.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://rpc.mintchain.io"
 explorer = "https://explorer.mintchain.io"
 superchain_level = 0
 governed_by_optimism = false
-superchain_time = 0
 data_availability_type = "eth-da"
 chain_id = 185
 batch_inbox_addr = "0x4e31448a098393727b786e25B54E59DcA1b77FE1"

--- a/superchain/configs/mainnet/mode.toml
+++ b/superchain/configs/mainnet/mode.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://mainnet-sequencer.mode.network"
 explorer = "https://explorer.mode.network"
 superchain_level = 1
 governed_by_optimism = true
-superchain_time = 0
 data_availability_type = "eth-da"
 chain_id = 34443
 batch_inbox_addr = "0x24E59d9d3Bd73ccC28Dc54062AF7EF7bFF58Bd67"

--- a/superchain/configs/mainnet/orderly.toml
+++ b/superchain/configs/mainnet/orderly.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://rpc.orderly.network"
 explorer = "https://explorer.orderly.network"
 superchain_level = 0
 governed_by_optimism = false
-superchain_time = 0
 data_availability_type = "alt-da"
 chain_id = 291
 batch_inbox_addr = "0x08aA34cC843CeEBcC88A627F18430294aA9780be"

--- a/superchain/configs/mainnet/polynomial.toml
+++ b/superchain/configs/mainnet/polynomial.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://rpc.polynomial.fi"
 explorer = "https://polynomialscan.io"
 superchain_level = 1
 governed_by_optimism = false
-superchain_time = 0
 data_availability_type = "eth-da"
 chain_id = 8008
 batch_inbox_addr = "0x0bd57e83B5E0f9eCD84d559bB58e1EcFEEdD2565"

--- a/superchain/configs/mainnet/snax.toml
+++ b/superchain/configs/mainnet/snax.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://mainnet.snaxchain.io"
 explorer = "https://explorer.snaxchain.io"
 superchain_level = 0
 governed_by_optimism = false
-superchain_time = 0
 data_availability_type = "eth-da"
 chain_id = 2192
 batch_inbox_addr = "0xFeC57BD3729a5F930d4Ee8ac5992Fdc8988426e4"

--- a/superchain/configs/mainnet/tbn.toml
+++ b/superchain/configs/mainnet/tbn.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://sequencer.bnry.mainnet.zeeve.net"
 explorer = "https://explorer.thebinaryholdings.com"
 superchain_level = 0
 governed_by_optimism = false
-superchain_time = 1726070401
 data_availability_type = "eth-da"
 chain_id = 624
 batch_inbox_addr = "0xFF00000000000000000000000000000000000624"

--- a/superchain/configs/mainnet/zora.toml
+++ b/superchain/configs/mainnet/zora.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://rpc.zora.energy"
 explorer = "https://explorer.zora.energy"
 superchain_level = 1
 governed_by_optimism = true
-superchain_time = 0
 data_availability_type = "eth-da"
 chain_id = 7777777
 batch_inbox_addr = "0x6F54Ca6F6EdE96662024Ffd61BFd18f3f4e34DFf"

--- a/superchain/configs/sepolia/creator-chain-testnet.toml
+++ b/superchain/configs/sepolia/creator-chain-testnet.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://rpc.creatorchain.io"
 explorer = "https://explorer.creatorchain.io"
 superchain_level = 0
 governed_by_optimism = false
-superchain_time = 0
 data_availability_type = "eth-da"
 chain_id = 66665
 batch_inbox_addr = "0xFA5c2402828228a8Dd700bA1E71f5E1128876Fa8"

--- a/superchain/configs/sepolia/ethernity.toml
+++ b/superchain/configs/sepolia/ethernity.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://testnet.ethernitychain.io"
 explorer = "https://testnet.ernscan.io"
 superchain_level = 1
 governed_by_optimism = false
-superchain_time = 0
 data_availability_type = "eth-da"
 chain_id = 233
 batch_inbox_addr = "0xFf00000000000000000000000000000000000233"

--- a/superchain/configs/sepolia/lisk.toml
+++ b/superchain/configs/sepolia/lisk.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://rpc.sepolia-api.lisk.com"
 explorer = "https://sepolia-blockscout.lisk.com"
 superchain_level = 1
 governed_by_optimism = false
-superchain_time = 1708534800
 data_availability_type = "eth-da"
 chain_id = 4202
 batch_inbox_addr = "0xff00000000000000000000000000000000004202"

--- a/superchain/configs/sepolia/metal.toml
+++ b/superchain/configs/sepolia/metal.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://testnet.rpc.metall2.com"
 explorer = "https://testnet.explorer.metall2.com"
 superchain_level = 1
 governed_by_optimism = true
-superchain_time = 1708534800
 data_availability_type = "eth-da"
 chain_id = 1740
 batch_inbox_addr = "0x24567B64a86A4c966655fba6502a93dFb701E316"

--- a/superchain/configs/sepolia/mode.toml
+++ b/superchain/configs/sepolia/mode.toml
@@ -4,7 +4,6 @@ sequencer_rpc = "https://sepolia.mode.network"
 explorer = "https://sepolia.explorer.mode.network"
 superchain_level = 1
 governed_by_optimism = true
-superchain_time = 1703203200
 data_availability_type = "eth-da"
 chain_id = 919
 batch_inbox_addr = "0xcDDaE6148dA1E003C230E4527f9baEdc8a204e7E"


### PR DESCRIPTION
## Description

This PR removes the `superchain_time` from chain configurations that are not on the latest smart contract release version and/or hardfork. I have added the `F-do-not-merge` label because I want to do comms with these chain operators prior to merging and this going into effect. They need an opportunity to assess the downstream effects of this change.

Certain edge cases will be applied if the Security Council or the Optimism Foundation is part of the multisig that holds the L1 ProxyAdmin owner role. If these entities are part of your upgrade process and you're behind on L1 smart contract upgrades; we are actively working towards upgrading these chains to the latest version. We will add the superchain wide activation behavior back to your chains once we have them in sync with the Superchain whom conform to the [Standard Rollup charter](https://docs.optimism.io/superchain/blockspace-charter). 

## Motivation

The way we test upgrades are to do the L1 contract upgrade first and then activate the hard fork. We do not want to be activating hard forks on networks that do not have the latest L1 contract releases yet because there are potential footguns that may not have been considered because we are following the expected upgrade release process of L1 contracts then hard fork.