### PR TITLE
Finalize op-program v1.6.0-rc.2 as v1.6.0

### DIFF
--- a/validation/standard/standard-prestates.toml
+++ b/validation/standard/standard-prestates.toml
@@ -1,5 +1,17 @@
-latest_stable = "1.5.0"
+latest_stable = "1.6.0"
 latest_rc = "1.6.0-rc.2"
+
+[[prestates."1.6.0"]]
+type = "cannon32"
+hash = "0x03513e996556589f633fe1d38d694f63bc93cca5df559af37631b30875a829e9"
+
+[[prestates."1.6.0"]]
+type = "cannon64"
+hash = "0x03682932cec7ce0a3874b19675a6bbc923054a7b321efc7d3835187b172494b6"
+
+[[prestates."1.6.0"]]
+  type = "interop"
+  hash = "0x0399cfb018011977a027d1e7a85eb7ff101aec9bfc7d6500abac944c47a4581f"
 
 [[prestates."1.6.0-rc.2"]]
 type = "cannon32"


### PR DESCRIPTION
Finalize op-program v1.6.0-rc.2 as v1.6.0

https://github.com/ethereum-optimism/optimism/releases/tag/op-program/v1.6.0