### PR TITLE
staging: extract depset from state file

### DIFF
--- a/ops/internal/deployer/opaque_map.go
+++ b/ops/internal/deployer/opaque_map.go
@@ -241,3 +241,17 @@ func (om OpaqueState) GetChainID(idx int) (uint64, error) {
 	h := common.HexToHash(val)
 	return h.Big().Uint64(), nil
 }
+
+func (s OpaqueState) ReadInteropDepSet() (map[string]interface{}, error) {
+	interopDepSet, ok := s["interopDepSet"]
+	if !ok || interopDepSet == nil {
+		return nil, nil
+	}
+
+	depSet, ok := interopDepSet.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("interopDepSet is not a map[string]interface{}")
+	}
+
+	return depSet, nil
+}

--- a/ops/internal/manage/staging.go
+++ b/ops/internal/manage/staging.go
@@ -128,6 +128,15 @@ func InflateChainConfig(opd *deployer.OpDeployer, st deployer.OpaqueState, state
 	}
 
 	cfg.Addresses = addresses
+
+	// Check for depsets in the state.json
+	interop, err := ExtractInteropDepSet(st)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg.Interop = interop
+
 	return cfg, nil
 }
 
@@ -344,4 +353,28 @@ func GetContractAddressesFromState(st deployer.OpaqueState, idx int) (config.Add
 	addresses.PermissionedDisputeGame = config.NewChecksummedAddress(permissionedDisputeGame)
 
 	return addresses, nil
+}
+
+// ExtractInteropDepSet reads the interop dependency set from state and converts it to config.Interop
+func ExtractInteropDepSet(st deployer.OpaqueState) (*config.Interop, error) {
+	interopDepSet, err := st.ReadInteropDepSet()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read interop dep set: %w", err)
+	}
+
+	if interopDepSet == nil {
+		return nil, nil
+	}
+
+	interop := &config.Interop{
+		Dependencies: make(map[string]config.StaticConfigDependency),
+	}
+
+	if deps, ok := interopDepSet["dependencies"].(map[string]interface{}); ok {
+		for key := range deps {
+			interop.Dependencies[key] = config.StaticConfigDependency{}
+		}
+	}
+
+	return interop, nil
 }

--- a/ops/internal/manage/staging_test.go
+++ b/ops/internal/manage/staging_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/superchain-registry/ops/internal/config"
+	"github.com/ethereum-optimism/superchain-registry/ops/internal/deployer"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
 )
@@ -24,4 +25,83 @@ func TestCopyDeployConfigHFTimes(t *testing.T) {
 		CanyonTime: config.NewHardforkTime(1),
 		DeltaTime:  config.NewHardforkTime(2),
 	}, b)
+}
+
+func TestExtractInteropDepSet(t *testing.T) {
+	tests := []struct {
+		name        string
+		stateData   deployer.OpaqueState
+		expected    *config.Interop
+		expectError bool
+	}{
+		{
+			name: "valid interop dependencies",
+			stateData: deployer.OpaqueState{
+				"interopDepSet": map[string]interface{}{
+					"dependencies": map[string]interface{}{
+						"123": map[string]interface{}{},
+						"456": map[string]interface{}{},
+					},
+				},
+			},
+			expected: &config.Interop{
+				Dependencies: map[string]config.StaticConfigDependency{
+					"123": {},
+					"456": {},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:        "nil interopDepSet",
+			stateData:   deployer.OpaqueState{},
+			expected:    nil,
+			expectError: false,
+		},
+		{
+			name: "empty dependencies",
+			stateData: deployer.OpaqueState{
+				"interopDepSet": map[string]interface{}{
+					"dependencies": map[string]interface{}{},
+				},
+			},
+			expected: &config.Interop{
+				Dependencies: map[string]config.StaticConfigDependency{},
+			},
+			expectError: false,
+		},
+		{
+			name: "non-map dependencies",
+			stateData: deployer.OpaqueState{
+				"interopDepSet": map[string]interface{}{
+					"dependencies": "not a map",
+				},
+			},
+			expected: &config.Interop{
+				Dependencies: map[string]config.StaticConfigDependency{},
+			},
+			expectError: false,
+		},
+		{
+			name: "interopDepSet not a map",
+			stateData: deployer.OpaqueState{
+				"interopDepSet": "not a map",
+			},
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ExtractInteropDepSet(tt.stateData)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Pulls the depset from a state.json file and adds it to the staged chain struct, which then gets propagated to the chain config .toml stored in the registry