### PR TITLE
Fix validation_test.go reference path in standard readme

### DIFF
--- a/validation/standard/readme.md
+++ b/validation/standard/readme.md
@@ -5,5 +5,5 @@ Distinct, named declaration files have been added (where necessary) to allow tes
 
 Parameters may be declared to be equal to a pair of values, meaning that the parameter must be within the bounds defined by those values.
 
-The TOML files are embedded into Go bindings, which are in turn referenced by the validation checks in the parent directory. The entrypoint for those checks is [`validation_test.go`](../validation_test.go).
+The TOML files are embedded into Go bindings, which are in turn referenced by the validation checks in the parent directory. The entrypoint for those checks is [`validation_test.go`](../../ops/internal/validation/versions_test.go).
 


### PR DESCRIPTION
Update the incorrect file path reference in validation/standard/readme.md.
The file was pointing to a non-existent ../validation_test.go file in the
parent directory. Updated to point to the correct location at
../../ops/internal/validation/versions_test.go which contains the relevant
validation tests for the standard configuration files.

This fixes the broken link error that was appearing during validation.