### PR TITLE
Add codecove

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+    patch:
+      default:
+        target: auto
+        threshold: 0%
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: true
+      loop: true
+      method: false
+      macro: false
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
This PR adds Codecov integration to the repository following the pattern established in ethereum-optimism/optimism#13062.
This change:
- Adds a codecov.yml configuration file to the root of the repository
- Utilizes the existing codecov/upload step already present in CircleCI configuration
- Configures code coverage thresholds and reporting settings

Fixes #709 