### PR TITLE
Add kona 1.2.12 prestates

### DIFF
--- a/validation/standard/standard-prestates.toml
+++ b/validation/standard/standard-prestates.toml
@@ -409,6 +409,14 @@ hash="0x03838c1ea9534e538a41bc8a8facbdd71e16724ab96af53532454ca3a82a2e30"
 type="cannon64-kona-interop"
 hash="0x03a5c095d40ab1a6631ea8f0e19efe3dc43b15c2832dba31533210075469f416"
 
+[[prestates."1.2.12"]]
+type="cannon64-kona"
+hash="0x0399b5b33a5c6d5970f1b326abfb79c25cce8faef14235a28d4c4fdf70190673"
+
+[[prestates."1.2.12"]]
+type="cannon64-kona-interop"
+hash="0x03a319937faf4147b0710e21392f776e1ec902050e0f0f1cb0dc95b59a5eda26"
+
 [[prestates."1.2.13"]]
 type="cannon64-kona"
 hash="0x034f407b2fbbdf34a966e03915d02da5e59259bf3eb729f823acdffb86a37c2e"


### PR DESCRIPTION
Adds prestates for https://github.com/ethereum-optimism/optimism/tree/refs/tags/kona-client/v1.2.12