### PR TITLE
feat(proofs): update standard proof-game timing params

### DIFF
--- a/ops/internal/report/testdata/expected-comment.md
+++ b/ops/internal/report/testdata/expected-comment.md
@@ -46,7 +46,7 @@
 | ✅ | AbsolutePrestate | `0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c` | `0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c` |
 | ✅ | MaxGameDepth | `73` | `73` |
 | ✅ | SplitDepth | `30` | `30` |
-| ✅ | MaxClockDuration | `302400` | `302400` |
+| ✅ | MaxClockDuration | `561600` | `561600` |
 | ✅ | ClockExtension | `10800` | `10800` |
 
 </details>

--- a/ops/internal/report/testdata/l1-report.json
+++ b/ops/internal/report/testdata/l1-report.json
@@ -26,7 +26,7 @@
       "AbsolutePrestate": "0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c",
       "MaxGameDepth": 73,
       "SplitDepth": 30,
-      "MaxClockDuration": 302400,
+      "MaxClockDuration": 561600,
       "ClockExtension": 10800
     },
     "Permissionless": null

--- a/validation/standard/standard-config-params-mainnet.toml
+++ b/validation/standard/standard-config-params-mainnet.toml
@@ -5,8 +5,8 @@ seq_window_size = [3600, 3600]
 block_time = [1, 2]
 
 [optimism_portal_2]
-proof_maturity_delay_seconds = [604800, 604800]        # 7 days
-dispute_game_finality_delay_seconds = [302400, 302400] # 3.5 days
+proof_maturity_delay_seconds = [43200, 43200]        # 12 hours
+dispute_game_finality_delay_seconds = [43200, 43200] # 12 hours
 respected_game_type = 0
 
 [resource_config]
@@ -37,5 +37,5 @@ minimum_base_fee = [0, 10_000_000_000] # 10 Gwei
 game_type = 1
 max_game_depth = 73
 split_depth = 30
-max_clock_duration = 302400
+max_clock_duration = 561600
 clock_extension = 10800

--- a/validation/standard/standard-config-params-sepolia.toml
+++ b/validation/standard/standard-config-params-sepolia.toml
@@ -5,8 +5,8 @@ seq_window_size = [3600, 3600]
 block_time = [1, 2]
 
 [optimism_portal_2]
-proof_maturity_delay_seconds = [604800, 604800]        # 7 days
-dispute_game_finality_delay_seconds = [302400, 302400] # 3.5 days
+proof_maturity_delay_seconds = [43200, 43200]        # 12 hours
+dispute_game_finality_delay_seconds = [43200, 43200] # 12 hours
 respected_game_type = 0
 
 [resource_config]
@@ -37,5 +37,5 @@ minimum_base_fee = [0, 10_000_000_000] # 10 Gwei
 game_type = 1
 max_game_depth = 73
 split_depth = 30
-max_clock_duration = 302400
+max_clock_duration = 561600
 clock_extension = 10800


### PR DESCRIPTION
## Summary

Registry policy/reporting update: the standard proof-game timing parameters are updated to match the new proof-game timing defaults from the optimism contracts/deployer change.

Standard params now encode (mainnet + sepolia):

- `proof_maturity_delay_seconds = [43200, 43200]` (12 hours, was 7 days)
- `dispute_game_finality_delay_seconds = [43200, 43200]` (12 hours, was 3.5 days)
- `[proofs.permissioned] max_clock_duration = 561600` (6.5 days, was 3.5 days)

This keeps the 7 day total optimistic path: the portal proof-maturity air gap and the dispute-game finality air gap are both 12h, and the optimistic dispute-game max clock duration is 6.5 days.

## Changes

- `validation/standard/standard-config-params-mainnet.toml`
- `validation/standard/standard-config-params-sepolia.toml`
- `ops/internal/report/testdata/l1-report.json` — mock deployed chain `MaxClockDuration` updated `302400` -> `561600` so the report testdata represents a chain compliant with the new standard.
- `ops/internal/report/testdata/expected-comment.md` — mechanical golden-output update forced by the standard-param bump

## Validation

- `validation` module: `go test ./...` — PASS
- `ops/internal/report` `TestRenderComment` — PASS