### PR TITLE
github: require go-reviewers for .go files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 * @ethereum-optimism/superchain-registry-reviewers
 
 # go files require go-reviewers
-*.go @ethereum-optimism/go-reviewers @ethereum-optimism/superchain-registry-reviewers
+*.go @ethereum-optimism/go-reviewers
+*.go @ethereum-optimism/superchain-registry-reviewers
 
 /validation/standard/standard-prestates.toml @ethereum-optimism/proofs @ethereum-optimism/superchain-registry-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,7 @@
 # Default code-owner
 * @ethereum-optimism/superchain-registry-reviewers
 
+# go files require go-reviewers
+*.go @ethereum-optimism/go-reviewers @ethereum-optimism/superchain-registry-reviewers
+
 /validation/standard/standard-prestates.toml @ethereum-optimism/proofs @ethereum-optimism/superchain-registry-reviewers


### PR DESCRIPTION
This is a permissions change to require go-reviewers to approve any prs that modify .go files.