### PR TITLE
Add missing timestamp for mainnet chains

### DIFF
--- a/superchain/configs/mainnet/bob.toml
+++ b/superchain/configs/mainnet/bob.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
   isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
+  jovian_time = 1773325801 # Thu 12 Mar 2026 14:30:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/celo.toml
+++ b/superchain/configs/mainnet/celo.toml
@@ -20,6 +20,7 @@ gas_paying_token = "0x057898f3C43F129a17517B9056D23851F124b19f"
   granite_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   holocene_time = 1752073200 # Wed 9 Jul 2025 15:00:00 UTC
   isthmus_time = 1752073200 # Wed 9 Jul 2025 15:00:00 UTC
+  jovian_time = 1774958788 # Tue 31 Mar 2026 12:06:28 UTC
 
 [optimism]
   eip1559_elasticity = 5

--- a/superchain/configs/mainnet/fraxtal.toml
+++ b/superchain/configs/mainnet/fraxtal.toml
@@ -18,7 +18,7 @@ max_sequencer_drift = 600
   fjord_time = 1733947201 # Wed 11 Dec 2024 20:00:01 UTC
   granite_time = 1738958401 # Fri 7 Feb 2025 20:00:01 UTC
   holocene_time = 1744052401 # Mon 7 Apr 2025 19:00:01 UTC
-  isthmus_time = 1755716401 # Wed 20 Aug 2025 21:00:01 UTC
+  isthmus_time = 1755716401 # Wed 20 Aug 2025 19:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 10

--- a/superchain/configs/mainnet/fraxtal.toml
+++ b/superchain/configs/mainnet/fraxtal.toml
@@ -17,6 +17,8 @@ max_sequencer_drift = 600
   ecotone_time = 1717009201 # Wed 29 May 2024 19:00:01 UTC
   fjord_time = 1733947201 # Wed 11 Dec 2024 20:00:01 UTC
   granite_time = 1738958401 # Fri 7 Feb 2025 20:00:01 UTC
+  holocene_time = 1744052401 # Mon 7 Apr 2025 19:00:01 UTC
+  isthmus_time = 1755716401 # Wed 20 Aug 2025 21:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 10

--- a/superchain/configs/mainnet/lyra.toml
+++ b/superchain/configs/mainnet/lyra.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
   isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
+  jovian_time = 1769065201 # Thu 22 Jan 2026 07:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/orderly.toml
+++ b/superchain/configs/mainnet/orderly.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   granite_time = 1726070401 # Wed 11 Sep 2024 16:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
   isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
+  jovian_time = 1769065201 # Thu 22 Jan 2026 07:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/shape.toml
+++ b/superchain/configs/mainnet/shape.toml
@@ -17,6 +17,8 @@ max_sequencer_drift = 1800
   ecotone_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   fjord_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   granite_time = 1727370000 # Thu 26 Sep 2024 17:00:00 UTC
+  holocene_time = 1739880000 # Tue 18 Feb 2025 12:00:00 UTC
+  isthmus_time = 1774530000 # Thu 26 Mar 2026 13:00:00 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/sseed.toml
+++ b/superchain/configs/mainnet/sseed.toml
@@ -19,6 +19,7 @@ max_sequencer_drift = 600
   granite_time = 1726185601 # Fri 13 Sep 2024 00:00:01 UTC
   holocene_time = 1736445601 # Thu 9 Jan 2025 18:00:01 UTC
   isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
+  jovian_time = 1769065201 # Thu 22 Jan 2026 07:00:01 UTC
 
 [optimism]
   eip1559_elasticity = 6


### PR DESCRIPTION
# Add missing `holocene_time` / `isthmus_time` / `jovian_time` to 7 mainnet chains

The registry is out of sync with on-chain state on 7 mainnet OP-Stack chains. Each chain has shipped a hardfork without a corresponding `[hardforks]` entry. This PR backfills the missing timestamps, all sourced from authoritative configs (op-node `optimism_rollupConfig` RPC, the chain's own `rollup.json`, or the chain's official run-a-node documentation).

## Changes

| File | Field added | Value (unix s) | Human time (UTC) |
|---|---|---|---|
| `superchain/configs/mainnet/celo.toml` | `jovian_time` | `1774958788` | Tue 31 Mar 2026 12:06:28 |
| `superchain/configs/mainnet/bob.toml` | `jovian_time` | `1773325801` | Thu 12 Mar 2026 14:30:01 |
| `superchain/configs/mainnet/lyra.toml` | `jovian_time` | `1769065201` | Thu 22 Jan 2026 07:00:01 |
| `superchain/configs/mainnet/orderly.toml` | `jovian_time` | `1769065201` | Thu 22 Jan 2026 07:00:01 |
| `superchain/configs/mainnet/sseed.toml` | `jovian_time` | `1769065201` | Thu 22 Jan 2026 07:00:01 |
| `superchain/configs/mainnet/fraxtal.toml` | `holocene_time` | `1744052401` | Mon 7 Apr 2025 19:00:01 |
| `superchain/configs/mainnet/fraxtal.toml` | `isthmus_time` | `1755716401` | Wed 20 Aug 2025 21:00:01 |
| `superchain/configs/mainnet/shape.toml` | `holocene_time` | `1739880000` | Tue 18 Feb 2025 12:00:00 |
| `superchain/configs/mainnet/shape.toml` | `isthmus_time` | `1774530000` | Thu 26 Mar 2026 13:00:00 |


## Sources

Every value below comes from a first-party authoritative source.

### Celo (`jovian_time = 1774958788`)
- **Official upgrade notice:** [docs.celo.org/infra-partners/notices/jovian-upgrade](https://docs.celo.org/infra-partners/notices/jovian-upgrade) — quote: *"Mainnet activation: Tue, Mar 31, 2026, 12:06:28 UTC. Activation timestamp: `1774958788`"*

### BOB (`jovian_time = 1773325801`)
- **Official node-operator docs:** [docs.gobob.xyz/docs/bob-chain/full-node](https://docs.gobob.xyz/docs/bob-chain/full-node) — `OP_NODE_OVERRIDE_JOVIAN=1773325801`
- **op-node `optimism_rollupConfig` (live, https://rpc.gobob.xyz):** returns `jovian_time: 1773325801` ✓ (confirms doc value)

### Lyra Chain (`jovian_time = 1769065201`)
- **op-node `optimism_rollupConfig` (live, https://rpc.lyra.finance):** returns `jovian_time: 1769065201`

### Orderly Mainnet (`jovian_time = 1769065201`)
- **op-node `optimism_rollupConfig` (live, https://rpc.orderly.network):** returns `jovian_time: 1769065201`

### Superseed (`jovian_time = 1769065201`)
- **op-node `optimism_rollupConfig` (live, https://mainnet.superseed.xyz):** returns `jovian_time: 1769065201`

### Fraxtal (`holocene_time = 1744052401`, `isthmus_time = 1755716401`)
- **Source: Fraxtal `rollup.json`** — fields `"holocene_time": 1744052401, "isthmus_time": 1755716401`
- **Releases:** [`FraxFinance/fraxtal-node` mainnet-20250325 — "Scheduled mainnet holocene hard fork"](https://github.com/FraxFinance/fraxtal-node/releases/tag/mainnet-20250325) and [mainnet-20250806 — "Scheduled mainnet isthmus hard fork"](https://github.com/FraxFinance/fraxtal-node/releases/tag/mainnet-20250806)

### Shape (`holocene_time = 1739880000`, `isthmus_time = 1774530000`)
- **Official node-operator docs:** [docs.shape.network/technical-details/run-a-node](https://docs.shape.network/technical-details/run-a-node) — explicit op-node override flags:
  ```
  --override.granite=1727370000 --override.holocene=1739880000 --override.isthmus=1774530000
  ```


