### PR TITLE
(fix)deployer: ensure just commands will run locally

### DIFF
--- a/justfile
+++ b/justfile
@@ -47,10 +47,13 @@ print-staging-report: (_run_ops_bin 'print_staging_report')
 
 check-genesis-integrity: (_run_ops_bin 'check_genesis_integrity')
 
-create-config SHORTNAME FILENAME:
+create-config SHORTNAME FILENAME: build-deployer-binaries
 	@just _run_ops_bin "create_config" "--shortname {{SHORTNAME}} --state-filename $(realpath {{FILENAME}})"
 
-import-devnet STATEFILE MANIFESTFILE:
+import-devnet STATEFILE MANIFESTFILE: build-deployer-binaries
 	@just _run_ops_bin "import_devnet" "--state-filename $(realpath {{STATEFILE}}) --manifest-path $(realpath {{MANIFESTFILE}})"
+
+build-deployer-binaries:
+  @bash ops/internal/deployer/scripts/build-binaries.sh
 
 check-chainlist: (_run_ops_bin 'check_chainlist')

--- a/ops/internal/deployer/deployer.go
+++ b/ops/internal/deployer/deployer.go
@@ -34,6 +34,13 @@ func init() {
 		panic(fmt.Sprintf("failed to parse versions.json: %v", err))
 	}
 	CacheDir = os.Getenv(cacheDirEnvVar)
+	if CacheDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			panic(fmt.Sprintf("failed to get user home directory: %v", err))
+		}
+		CacheDir = filepath.Join(homeDir, ".cache/op-deployer")
+	}
 }
 
 // OpDeployer manages the process of building a specific binary of op-deployer,


### PR DESCRIPTION
Having a local copy of the op-deployer binaries is a prerequisite to running some of the user-facing just commands. This pr ensures those binaries will built as part of the just recipes.