### PR TITLE
Add op-program 1.8.0-rc.4 prestate

### DIFF
--- a/validation/standard/standard-prestates.toml
+++ b/validation/standard/standard-prestates.toml
@@ -1,5 +1,13 @@
 latest_stable = "1.6.1"
-latest_rc = "1.8.0-rc.3"
+latest_rc = "1.8.0-rc.4"
+
+[[prestates."1.8.0-rc.4"]]
+type="cannon64"
+hash="0x03caa1871bb9fe7f9b11217c245c16e4ded33367df5b3ccb2c6d0a847a217d1b"
+
+[[prestates."1.8.0-rc.4"]]
+type="interop"
+hash="0x03455f7f2179327853a989648c3ac9f2d58be45137bae603271660519b4d5245"
 
 [[prestates."1.8.0-rc.3"]]
 type="cannon64"


### PR DESCRIPTION
Adds op-program v1.8.0-rc.4 prestart to standard-prestates.toml