### PR TITLE
chore(prestates): add kona-client/v1.5.2 entries

### DIFF
--- a/validation/standard/standard-prestates.toml
+++ b/validation/standard/standard-prestates.toml
@@ -424,3 +424,11 @@ hash="0x034f407b2fbbdf34a966e03915d02da5e59259bf3eb729f823acdffb86a37c2e"
 [[prestates."1.2.13"]]
 type="cannon64-kona-interop"
 hash="0x035ef680a6fa34c50d8d8169075b5d133ecd7b38fe2b2a83cc76fc81ae5d7c52"
+
+[[prestates."1.5.2"]]
+type="cannon64-kona"
+hash="0x0342fb4df7931013ac09dd028d083e1b641f044a2085b2a807b67417ec912d6e"
+
+[[prestates."1.5.2"]]
+type="cannon64-kona-interop"
+hash="0x03ae89b2187ce030608efb2a4df76c7dd62d9293f708764bfefa593f89f77a1f"


### PR DESCRIPTION
## Summary

Adds `cannon64-kona` and `cannon64-kona-interop` prestate hashes for `kona-client/v1.5.2` (U19 release, tagged 2026-05-21 by @pauldowman).

## New entries

| Tag | Variant | Hash |
|---|---|---|
| `kona-client/v1.5.2` | cannon64-kona | `0x0342fb4df7931013ac09dd028d083e1b641f044a2085b2a807b67417ec912d6e` |
| `kona-client/v1.5.2` | cannon64-kona-interop | `0x03ae89b2187ce030608efb2a4df76c7dd62d9293f708764bfefa593f89f77a1f` |

## Reproducibility

Built from `ethereum-optimism/optimism@a5f807798b0896becd497d27b92afe911b088ad4` (the commit `kona-client/v1.5.2` points at):

```bash
git clone --branch kona-client/v1.5.2 --depth 1 https://github.com/ethereum-optimism/optimism
cd optimism/rust && just reproducible-kona-prestate
jq -r .pre kona/prestate-artifacts-cannon/prestate-proof.json
jq -r .pre kona/prestate-artifacts-cannon-interop/prestate-proof.json
```

## Test plan

- [ ] CI passes (TOML parsing + any prestate-validation jobs)
- [ ] Reviewer can rebuild locally and reproduce both hashes
- [ ] Preimages uploaded to `gs://kona-proof-prestates/cannon/` so op-challenger can fetch them at dispute time

🤖 Generated with [Claude Code](https://claude.com/claude-code)