### PR TITLE
Add 1.8.0 and 1.9.0-rc.1 prestates to standard-prestates.toml

### DIFF
--- a/validation/standard/standard-prestates.toml
+++ b/validation/standard/standard-prestates.toml
@@ -1,5 +1,13 @@
 latest_stable = "1.6.1"
-latest_rc = "1.8.0-rc.4"
+latest_rc = "1.9.0-rc.1"
+
+[[prestates."1.9.0-rc.1"]]
+type="cannon64"
+hash="0x033c000916b4a88cfffeceddd6cf0f4be3897a89195941e5a7c3f8209b4dbb6e"
+
+[[prestates."1.9.0-rc.1"]]
+type="interop"
+hash="0x03b985a286da46ca88c0a965a53942daade9ffe1ae6b854a8f2d083df1cfaf59"
 
 [[prestates."1.8.0"]]
 type="cannon64"


### PR DESCRIPTION
This adds the finalized op-program 1.8.0 release, and the 1.9.0-rc.1 prestate to standard-prestates.toml