### PR TITLE
Update kona prestates

### DIFF
--- a/validation/standard/standard-prestates.toml
+++ b/validation/standard/standard-prestates.toml
@@ -337,14 +337,6 @@ hash="0x034726fbf9eb7cb9aeb1633dc9a1434d161bb8875f15a940ddee07f9f7192b26"
 type="cannon64-kona-interop"
 hash="0x03e8bc1c6bf2d4c4920b0fad19e7717b44720721eb523e2c9d974816881a6894"
 
-[[prestates."1.2.0"]]
-type="cannon64-kona"
-hash="0x03723aeb1fe69eebd6b0155a4570f5944e9a2c1d918183a014b6da2fc2d1b5e5"
-
-[[prestates."1.2.0"]]
-type="cannon64-kona-interop"
-hash="0x03dd682a7c55084b42c4f4711f2c501126ed8dc05808c7ef19537dbf57bcbed7"
-
 [[prestates."1.2.1"]]
 type="cannon64-kona"
 hash="0x03723aeb1fe69eebd6b0155a4570f5944e9a2c1d918183a014b6da2fc2d1b5e5"
@@ -352,3 +344,11 @@ hash="0x03723aeb1fe69eebd6b0155a4570f5944e9a2c1d918183a014b6da2fc2d1b5e5"
 [[prestates."1.2.1"]]
 type="cannon64-kona-interop"
 hash="0x03dd682a7c55084b42c4f4711f2c501126ed8dc05808c7ef19537dbf57bcbed7"
+
+[[prestates."1.2.2"]]
+type="cannon64-kona"
+hash="0x03e183aa55db11aba6c1f2f7adccad15411d44fb54285e104cb73468927de0e7"
+
+[[prestates."1.2.2"]]
+type="cannon64-kona-interop"
+hash="0x033f554908ed264b81963ad6bf8a856c7c114af950df5a6fff67c5db85886083"


### PR DESCRIPTION
The kona-client/v1.2.0 release tag was _deleted_ from the kona repository as it had an incorrect Jovian timestamp (a one time thing).
It's been replaced with kona-client/v1.2.2. This PR reflects that.