### PR TITLE
circleci: fix daily-codegen trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -487,7 +487,7 @@ workflows:
   daily-codegen:
     when:
       or:
-        - equal: ["build_daily", << pipeline.trigger_source >>]
+        - equal: ["build_daily", << pipeline.schedule.name >>]
         - and:
             - equal: [true, << pipeline.parameters.daily_codegen_dispatch >>]
             - equal: ["api", << pipeline.trigger_source >>]


### PR DESCRIPTION
The daily-codegen did not properly trigger on our circleci schedule. This pr should fix it.