### PR TITLE
jovian: add bounds for minimum base fee in standard config

### DIFF
--- a/validation/standard/standard-config-params-mainnet.toml
+++ b/validation/standard/standard-config-params-mainnet.toml
@@ -31,6 +31,7 @@ base_fee_scalar = [0, 10_000_000]
 gas_limit = [8_000_000, 200_000_000]
 operator_fee_scalar = [0, 0]
 operator_fee_constant = [0, 0]
+minmum_base_fee = [0, 10_000_000_000] # 10 Gwei
 
 [proofs.permissioned]
 game_type = 1


### PR DESCRIPTION
This change forms part of a [proposal put to Optimism Governance](https://gov.optimism.io/t/upgrade-17-proposal-jovian-hardfork/10374), so should only be merged after it is approved by gov.

Summary:

Minimum base fee: no minimum, but standard chains must not set it higher than 10 GWei.
DA Footprint Gas Scalar: no restrictions