### PR TITLE
genesis integrity: add missing hardforks

### DIFF
--- a/ops/internal/config/chain.go
+++ b/ops/internal/config/chain.go
@@ -110,6 +110,8 @@ type Hardforks struct {
 	HoloceneTime           *HardforkTime `toml:"holocene_time"`
 	PectraBlobScheduleTime *HardforkTime `toml:"pectra_blob_schedule_time,omitempty"`
 	IsthmusTime            *HardforkTime `toml:"isthmus_time"`
+	InteropTime            *HardforkTime `toml:"interop_time,omitempty"`
+	JovianTime             *HardforkTime `toml:"jovian_time,omitempty"`
 }
 
 type Genesis struct {

--- a/ops/internal/manage/validation.go
+++ b/ops/internal/manage/validation.go
@@ -95,7 +95,7 @@ func ValidateGenesisIntegrity(cfg *config.Chain, genesis *core.Genesis) error {
 		MergeNetsplitBlock:      common.Big0,
 		ShanghaiTime:            cfg.Hardforks.CanyonTime.U64Ptr(),  // Shanghai activates with Canyon
 		CancunTime:              cfg.Hardforks.EcotoneTime.U64Ptr(), // Cancun activates with Ecotone
-		PragueTime:              nil,
+		PragueTime:              cfg.Hardforks.IsthmusTime.U64Ptr(), // Prague activates with Isthmus
 		BedrockBlock:            common.Big0,
 		RegolithTime:            &genesisActivation,
 		CanyonTime:              cfg.Hardforks.CanyonTime.U64Ptr(),
@@ -103,6 +103,9 @@ func ValidateGenesisIntegrity(cfg *config.Chain, genesis *core.Genesis) error {
 		FjordTime:               cfg.Hardforks.FjordTime.U64Ptr(),
 		GraniteTime:             cfg.Hardforks.GraniteTime.U64Ptr(),
 		HoloceneTime:            cfg.Hardforks.HoloceneTime.U64Ptr(),
+		IsthmusTime:             cfg.Hardforks.IsthmusTime.U64Ptr(),
+		InteropTime:             cfg.Hardforks.InteropTime.U64Ptr(),
+		JovianTime:              cfg.Hardforks.JovianTime.U64Ptr(),
 		TerminalTotalDifficulty: common.Big0,
 		Ethash:                  nil,
 		Clique:                  nil,


### PR DESCRIPTION
This is necessary to support genesis integrity checks for chains with Isthmus and/or Interop activated at genesis (i.e. recent devnets). 