### PR TITLE
chore(ops): rename interop_time to lagoon_time

### DIFF
--- a/ops/internal/config/chain.go
+++ b/ops/internal/config/chain.go
@@ -116,7 +116,7 @@ type Hardforks struct {
 	HoloceneTime           *HardforkTime `toml:"holocene_time"`
 	PectraBlobScheduleTime *HardforkTime `toml:"pectra_blob_schedule_time,omitempty"`
 	IsthmusTime            *HardforkTime `toml:"isthmus_time"`
-	InteropTime            *HardforkTime `toml:"interop_time"`
+	LagoonTime             *HardforkTime `toml:"lagoon_time"`
 	JovianTime             *HardforkTime `toml:"jovian_time"`
 	KarstTime              *HardforkTime `toml:"karst_time"`
 }

--- a/ops/internal/manage/depsets.go
+++ b/ops/internal/manage/depsets.go
@@ -142,7 +142,7 @@ func (dc *DepsetChecker) checkOffchain(cfgs []DiskChainConfig) error {
 
 // checkOnchain ensures that DisputeGameFactoryProxy and EthLockboxProxy addresses read from onchain
 // are the same for all chains in a depset. These checks are only performed for chains who have
-// already activated interop (i.e. interop_time < current unix timestamp).
+// already activated interop (i.e. lagoon_time < current unix timestamp).
 func (dc *DepsetChecker) checkOnchain(cfgs []DiskChainConfig) error {
 	if len(cfgs) == 0 {
 		return fmt.Errorf("no chain configs provided to checkOnchain")
@@ -156,8 +156,8 @@ func (dc *DepsetChecker) checkOnchain(cfgs []DiskChainConfig) error {
 	now := time.Now().Unix()
 	var activatedChains []DiskChainConfig
 	for _, cfg := range cfgs {
-		interopTime := cfg.Config.Hardforks.InteropTime
-		if interopTime == nil || *interopTime.U64Ptr() > uint64(now) {
+		lagoonTime := cfg.Config.Hardforks.LagoonTime
+		if lagoonTime == nil || *lagoonTime.U64Ptr() > uint64(now) {
 			continue
 		}
 		activatedChains = append(activatedChains, cfg)

--- a/ops/internal/manage/testdata/depsets_invalid/depset_length_1.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/depset_length_1.toml
@@ -2,7 +2,7 @@ name = "Test Chain 3"
 chain_id = 903
 
 [hardforks]
-interop_time = 3333
+lagoon_time = 3333
 
 [interop]
 dependencies."903" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/depset_length_2.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/depset_length_2.toml
@@ -2,7 +2,7 @@ name = "Test Chain 4"
 chain_id = 904
 
 [hardforks]
-interop_time = 4444
+lagoon_time = 4444
 
 [interop]
 dependencies."904" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/missing_address_1.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/missing_address_1.toml
@@ -2,7 +2,7 @@ name = "Test Chain 2"
 chain_id = 902
 
 [hardforks]
-interop_time = 4424
+lagoon_time = 4424
 
 [interop]
 dependencies."902" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/missing_address_2.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/missing_address_2.toml
@@ -2,7 +2,7 @@ name = "Test Chain 4"
 chain_id = 904
 
 [hardforks]
-interop_time = 4424
+lagoon_time = 4424
 
 [interop]
 dependencies."902" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/transience/chain1.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/transience/chain1.toml
@@ -2,7 +2,7 @@ name = "Test Chain 1"
 chain_id = 901
 
 [hardforks]
-interop_time = 1234
+lagoon_time = 1234
 
 [interop]
 dependencies."901" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/transience/chain2.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/transience/chain2.toml
@@ -2,7 +2,7 @@ name = "Test Chain 2"
 chain_id = 902
 
 [hardforks]
-interop_time = 4424
+lagoon_time = 4424
 
 [interop]
 dependencies."901" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/transience/chain3.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/transience/chain3.toml
@@ -2,7 +2,7 @@ name = "Test Chain 3"
 chain_id = 903
 
 [hardforks]
-interop_time = 4424
+lagoon_time = 4424
 
 [interop]
 dependencies."901" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/transience/chain4.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/transience/chain4.toml
@@ -2,7 +2,7 @@ name = "Test Chain 4"
 chain_id = 904
 
 [hardforks]
-interop_time = 4424
+lagoon_time = 4424
 
 [interop]
 dependencies."901" = {}

--- a/ops/internal/manage/testdata/depsets_invalid/transience/chain5.toml
+++ b/ops/internal/manage/testdata/depsets_invalid/transience/chain5.toml
@@ -2,7 +2,7 @@ name = "Test Chain 5"
 chain_id = 905
 
 [hardforks]
-interop_time = 4424
+lagoon_time = 4424
 
 [interop]
 dependencies."901" = {}

--- a/ops/internal/manage/testdata/depsets_valid/chain1.toml
+++ b/ops/internal/manage/testdata/depsets_valid/chain1.toml
@@ -2,7 +2,7 @@ name = "Test Chain 1"
 chain_id = 901
 
 [hardforks]
-interop_time = 1234
+lagoon_time = 1234
 
 [interop]
 dependencies."901" = {}

--- a/ops/internal/manage/testdata/depsets_valid/chain2.toml
+++ b/ops/internal/manage/testdata/depsets_valid/chain2.toml
@@ -2,7 +2,7 @@ name = "Test Chain 2"
 chain_id = 902
 
 [hardforks]
-interop_time = 4424
+lagoon_time = 4424
 
 [interop]
 dependencies."902" = {}

--- a/ops/internal/manage/testdata/depsets_valid/chain3.toml
+++ b/ops/internal/manage/testdata/depsets_valid/chain3.toml
@@ -2,4 +2,4 @@ name = "Test Chain 3"
 chain_id = 903
 
 [hardforks]
-interop_time = 4424
+lagoon_time = 4424

--- a/ops/internal/manage/testdata/depsets_valid/chain5.toml
+++ b/ops/internal/manage/testdata/depsets_valid/chain5.toml
@@ -2,7 +2,7 @@ name = "Test Chain 5"
 chain_id = 905
 
 [hardforks]
-interop_time = 5555
+lagoon_time = 5555
 
 [interop]
 dependencies."905" = {}

--- a/ops/internal/manage/testdata/depsets_valid/chain6.toml
+++ b/ops/internal/manage/testdata/depsets_valid/chain6.toml
@@ -2,7 +2,7 @@ name = "Test Chain 6"
 chain_id = 906
 
 [hardforks]
-interop_time = 6666
+lagoon_time = 6666
 
 [interop]
 dependencies."905" = {}

--- a/ops/internal/manage/testdata/depsets_valid/chain7.toml
+++ b/ops/internal/manage/testdata/depsets_valid/chain7.toml
@@ -2,7 +2,7 @@ name = "Test Chain 7"
 chain_id = 907
 
 [hardforks]
-interop_time = 7777
+lagoon_time = 7777
 
 [interop]
 dependencies."905" = {}

--- a/ops/internal/manage/validation.go
+++ b/ops/internal/manage/validation.go
@@ -104,7 +104,7 @@ func ValidateGenesisIntegrity(cfg *config.Chain, genesis *core.Genesis) error {
 		GraniteTime:             cfg.Hardforks.GraniteTime.U64Ptr(),
 		HoloceneTime:            cfg.Hardforks.HoloceneTime.U64Ptr(),
 		IsthmusTime:             cfg.Hardforks.IsthmusTime.U64Ptr(),
-		InteropTime:             cfg.Hardforks.InteropTime.U64Ptr(),
+		InteropTime:             cfg.Hardforks.LagoonTime.U64Ptr(), // op-geth still names this InteropTime; remove carveout once op-geth renames to LagoonTime
 		JovianTime:              cfg.Hardforks.JovianTime.U64Ptr(),
 		TerminalTotalDifficulty: common.Big0,
 		Ethash:                  nil,

--- a/superchain/configs/rehearsal-0-bn/rehearsal-0-bn-0.toml
+++ b/superchain/configs/rehearsal-0-bn/rehearsal-0-bn-0.toml
@@ -20,7 +20,7 @@ max_sequencer_drift = 600
   granite_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   holocene_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   isthmus_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
-  interop_time = 1749150000 # Thu 5 Jun 2025 19:00:00 UTC
+  lagoon_time = 1749150000 # Thu 5 Jun 2025 19:00:00 UTC
 
 [interop]
   [interop.dependencies]

--- a/superchain/configs/rehearsal-0-bn/rehearsal-0-bn-1.toml
+++ b/superchain/configs/rehearsal-0-bn/rehearsal-0-bn-1.toml
@@ -20,7 +20,7 @@ max_sequencer_drift = 600
   granite_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   holocene_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   isthmus_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
-  interop_time = 1749150000 # Thu 5 Jun 2025 19:00:00 UTC
+  lagoon_time = 1749150000 # Thu 5 Jun 2025 19:00:00 UTC
 
 [interop]
   [interop.dependencies]

--- a/superchain/configs/rehearsal-0-bn/superchain.toml
+++ b/superchain/configs/rehearsal-0-bn/superchain.toml
@@ -4,7 +4,7 @@ superchain_config_addr = "0x672F11f34b7bE67C13A6FCba819c339bc3B0a585"
 op_contracts_manager_addr = "0x0fcD165e2531C934a186e3a412D58Daa241E0Ad0"
 
 [hardforks]
-  interop_time = 1749150000 # Thu 5 Jun 2025 19:00:00 UTC
+  lagoon_time = 1749150000 # Thu 5 Jun 2025 19:00:00 UTC
 
 [l1]
   chain_id = 11155111


### PR DESCRIPTION
## Summary

Follow-up to the [Interop → Lagoon hardfork rename](https://github.com/ethereum-optimism/optimism/pull/21105) and umbrella issue [ethereum-optimism/optimism#21135](https://github.com/ethereum-optimism/optimism/issues/21135). Renames the registry's `interop_time` TOML field to `lagoon_time` so downstream consumers (optimism monorepo, kona, op-alloy) can drop their carveouts.

## Changes

- `ops/internal/config/chain.go` — `Hardforks.InteropTime` → `Hardforks.LagoonTime`, TOML tag `interop_time` → `lagoon_time`
- `ops/internal/manage/depsets.go` — local var + comment renamed
- `ops/internal/manage/validation.go` — RHS flipped to `cfg.Hardforks.LagoonTime`; LHS (`params.ChainConfig.InteropTime`) keeps the old name because that field belongs to op-geth and hasn't renamed yet. Inline comment marks the carveout.
- 18 TOML fixtures touched: 15 test fixtures in `ops/internal/manage/testdata/`, 3 rehearsal configs in `superchain/configs/rehearsal-0-bn/`
- No production mainnet/sepolia chain configs reference this field, so no canonical chain TOMLs are touched

## Follow-ups

- op-geth: rename `InteropTime` → `LagoonTime` on `params.ChainConfig` and own TOML mirror; rebundle `superchain-configs.zip`
- optimism monorepo cleanup: drop the four carveouts and the one new carveout introduced here