### PR TITLE
circleci: add condition to notify workflow for webhook triggers only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,6 +400,8 @@ workflows:
             - build-deployer-binaries
 
   notify-when-chain-is-added-to-registry:
+    when:
+      equal: ["webhook", << pipeline.trigger_source >>]
     jobs:
       - notify-when-chain-is-added-to-registry:
           context: circleci-repo-superchain-registry


### PR DESCRIPTION
This pull request includes a small update to the `.circleci/config.yml` file. It adds a condition to the `notify-when-chain-is-added-to-registry` workflow to ensure it only triggers when the pipeline's `trigger_source` equals "webhook".