### PR TITLE
depsets: onchain checks dependent on interop_time

### DIFF
--- a/ops/internal/manage/depsets.go
+++ b/ops/internal/manage/depsets.go
@@ -154,23 +154,23 @@ func (dc *DepsetChecker) checkOnchain(cfgs []DiskChainConfig) error {
 
 	// Find chains that have already activated interop
 	now := time.Now().Unix()
-	var validChains []DiskChainConfig
+	var activatedChains []DiskChainConfig
 	for _, cfg := range cfgs {
 		interopTime := cfg.Config.Hardforks.InteropTime
 		if interopTime == nil || *interopTime.U64Ptr() > uint64(now) {
 			continue
 		}
-		validChains = append(validChains, cfg)
+		activatedChains = append(activatedChains, cfg)
 	}
 
 	// If we have fewer than 2 activated chains, no comparison needed
-	if len(validChains) < 2 {
+	if len(activatedChains) < 2 {
 		dc.lgr.Info("skipping onchain checks for depset")
 		return nil
 	}
 
 	// Get and validate the first valid chain's addresses
-	firstAddrs, err := dc.getAndValidateAddresses(validChains[0].Config.ChainID)
+	firstAddrs, err := dc.getAndValidateAddresses(activatedChains[0].Config.ChainID)
 	if err != nil {
 		return err
 	}
@@ -181,8 +181,8 @@ func (dc *DepsetChecker) checkOnchain(cfgs []DiskChainConfig) error {
 	// firstEthLockboxProxy := strings.ToLower((*firstAddrs.EthLockboxProxy).String())
 
 	// Check all remaining valid chains in the dependency set
-	for i := 1; i < len(validChains); i++ {
-		cfg := validChains[i]
+	for i := 1; i < len(activatedChains); i++ {
+		cfg := activatedChains[i]
 		addrs, err := dc.getAndValidateAddresses(cfg.Config.ChainID)
 		if err != nil {
 			return err

--- a/ops/internal/manage/depsets.go
+++ b/ops/internal/manage/depsets.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/superchain-registry/ops/internal/config"
@@ -14,7 +15,6 @@ import (
 var (
 	errDepsetLengths       = errors.New("inconsistent depset lengths")
 	errInconsistentDepsets = errors.New("inconsistent depset values")
-	errMissingInteropTime  = errors.New("missing interop_time hardfork timestamp")
 	errMissingAddress      = errors.New("missing address")
 )
 
@@ -115,13 +115,8 @@ func (dc *DepsetChecker) checkOffchain(cfgs []DiskChainConfig) error {
 			return fmt.Errorf("chain %d is part of superchain %s, expected superchain %s", cfg.Config.ChainID, cfg.Superchain, firstSuperchain)
 		}
 
-		// check that interop_time is set for this chain
-		thisDepset := cfg.Config.Interop.Dependencies
-		if cfg.Config.Hardforks.InteropTime == nil {
-			return fmt.Errorf("%w: chainId %d", errMissingInteropTime, cfg.Config.ChainID)
-		}
-
 		// check equality of dependency sets
+		thisDepset := cfg.Config.Interop.Dependencies
 		if i > 0 {
 			// 1. check if the maps have the same length
 			if len(firstDepset) != len(thisDepset) {
@@ -146,7 +141,8 @@ func (dc *DepsetChecker) checkOffchain(cfgs []DiskChainConfig) error {
 }
 
 // checkOnchain ensures that DisputeGameFactoryProxy and EthLockboxProxy addresses read from onchain
-// are the same for all chains in a depset
+// are the same for all chains in a depset. These checks are only performed for chains who have
+// already activated interop (i.e. interop_time < current unix timestamp).
 func (dc *DepsetChecker) checkOnchain(cfgs []DiskChainConfig) error {
 	if len(cfgs) == 0 {
 		return fmt.Errorf("no chain configs provided to checkOnchain")
@@ -156,8 +152,25 @@ func (dc *DepsetChecker) checkOnchain(cfgs []DiskChainConfig) error {
 		return nil
 	}
 
-	// Get and validate the first chain's addresses
-	firstAddrs, err := dc.getAndValidateAddresses(cfgs[0].Config.ChainID)
+	// Find chains that have already activated interop
+	now := time.Now().Unix()
+	var validChains []DiskChainConfig
+	for _, cfg := range cfgs {
+		interopTime := cfg.Config.Hardforks.InteropTime
+		if interopTime == nil || *interopTime.U64Ptr() > uint64(now) {
+			continue
+		}
+		validChains = append(validChains, cfg)
+	}
+
+	// If we have fewer than 2 activated chains, no comparison needed
+	if len(validChains) < 2 {
+		dc.lgr.Info("skipping onchain checks for depset")
+		return nil
+	}
+
+	// Get and validate the first valid chain's addresses
+	firstAddrs, err := dc.getAndValidateAddresses(validChains[0].Config.ChainID)
 	if err != nil {
 		return err
 	}
@@ -167,8 +180,9 @@ func (dc *DepsetChecker) checkOnchain(cfgs []DiskChainConfig) error {
 	// issue: https://github.com/ethereum-optimism/optimism/issues/16058
 	// firstEthLockboxProxy := strings.ToLower((*firstAddrs.EthLockboxProxy).String())
 
-	// Check all chains in the dependency set
-	for _, cfg := range cfgs {
+	// Check all remaining valid chains in the dependency set
+	for i := 1; i < len(validChains); i++ {
+		cfg := validChains[i]
 		addrs, err := dc.getAndValidateAddresses(cfg.Config.ChainID)
 		if err != nil {
 			return err

--- a/ops/internal/manage/depsets_test.go
+++ b/ops/internal/manage/depsets_test.go
@@ -102,27 +102,6 @@ func TestDepsetChecker_checkOffchain(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, errDepsetLengths)
 	})
-
-	t.Run("missing interop_time", func(t *testing.T) {
-		addrs := loadAddresses(t, validAddressesPath)
-		var cfg1 config.Chain
-		err := paths.ReadTOMLFile("testdata/depsets_invalid/missing_interop_time_1.toml", &cfg1)
-		require.NoError(t, err)
-
-		var cfg2 config.Chain
-		err = paths.ReadTOMLFile("testdata/depsets_invalid/missing_interop_time_2.toml", &cfg2)
-		require.NoError(t, err)
-
-		chains := []DiskChainConfig{
-			{Config: &cfg1, Superchain: "test"},
-			{Config: &cfg2, Superchain: "test"},
-		}
-
-		checker := NewDepsetChecker(lgr, chains, addrs)
-		err = checker.checkOffchain(chains)
-		require.Error(t, err)
-		require.ErrorIs(t, err, errMissingInteropTime)
-	})
 }
 
 func TestDepsetChecker_checkOnchain(t *testing.T) {
@@ -176,8 +155,8 @@ func TestDepsetChecker_checkOnchain(t *testing.T) {
 
 	t.Run("missing proxy addresses", func(t *testing.T) {
 		addrs := loadAddresses(t, invalidAddressesPath)
-		chain1 := loadChainConfig(t, "testdata/depsets_valid/chain2.toml")
-		chain2 := loadChainConfig(t, "testdata/depsets_valid/chain4.toml")
+		chain1 := loadChainConfig(t, "testdata/depsets_invalid/missing_address_1.toml")
+		chain2 := loadChainConfig(t, "testdata/depsets_invalid/missing_address_2.toml")
 		chains := []DiskChainConfig{
 			{Config: chain1, Superchain: "test"},
 			{Config: chain2, Superchain: "test"},

--- a/ops/internal/manage/testdata/depsets_invalid/missing_address_1.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/missing_address_1.toml
@@ -1,0 +1,9 @@
+name = "Test Chain 2"
+chain_id = 902
+
+[hardforks]
+interop_time = 4424
+
+[interop]
+dependencies."902" = {}
+dependencies."904" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/missing_address_2.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/missing_address_2.toml
@@ -1,0 +1,9 @@
+name = "Test Chain 4"
+chain_id = 904
+
+[hardforks]
+interop_time = 4424
+
+[interop]
+dependencies."902" = {}
+dependencies."904" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/missing_interop_time_1.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/missing_interop_time_1.toml
@@ -1,9 +1,0 @@
-name = "Test Chain 5"
-chain_id = 905
-
-[hardforks]
-interop_time = 5555
-
-[interop]
-dependencies."905" = {}
-dependencies."906" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/missing_interop_time_2.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/missing_interop_time_2.toml
@@ -1,8 +1,0 @@
-name = "Test Chain 6"
-chain_id = 906
-
-[hardforks]
-
-[interop]
-dependencies."905" = {}
-dependencies."906" = {}


### PR DESCRIPTION
Modifies the depset checker based on recent tests of the devnet rehearsal:
1. Allows chain configs to have a depset even if they don't have an `interop_time` set yet
2. Only performs onchain checks for chains whose `interop_time` < the current time

So the new validations will be:
1. offchain: performed for all chains who have a depset in their config
2. onchain: only performed if the chain also has an `interop_time` < current time