### PR TITLE
Add kona prestates for v1.6.0-rc.2

### DIFF
--- a/validation/standard/standard-prestates.toml
+++ b/validation/standard/standard-prestates.toml
@@ -456,3 +456,11 @@ hash="0x03cdb57a890f7e129d5abbe074f19425f94cf2b84f614aab008a96f91debae65"
 [[prestates."1.6.0-rc.1"]]
 type="cannon64-kona-interop"
 hash="0x039e98f06aa04983d15f8dfce40884c4c93131de8ab4c01d9e647ab38a954894"
+
+[[prestates."1.6.0-rc.2"]]
+type="cannon64-kona"
+hash="0x0337ecb3604c0b40c352e0c7711beb17a212d583f4fe956fd8d66e29ad5f9025"
+
+[[prestates."1.6.0-rc.2"]]
+type="cannon64-kona-interop"
+hash="0x03e3a42cf9a1d116f414206c465c6cdb74556136090e7c9556329403da0f310f"


### PR DESCRIPTION
Add the kona-client v1.6.0-rc.2 absolute prestate hashes to `standard-prestates.toml`.

- `cannon64-kona` (non-interop): `0x0337ecb3604c0b40c352e0c7711beb17a212d583f4fe956fd8d66e29ad5f9025`
- `cannon64-kona-interop` (interop): `0x03e3a42cf9a1d116f414206c465c6cdb74556136090e7c9556329403da0f310f`

Built reproducibly via `just reproducible-kona-prestate` from the `kona-client/v1.6.0-rc.2` tag.