### PR TITLE
isthmus and jovian timestamps for boba-mainnet and boba-sepolia

### DIFF
--- a/superchain/configs/mainnet/boba.toml
+++ b/superchain/configs/mainnet/boba.toml
@@ -18,6 +18,8 @@ max_sequencer_drift = 600
   fjord_time = 1725951600 # Tue 10 Sep 2024 07:00:00 UTC
   granite_time = 1729753200 # Thu 24 Oct 2024 07:00:00 UTC
   holocene_time = 1738785600 # Wed 5 Feb 2025 20:00:00 UTC
+  isthmus_time = 1787011200 # Tue 18 Aug 2026 00:00:00 UTC
+  jovian_time = 1787616000 # Tue 25 Aug 2026 00:00:00 UTC
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/sepolia/boba.toml
+++ b/superchain/configs/sepolia/boba.toml
@@ -19,6 +19,8 @@ max_sequencer_drift = 600
   granite_time = 1726470000 # Mon 16 Sep 2024 07:00:00 UTC
   holocene_time = 1736150400 # Mon 6 Jan 2025 08:00:00 UTC
   pectra_blob_schedule_time = 1743534000 # Tue 1 Apr 2025 19:00:00 UTC
+  isthmus_time = 1786579200 # Thu 13 Aug 2026 00:00:00 UTC
+  jovian_time = 1787184000 # Thu 20 Aug 2026 00:00:00 UTC
 
 [optimism]
   eip1559_elasticity = 6


### PR DESCRIPTION
# Summary

This PR configures isthmus and jovian hardfork timestamps for `Boba Mainnet` and `Boba Sepolia`.
## Boba Mainnet
  * isthmus_time = 1787011200 # Tue 18 Aug 2026 00:00:00 UTC
  * jovian_time = 1787616000 # Tue 25 Aug 2026 00:00:00 UTC

## Boba Sepolia
  * isthmus_time = 1786579200 # Thu 13 Aug 2026 00:00:00 UTC
  * jovian_time = 1787184000 # Thu 20 Aug 2026 00:00:00 UTC
   
## Checklist

- [X] I have declared the chain at the appropriate [Superchain Level](../docs/glossary.md#superchain-level-and-rollup-stage).
- [X] I have run `just codegen $SEPOLIA_RPC_URL,$MAINNET_RPC_URL` to ensure that all auto-generated files are updated
- [X] I have checked `Allow edits from maintainers` on this PR.
