### PR TITLE
configs: use slimmed down depset schema

### DIFF
--- a/ops/internal/config/chain.go
+++ b/ops/internal/config/chain.go
@@ -60,13 +60,10 @@ type StagedChain struct {
 	DeploymentL2ContractsVersion *artifacts.Locator `toml:"deployment_l2_contracts_version"`
 }
 
-type Dependency struct {
-	ChainIndex     uint32 `json:"chainIndex" toml:"chain_index"`
-	ActivationTime uint64 `json:"activationTime" toml:"activation_time"`
-}
+type StaticConfigDependency struct{}
 
 type Interop struct {
-	Dependencies map[string]Dependency `json:"dependencies" toml:"dependencies"`
+	Dependencies map[string]StaticConfigDependency `json:"dependencies" toml:"dependencies"`
 }
 
 type Chain struct {

--- a/ops/internal/manage/depsets_test.go
+++ b/ops/internal/manage/depsets_test.go
@@ -60,19 +60,6 @@ func TestDepsetChecker(t *testing.T) {
 		require.NoError(t, checker.Check())
 	})
 
-	t.Run("invalid depsets", func(t *testing.T) {
-		addrs := loadAddresses(t, validAddressesPath)
-
-		var cfgs []DiskChainConfig
-		chain1 := loadChainConfig(t, "testdata/depsets_invalid/depset_value_1.toml")
-		chain2 := loadChainConfig(t, "testdata/depsets_invalid/depset_value_2.toml")
-		cfgs = append(cfgs, DiskChainConfig{Config: chain1, Superchain: "test"})
-		cfgs = append(cfgs, DiskChainConfig{Config: chain2, Superchain: "test"})
-
-		checker := NewDepsetChecker(lgr, cfgs, addrs)
-		require.Error(t, checker.Check())
-	})
-
 	t.Run("invalid depsets (transience)", func(t *testing.T) {
 		addrs := loadAddresses(t, "testdata/depsets_invalid/transience/addresses.json")
 		chains, err := CollectChainConfigs("testdata/depsets_invalid/transience")
@@ -93,38 +80,6 @@ func TestDepsetChecker_checkOffchain(t *testing.T) {
 		err := checker.checkOffchain(nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no chain configs provided to checkOffchain")
-	})
-
-	t.Run("invalid activation_time", func(t *testing.T) {
-		addrs := loadAddresses(t, validAddressesPath)
-		var cfg config.Chain
-		err := paths.ReadTOMLFile("testdata/depsets_invalid/activation_time.toml", &cfg)
-		require.NoError(t, err)
-
-		chains := []DiskChainConfig{
-			{Config: &cfg, Superchain: "test"},
-		}
-
-		checker := NewDepsetChecker(lgr, chains, addrs)
-		err = checker.checkOffchain(chains)
-		require.Error(t, err)
-		require.ErrorIs(t, err, errInvalidActivationTime)
-	})
-
-	t.Run("duplicate chain index", func(t *testing.T) {
-		addrs := loadAddresses(t, validAddressesPath)
-		var cfg config.Chain
-		err := paths.ReadTOMLFile("testdata/depsets_invalid/duplicate_chain_index.toml", &cfg)
-		require.NoError(t, err)
-
-		chains := []DiskChainConfig{
-			{Config: &cfg, Superchain: "test"},
-		}
-
-		checker := NewDepsetChecker(lgr, chains, addrs)
-		err = checker.checkOffchain(chains)
-		require.Error(t, err)
-		require.ErrorIs(t, err, errDuplicateChainIndex)
 	})
 
 	t.Run("inconsistent depset lengths", func(t *testing.T) {
@@ -148,14 +103,14 @@ func TestDepsetChecker_checkOffchain(t *testing.T) {
 		require.ErrorIs(t, err, errDepsetLengths)
 	})
 
-	t.Run("inconsistent depset activation times", func(t *testing.T) {
+	t.Run("missing interop_time", func(t *testing.T) {
 		addrs := loadAddresses(t, validAddressesPath)
 		var cfg1 config.Chain
-		err := paths.ReadTOMLFile("testdata/depsets_invalid/depset_value_1.toml", &cfg1)
+		err := paths.ReadTOMLFile("testdata/depsets_invalid/missing_interop_time_1.toml", &cfg1)
 		require.NoError(t, err)
 
 		var cfg2 config.Chain
-		err = paths.ReadTOMLFile("testdata/depsets_invalid/depset_value_2.toml", &cfg2)
+		err = paths.ReadTOMLFile("testdata/depsets_invalid/missing_interop_time_2.toml", &cfg2)
 		require.NoError(t, err)
 
 		chains := []DiskChainConfig{
@@ -166,7 +121,7 @@ func TestDepsetChecker_checkOffchain(t *testing.T) {
 		checker := NewDepsetChecker(lgr, chains, addrs)
 		err = checker.checkOffchain(chains)
 		require.Error(t, err)
-		require.ErrorIs(t, err, errInconsistentDepsets)
+		require.ErrorIs(t, err, errMissingInteropTime)
 	})
 }
 

--- a/ops/internal/manage/testdata/depsets_invalid/activation_time.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/activation_time.toml
@@ -1,9 +1,0 @@
-name = "Test Chain 4"
-chain_id = 904
-
-[hardforks]
-interop_time = 1746806401
-
-[interop]
-dependencies."904" = { chain_index = 0, activation_time = 1746000000, history_min_time = 40 }
-dependencies."903" = { chain_index = 1, activation_time = 1746806401, history_min_time = 40 }

--- a/ops/internal/manage/testdata/depsets_invalid/depset_length_1.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/depset_length_1.toml
@@ -5,5 +5,5 @@ chain_id = 903
 interop_time = 3333
 
 [interop]
-dependencies."903" = { chain_index = 1, activation_time = 3333, history_min_time = 40 }
-dependencies."904" = { chain_index = 2, activation_time = 4444, history_min_time = 456 }
+dependencies."903" = {}
+dependencies."904" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/depset_length_2.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/depset_length_2.toml
@@ -5,4 +5,4 @@ chain_id = 904
 interop_time = 4444
 
 [interop]
-dependencies."904" = { chain_index = 4, activation_time = 4444, history_min_time = 456 }
+dependencies."904" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/depset_value_1.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/depset_value_1.toml
@@ -1,9 +1,0 @@
-name = "Test Chain 5"
-chain_id = 905
-
-[hardforks]
-interop_time = 5555
-
-[interop]
-dependencies."905" = { chain_index = 1, activation_time = 5555, history_min_time = 40 }
-dependencies."906" = { chain_index = 2, activation_time = 5555, history_min_time = 456 }

--- a/ops/internal/manage/testdata/depsets_invalid/depset_value_2.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/depset_value_2.toml
@@ -1,9 +1,0 @@
-name = "Test Chain 6"
-chain_id = 906
-
-[hardforks]
-interop_time = 6666
-
-[interop]
-dependencies."906" = { chain_index = 1, activation_time = 6666, history_min_time = 40 }
-dependencies."905" = { chain_index = 2, activation_time = 5555, history_min_time = 456 }

--- a/ops/internal/manage/testdata/depsets_invalid/duplicate_chain_index.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/duplicate_chain_index.toml
@@ -1,9 +1,0 @@
-name = "Test Chain 1"
-chain_id = 901
-
-[hardforks]
-interop_time = 1234
-
-[interop]
-dependencies."901" = { chain_index = 1, activation_time = 1234, history_min_time = 40 }
-dependencies."902" = { chain_index = 1, activation_time = 4424, history_min_time = 456 }

--- a/ops/internal/manage/testdata/depsets_invalid/missing_interop_time_1.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/missing_interop_time_1.toml
@@ -7,4 +7,3 @@ interop_time = 5555
 [interop]
 dependencies."905" = {}
 dependencies."906" = {}
-dependencies."907" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/missing_interop_time_2.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/missing_interop_time_2.toml
@@ -2,9 +2,7 @@ name = "Test Chain 6"
 chain_id = 906
 
 [hardforks]
-interop_time = 6666
 
 [interop]
 dependencies."905" = {}
 dependencies."906" = {}
-dependencies."907" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/transience/chain1.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/transience/chain1.toml
@@ -5,6 +5,6 @@ chain_id = 901
 interop_time = 1234
 
 [interop]
-dependencies."901" = { chain_index = 0, activation_time = 1234, history_min_time = 40 }
-dependencies."902" = { chain_index = 1, activation_time = 4424, history_min_time = 456 }
-dependencies."903" = { chain_index = 2, activation_time = 4424, history_min_time = 456 }
+dependencies."901" = {}
+dependencies."902" = {}
+dependencies."903" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/transience/chain2.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/transience/chain2.toml
@@ -5,6 +5,6 @@ chain_id = 902
 interop_time = 4424
 
 [interop]
-dependencies."901" = { chain_index = 0, activation_time = 1234, history_min_time = 40 }
-dependencies."902" = { chain_index = 1, activation_time = 4424, history_min_time = 456 }
-dependencies."903" = { chain_index = 2, activation_time = 4424, history_min_time = 456 }
+dependencies."901" = {}
+dependencies."902" = {}
+dependencies."903" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/transience/chain3.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/transience/chain3.toml
@@ -5,6 +5,6 @@ chain_id = 903
 interop_time = 4424
 
 [interop]
-dependencies."901" = { chain_index = 0, activation_time = 1234, history_min_time = 40 }
-dependencies."902" = { chain_index = 1, activation_time = 4424, history_min_time = 456 }
-dependencies."903" = { chain_index = 2, activation_time = 4424, history_min_time = 456 }
+dependencies."901" = {}
+dependencies."902" = {}
+dependencies."903" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/transience/chain4.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/transience/chain4.toml
@@ -5,6 +5,6 @@ chain_id = 904
 interop_time = 4424
 
 [interop]
-dependencies."901" = { chain_index = 0, activation_time = 1234, history_min_time = 40 }
-dependencies."904" = { chain_index = 1, activation_time = 4424, history_min_time = 456 }
-dependencies."905" = { chain_index = 2, activation_time = 4424, history_min_time = 456 }
+dependencies."901" = {}
+dependencies."904" = {}
+dependencies."905" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/transience/chain5.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/transience/chain5.toml
@@ -5,6 +5,6 @@ chain_id = 905
 interop_time = 4424
 
 [interop]
-dependencies."901" = { chain_index = 0, activation_time = 1234, history_min_time = 40 }
-dependencies."904" = { chain_index = 1, activation_time = 4424, history_min_time = 456 }
-dependencies."905" = { chain_index = 2, activation_time = 4424, history_min_time = 456 }
+dependencies."901" = {}
+dependencies."904" = {}
+dependencies."905" = {}

--- a/ops/internal/manage/testdata/depsets_valid/chain1.toml
+++ b/ops/internal/manage/testdata/depsets_valid/chain1.toml
@@ -5,5 +5,5 @@ chain_id = 901
 interop_time = 1234
 
 [interop]
-dependencies."901" = { chain_index = 0, activation_time = 1234, history_min_time = 40 }
-dependencies."902" = { chain_index = 1, activation_time = 4424, history_min_time = 456 }
+dependencies."901" = {}
+dependencies."902" = {}

--- a/ops/internal/manage/testdata/depsets_valid/chain2.toml
+++ b/ops/internal/manage/testdata/depsets_valid/chain2.toml
@@ -5,5 +5,5 @@ chain_id = 902
 interop_time = 4424
 
 [interop]
-dependencies."902" = { chain_index = 1, activation_time = 4424, history_min_time = 456 }
-dependencies."901" = { chain_index = 0, activation_time = 1234, history_min_time = 40 }
+dependencies."902" = {}
+dependencies."901" = {}

--- a/ops/internal/manage/testdata/depsets_valid/chain7.toml
+++ b/ops/internal/manage/testdata/depsets_valid/chain7.toml
@@ -5,6 +5,6 @@ chain_id = 907
 interop_time = 7777
 
 [interop]
-dependencies."905" = { chain_index = 1, activation_time = 5555, history_min_time = 40 }
-dependencies."906" = { chain_index = 2, activation_time = 6666, history_min_time = 456 }
-dependencies."907" = { chain_index = 3, activation_time = 7777, history_min_time = 456 }
+dependencies."905" = {}
+dependencies."906" = {}
+dependencies."907" = {}


### PR DESCRIPTION
# Overview
Updates depset schema (and associated validations and tests) to align with the new depset schema introduced by https://github.com/ethereum-optimism/optimism/pull/16123

# Related Issues
Closes https://github.com/ethereum-optimism/optimism/issues/16144