### PR TITLE
prestates for u16

### DIFF
--- a/validation/standard/standard-prestates.toml
+++ b/validation/standard/standard-prestates.toml
@@ -1,5 +1,13 @@
-latest_stable = "1.6.0"
-latest_rc = "1.6.0-rc.2"
+latest_stable = "1.6.1"
+latest_rc = "1.6.1-rc.1"
+
+[[prestates."1.6.1"]]
+type = "cannon64"
+hash = "0x03eb07101fbdeaf3f04d9fb76526362c1eea2824e4c6e970bdb19675b72e4fc8"
+
+[[prestates."1.6.1"]]
+type = "interop"
+hash = "0x03fc3b4d091527d53f1ff369ea8ed65e5e17cc7fc98ebf75380238151cdc949c"
 
 [[prestates."1.6.1-rc.1"]]
 type = "cannon64"


### PR DESCRIPTION
Adds the absolute prestate approved by governance in the [Upgrade 16 proposal](https://gov.optimism.io/t/upgrade-16-proposal-interop-contracts-stage-1-and-go-1-23-support-in-cannon/10037#p-44676-absolute-prestate-19).