### PR TITLE
Add op-contracts/v2.1.0 to standard versions

### DIFF
--- a/validation/standard/standard-versions-mainnet.toml
+++ b/validation/standard/standard-versions-mainnet.toml
@@ -142,6 +142,25 @@ op_contracts_manager = { version = "1.9.0", address = "0x3a1f523a4bc09cd344a2745
 superchain_config = { version = "1.2.0", implementation_address = "0x4da82a327773965b8d4D85Fa3dB8249b387458E7" }
 protocol_versions = { version = "1.1.0", implementation_address = "0x37E15e4d6DFFa9e5E320Ee1eC036922E563CB76C" }
 
+# OPCM https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv2.1.0
+["op-contracts/v2.1.0"]
+system_config = { version = "2.4.0", implementation_address = "0x760c48c62a85045a6b69f07f4a9f22868659cbcc" }
+fault_dispute_game = { version = "1.4.1" }
+permissioned_dispute_game = { version = "1.4.1" }
+mips = { version = "1.3.0", address = "0xaa59a0777648bc75cd10364083e878c1ccd6112a" }
+optimism_portal = { version = "3.13.0", implementation_address = "0x2d7e764a0d9919e16983a46595cfa81fc34fa7cd" }
+anchor_state_registry = { version = "2.2.2", implementation_address = "0x7b465370bb7a333f99edd19599eb7fb1c2d3f8d2" }
+delayed_weth = { version = "1.3.0", implementation_address = "0x5e40b9231b86984b5150507046e354dbfbed3d9e" }
+dispute_game_factory = { version = "1.0.1", implementation_address = "0x4bbA758F006Ef09402eF31724203F316ab74e4a0" }
+preimage_oracle = { version = "1.1.4", address = "0x1fb8cdfc6831fc866ed9c51af8817da5c287add3" }
+l1_cross_domain_messenger = { version = "2.5.0", implementation_address = "0x3eA6084748ED1b2A9B5D4426181F1ad8C93F6231" }
+l1_erc721_bridge = { version = "2.3.1", implementation_address = "0x276d3730f219f7ec22274f7263180b8452b46d47" }
+l1_standard_bridge = { version = "2.2.2", implementation_address = "0x78972E88Ab8BBB517a36cAea23b931BAB58AD3c6" }
+optimism_mintable_erc20_factory = { version = "1.10.1", implementation_address = "0x5493f4677A186f64805fe7317D6993ba4863988F" }
+op_contracts_manager = { version = "1.6.0", address = "0x0afa62889a1d2cb061983c6569a273e626e5f2fc" }
+superchain_config = { version = "1.2.0", implementation_address = "0x4da82a327773965b8d4D85Fa3dB8249b387458E7" }
+protocol_versions = { version = "1.1.0", implementation_address = "0x37E15e4d6DFFa9e5E320Ee1eC036922E563CB76C" }
+
 # OPCM https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv2.0.0
 ["op-contracts/v2.0.0"]
 system_config = { version = "2.4.0", implementation_address = "0x760c48c62a85045a6b69f07f4a9f22868659cbcc" }

--- a/validation/standard/standard-versions-sepolia.toml
+++ b/validation/standard/standard-versions-sepolia.toml
@@ -142,6 +142,25 @@ op_contracts_manager = { version = "1.9.0", address = "0xfbceed4de885645fbded164
 superchain_config = { version = "1.2.0", implementation_address = "0x4da82a327773965b8d4D85Fa3dB8249b387458E7" }
 protocol_versions = { version = "1.1.0", implementation_address = "0x37E15e4d6DFFa9e5E320Ee1eC036922E563CB76C" }
 
+# OPCM https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv2.1.0
+["op-contracts/v2.1.0"]
+system_config = { version = "2.4.0", implementation_address = "0x760C48C62A85045A6B69f07F4a9f22868659CbCc" }
+fault_dispute_game = { version = "1.4.1" }
+permissioned_dispute_game = { version = "1.4.1" }
+mips = { version = "1.3.0", address = "0xaa59a0777648bc75cd10364083e878c1ccd6112a" }
+optimism_portal = { version = "3.13.0", implementation_address = "0x2D7e764a0D9919e16983a46595CfA81fc34fa7Cd" }
+anchor_state_registry = { version = "2.2.2", implementation_address = "0x7b465370BB7A333f99edd19599EB7Fb1c2D3F8D2" }
+delayed_weth = { version = "1.3.0", implementation_address = "0x5e40B9231B86984b5150507046e354dbFbeD3d9e" }
+dispute_game_factory = { version = "1.0.1", implementation_address = "0x4bbA758F006Ef09402eF31724203F316ab74e4a0" }
+preimage_oracle = { version = "1.1.4", address = "0x1fb8cdfc6831fc866ed9c51af8817da5c287add3" }
+l1_cross_domain_messenger = { version = "2.5.0", implementation_address = "0x3eA6084748ED1b2A9B5D4426181F1ad8C93F6231" }
+l1_erc721_bridge = { version = "2.3.1", implementation_address = "0x276d3730f219f7ec22274f7263180b8452b46d47" }
+l1_standard_bridge = { version = "2.2.2", implementation_address = "0x78972E88Ab8BBB517a36cAea23b931BAB58AD3c6" }
+optimism_mintable_erc20_factory = { version = "1.10.1", implementation_address = "0x5493f4677A186f64805fe7317D6993ba4863988F" }
+op_contracts_manager = { version = "1.6.0", address = "0x432704745cd7c90a28a646d091f228c882f0e3ed" }
+superchain_config = { version = "1.2.0", implementation_address = "0x4da82a327773965b8d4D85Fa3dB8249b387458E7" }
+protocol_versions = { version = "1.1.0", implementation_address = "0x37E15e4d6DFFa9e5E320Ee1eC036922E563CB76C" }
+
 # OPCM https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv2.0.0
 ["op-contracts/v2.0.0"]
 system_config = { version = "2.4.0", implementation_address = "0x760C48C62A85045A6B69f07F4a9f22868659CbCc" }


### PR DESCRIPTION
This adds the OPCM addresses deployed from the `op-contracts/v2.1.0` tag in the monorepo.

The only address which is changed from v2.0.0 is that of the OPCM.

