### PR TITLE
ops: exit with error code if check_chainlist fails

### DIFF
--- a/ops/cmd/check_chainlist/main.go
+++ b/ops/cmd/check_chainlist/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/ethereum-optimism/superchain-registry/ops/internal/manage"
 	"github.com/ethereum-optimism/superchain-registry/ops/internal/output"
@@ -12,6 +13,7 @@ import (
 func main() {
 	if err := mainErr(); err != nil {
 		output.WriteNotOK("%v\n", err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
If `check_chainlist` fails, it should exit with error code so the ci job fails. Without this fix, `check_chainlist` fails but the ci job incorrectly still passes.

Example [here](https://app.circleci.com/pipelines/github/ethereum-optimism/superchain-registry/18461/workflows/f98beff0-2af6-40b0-a17c-27316cd1c70a/jobs/126086) of a job that should have failed, but did not.