### PR TITLE
Add kona prestates for v1.6.0-rc.1

### DIFF
--- a/validation/standard/standard-prestates.toml
+++ b/validation/standard/standard-prestates.toml
@@ -448,3 +448,11 @@ hash="0x0342fb4df7931013ac09dd028d083e1b641f044a2085b2a807b67417ec912d6e"
 [[prestates."1.5.2"]]
 type="cannon64-kona-interop"
 hash="0x03ae89b2187ce030608efb2a4df76c7dd62d9293f708764bfefa593f89f77a1f"
+
+[[prestates."1.6.0-rc.1"]]
+type="cannon64-kona"
+hash="0x03cdb57a890f7e129d5abbe074f19425f94cf2b84f614aab008a96f91debae65"
+
+[[prestates."1.6.0-rc.1"]]
+type="cannon64-kona-interop"
+hash="0x039e98f06aa04983d15f8dfce40884c4c93131de8ab4c01d9e647ab38a954894"


### PR DESCRIPTION
Adds the kona-client `v1.6.0-rc.1` reproducible absolute prestate hashes to `validation/standard/standard-prestates.toml`.

Built via the reproducible Docker build (`just reproducible-prestate-kona`) at git tag `kona-client/v1.6.0-rc.1`:

- `cannon64-kona`: `0x03cdb57a890f7e129d5abbe074f19425f94cf2b84f614aab008a96f91debae65`
- `cannon64-kona-interop`: `0x039e98f06aa04983d15f8dfce40884c4c93131de8ab4c01d9e647ab38a954894`