### PR TITLE
Add v400-RC7

### DIFF
--- a/validation/standard/standard-versions-mainnet.toml
+++ b/validation/standard/standard-versions-mainnet.toml
@@ -3,6 +3,26 @@
 #   * proxied             : specify a standard "implementation_address"
 #   * neither             : specify neither a standard "address" nor "implementation_address"
 
+# Upgrade 16 https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv4.0.0-rc.7
+["op-contracts/v4.0.0-rc.7"]
+system_config = { version = "3.4.0", implementation_address = "0xfaa660bf783cbaa55e1b7f3475c20db74a53b9fa" }
+fault_dispute_game = { version = "1.4.1" }
+permissioned_dispute_game = { version = "1.7.0" }
+mips = { version = "1.4.0", address = "0x8a4e5594662775f71b05977a6c90590dd14e3c8f" }
+optimism_portal = { version = "4.6.0", implementation_address = "0xefed7f38bb9be74bba583a1a5b7d0fe7c9d5787a" }
+anchor_state_registry = { version = "3.5.0", implementation_address = "0xeb69cc681e8d4a557b30dffbad85affd47a2cf2e" }
+delayed_weth = { version = "1.5.0", implementation_address = "0x33dadc2d1aa9bb613a7ae6b28425ea00d44c6998" }
+eth_lockbox = { version = "1.2.0", implementation_address = "0x784d2f03593a42a6e4676a012762f18775ecbbe6" }
+dispute_game_factory = { version = "1.2.0", implementation_address = "0x33d1e8571a85a538ed3d5a4d88f46c112383439d" }
+preimage_oracle = { version = "1.1.4", address = "0x1fb8cdfc6831fc866ed9c51af8817da5c287add3" }
+l1_cross_domain_messenger = { version = "2.9.0", implementation_address = "0xd26bb3aaaa4cb5638a8581a4c4b1d937d8e05c54" }
+l1_erc721_bridge = { version = "2.7.0", implementation_address = "0x25d6cedeb277ad7ebee71226ed7877768e0b7a2f" }
+l1_standard_bridge = { version = "2.6.0", implementation_address = "0x44afb7722af276a601d524f429016a18b6923df0" }
+optimism_mintable_erc20_factory = { version = "1.10.1", implementation_address = "0x5493f4677a186f64805fe7317d6993ba4863988f" }
+op_contracts_manager = { version = "2.4.0", address = "0x4fefd0c327d08143be8037c45f8a29fa0d711e50" }
+superchain_config = { version = "2.3.0", implementation_address = "0xce28685eb204186b557133766eca00334eb441e4" }
+protocol_versions = { version = "1.1.0", implementation_address = "0x37e15e4d6dffa9e5e320ee1ec036922e563cb76c" }
+
 # Upgrade 16 https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv4.0.0-rc.6
 ["op-contracts/v4.0.0-rc.6"]
 system_config = { version = "3.4.0", implementation_address = "0xfaa660bf783cbaa55e1b7f3475c20db74a53b9fa" }

--- a/validation/standard/standard-versions-sepolia.toml
+++ b/validation/standard/standard-versions-sepolia.toml
@@ -3,6 +3,26 @@
 #   * proxied             : specify a standard "implementation_address"
 #   * neither             : specify neither a standard "address" nor "implementation_address"
 
+# Upgrade 16 https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv4.0.0-rc.7
+["op-contracts/v4.0.0-rc.7"]
+system_config = { version = "3.4.0", implementation_address = "0xfaa660bf783cbaa55e1b7f3475c20db74a53b9fa" }
+fault_dispute_game = { version = "1.4.1" }
+permissioned_dispute_game = { version = "1.7.0" }
+mips = { version = "1.4.0", address = "0x8a4e5594662775f71b05977a6c90590dd14e3c8f" }
+optimism_portal = { version = "4.6.0", implementation_address = "0xefed7f38bb9be74bba583a1a5b7d0fe7c9d5787a" }
+anchor_state_registry = { version = "3.5.0", implementation_address = "0xeb69cc681e8d4a557b30dffbad85affd47a2cf2e" }
+delayed_weth = { version = "1.5.0", implementation_address = "0x33dadc2d1aa9bb613a7ae6b28425ea00d44c6998" }
+eth_lockbox = { version = "1.2.0", implementation_address = "0x784d2f03593a42a6e4676a012762f18775ecbbe6" }
+dispute_game_factory = { version = "1.2.0", implementation_address = "0x33d1e8571a85a538ed3d5a4d88f46c112383439d" }
+preimage_oracle = { version = "1.1.4", address = "0x1fb8cdfc6831fc866ed9c51af8817da5c287add3" }
+l1_cross_domain_messenger = { version = "2.9.0", implementation_address = "0xd26bb3aaaa4cb5638a8581a4c4b1d937d8e05c54" }
+l1_erc721_bridge = { version = "2.7.0", implementation_address = "0x25d6cedeb277ad7ebee71226ed7877768e0b7a2f" }
+l1_standard_bridge = { version = "2.6.0", implementation_address = "0x44afb7722af276a601d524f429016a18b6923df0" }
+optimism_mintable_erc20_factory = { version = "1.10.1", implementation_address = "0x5493f4677a186f64805fe7317d6993ba4863988f" }
+op_contracts_manager = { version = "2.4.0", address = "0x44c191ce5ce35131e703532af75fa9ca221e2398" }
+superchain_config = { version = "2.3.0", implementation_address = "0xce28685eb204186b557133766eca00334eb441e4" }
+protocol_versions = { version = "1.1.0", implementation_address = "0x37e15e4d6dffa9e5e320ee1ec036922e563cb76c" }
+
 # Upgrade 16 https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv4.0.0-rc.6
 ["op-contracts/v4.0.0-rc.6"]
 system_config = { version = "3.4.0", implementation_address = "0xfaa660bf783cbaa55e1b7f3475c20db74a53b9fa" }


### PR DESCRIPTION
Adds a new tag, with addresses unchanged from the previous.

This new release is necessary because of changes in the StandardValidator, which although not listed in these toml files, is deployed by op-deployer and thus needs a new tag in order to ensure the correct version is deployed.

In the near future the SV will be added to the OPCM which will implicitly include it here.