### PR TITLE
Remove `Celo` from `chainList`

### DIFF
--- a/chainList.json
+++ b/chainList.json
@@ -1223,28 +1223,6 @@
     }
   },
   {
-    "name": "Celo",
-    "identifier": "mainnet/celo",
-    "chainId": 42220,
-    "rpc": [
-      "https://forno.celo.org"
-    ],
-    "explorers": [
-      "https://celoscan.io/"
-    ],
-    "superchainLevel": 0,
-    "governedByOptimism": false,
-    "dataAvailabilityType": "alt-da",
-    "parent": {
-      "type": "L2",
-      "chain": "mainnet"
-    },
-    "gasPayingToken": "0x057898f3C43F129a17517B9056D23851F124b19f",
-    "faultProofs": {
-      "status": "permissioned"
-    }
-  },
-  {
     "name": "rehearsal-0-bn-0",
     "identifier": "rehearsal-0-bn/rehearsal-0-bn-0",
     "chainId": 420120009,

--- a/chainList.toml
+++ b/chainList.toml
@@ -874,22 +874,6 @@
     status = "none"
 
 [[chains]]
-  name = "Celo"
-  identifier = "mainnet/celo"
-  chain_id = 42220
-  rpc = ["https://forno.celo.org"]
-  explorers = ["https://celoscan.io/"]
-  superchain_level = 0
-  governed_by_optimism = false
-  data_availability_type = "alt-da"
-  gas_paying_token = "0x057898f3C43F129a17517B9056D23851F124b19f"
-  [chains.parent]
-    type = "L2"
-    chain = "mainnet"
-  [chains.fault_proofs]
-    status = "permissioned"
-
-[[chains]]
   name = "rehearsal-0-bn-0"
   identifier = "rehearsal-0-bn/rehearsal-0-bn-0"
   chain_id = 420120009


### PR DESCRIPTION
In #1008 Celo was added to the Superchain Registry to later be removed in #1072. Nevertheless, some configuration files did not get properly reverted, resulting in Celo still being listed as part of the registry. This PR addresses this issue (see https://github.com/ethereum-optimism/superchain-registry/pull/1072#issuecomment-2984381100 for more context)
