### PR TITLE
Add proofs team to reviewers for standard prestates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 # Default code-owner
 * @ethereum-optimism/superchain-registry-reviewers
+
+/validation/standard/standard-prestates.toml @ethereum-optimism/proofs @ethereum-optimism/superchain-registry-reviewers


### PR DESCRIPTION
Add the proofs team to the list of people who can approve changes to the standard prestates. The proofs team owns development and maintenance of op-program and cannon which is where that list comes from.