### PR TITLE
Remove codecov from CI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@5.0.3
   utils: ethereum-optimism/circleci-utils@1.0.8
 
 executors:
@@ -61,9 +60,6 @@ jobs:
             MAINNET_RPC_URL: << pipeline.parameters.mainnet_rpc_url >>
       - store_test_results:
           path: << parameters.package >>/test-results.xml
-      - codecov/upload:
-          disable_search: true
-          files: ./<<parameters.package>>/coverage.out
 
   run-tool:
     circleci_ip_ranges: true


### PR DESCRIPTION
## Summary
This removes the codecov integration that was previously used for tracking test coverage in the CI pipeline, as it's [breaking stuff](https://app.circleci.com/pipelines/github/ethereum-optimism/superchain-registry/18815/workflows/702e97e2-6bca-4414-9ed6-ab98a7fb05f6/jobs/129994/steps) and internal discussions have concluded that we don't get value from it (notice that in the diff we were just uploading, no codecov checks are actually running). 

- Removed codecov orb from CircleCI configuration
- Removed codecov upload step from test jobs
