### PR TITLE
Add prompt to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,7 @@ This PR adds [Chain Name Here] to the registry.
 ## Checklist
 
 - [ ] I have declared the chain at the appropriate [Superchain Level](../docs/glossary.md#superchain-level-and-rollup-stage).
+- [ ] I confirm I have set `superchain_time` to an appropriate value if I want my chain to receive hardfork times with the rest of the superchain. See [hardfork activation inheritance](../docs/hardfork-activation-inheritance.md) and [CHAINS.md](../CHAINS.md) for details.
 - [ ] I have run `just codegen` to ensure that all generated files are created.
 - [ ] I have run `just codegen` to ensure that the chainlist and other generated files are up-to-date and include my chain.
 - [ ] I have checked `Allow edits from maintainers` on this PR.


### PR DESCRIPTION
resolves #752 

I've updated the PR template to clarify that setting `superchain_time` is optional but necessary for chains that want to receive hardfork times with the rest of the superchain. Added links to relevant documentation so contributors can understand the implications of this setting before submitting their chain. This helps ensure new chains make an informed decision about hardfork inheritance.
