### PR TITLE
Update CircleCI configuration to use latest utils orb version and add contexts for jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  utils: ethereum-optimism/circleci-utils@1.0.22
+  utils: ethereum-optimism/circleci-utils@1.0.27
 
 executors:
   default:
@@ -425,29 +425,35 @@ workflows:
     jobs:
       - build-deployer-binaries:
           name: build-deployer-binaries
+          context: circleci-repo-readonly-authenticated-github-token
       - go-lint-test:
           name: go-lint-test-ops
           package: ops
           requires:
             - build-deployer-binaries
+          context: circleci-repo-readonly-authenticated-github-token
       - go-lint-test:
           name: go-lint-test-validation
           package: validation
+          context: circleci-repo-readonly-authenticated-github-token
       - run-tool:
           name: check-genesis-integrity
           tool: check_genesis_integrity
           requires:
             - build-deployer-binaries
+          context: circleci-repo-readonly-authenticated-github-token
       - check-codegen:
           name: check-codegen
           requires:
             - build-deployer-binaries
+          context: circleci-repo-readonly-authenticated-github-token
       - run-tool:
           name: check-depsets
           tool: check_depsets
           requires:
             - check-codegen
             - build-deployer-binaries
+          context: circleci-repo-readonly-authenticated-github-token
       - run-tool:
           name: check-staging-synced
           tool: sync_staging
@@ -455,23 +461,28 @@ workflows:
           check_diff: true
           requires:
             - build-deployer-binaries
+          context: circleci-repo-readonly-authenticated-github-token
       - check-staging-empty:
           name: check-staging-empty
+          context: circleci-repo-readonly-authenticated-github-token
       - run-tool:
           name: check-apply-hardforks
           tool: apply_hardforks
           check_diff: true
           requires:
             - build-deployer-binaries
+          context: circleci-repo-readonly-authenticated-github-token
       - run-tool:
           name: check-chainlist
           tool: check_chainlist
           requires:
             - build-deployer-binaries
+          context: circleci-repo-readonly-authenticated-github-token
       - run-staging-report:
           name: run-staging-report
           requires:
             - build-deployer-binaries
+          context: circleci-repo-readonly-authenticated-github-token
 
   notify-when-chain-is-added-to-registry:
     when:


### PR DESCRIPTION
This pull request updates the CircleCI configuration to improve job security and reliability. The main changes include upgrading the `circleci-utils` orb version and adding a GitHub authentication context to all jobs that interact with GitHub, ensuring they have the necessary permissions.

**CI/CD configuration improvements:**

* Upgraded the `ethereum-optimism/circleci-utils` orb from version `1.0.22` to `1.0.27` in `.circleci/config.yml` for access to the latest features and fixes.

* Added the `circleci-repo-readonly-authenticated-github-token` context to all relevant jobs in the workflow, ensuring authenticated and authorized access to GitHub resources during CI runs.