### PR TITLE
updating gametype logic to support KONA

### DIFF
--- a/ops/internal/manage/codegen.go
+++ b/ops/internal/manage/codegen.go
@@ -168,10 +168,10 @@ func (s *CodegenSyncer) UpdateChainList(chainID string, onchainCfg script.ChainC
 
 	if onchainCfg.FaultProofStatus == nil {
 		chainListEntry.FaultProofs = config.FaultProofs{Status: "none"}
-	} else if onchainCfg.FaultProofStatus.RespectedGameType == 1 {
-		chainListEntry.FaultProofs = config.FaultProofs{Status: "permissioned"}
-	} else {
+	} else if onchainCfg.FaultProofStatus.RespectedGameType == 0 || onchainCfg.FaultProofStatus.RespectedGameType == 8 {
 		chainListEntry.FaultProofs = config.FaultProofs{Status: "permissionless"}
+	} else {
+		chainListEntry.FaultProofs = config.FaultProofs{Status: "permissioned"}
 	}
 
 	for i, entry := range s.ChainList {


### PR DESCRIPTION
## Description

I've just updated the logic when generating the chainList.json to only mark chains as permissionless if they're using game type 1 (CANNON) or game type 8 (KONA-CANNON). 

## Additional information

We noticed that https://github.com/ethereum-optimism/superchain-registry/pull/1116 was marking Celo as permissionless because their game type was 42, but L2Beat seems to suggest they're permissioned. I think this logic is what marked their chain incorrectly.

I have not added any tests