### PR TITLE
Updating sseed's hardfork activation times

### DIFF
--- a/superchain/configs/mainnet/sseed.toml
+++ b/superchain/configs/mainnet/sseed.toml
@@ -16,6 +16,9 @@ max_sequencer_drift = 600
   delta_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   ecotone_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   fjord_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
+  granite_time = 1726185601 # Fri 13 Sep 2024 00:00:01 UTC
+  holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
+  isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6


### PR DESCRIPTION
## Description

Updating Superseed Mainnet's hardforks based on the changes @emilianobonassi wanted to make in https://github.com/ethereum-optimism/superchain-registry/pull/994. They have the same diff, but the CI passed on my branch.