### PR TITLE
ops/fs: stage AtomicWrite temp file in destination dir

### DIFF
--- a/ops/internal/fs/atomic.go
+++ b/ops/internal/fs/atomic.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 type AtomicWriter struct {
@@ -33,7 +34,9 @@ func (w *AtomicWriter) Write(data []byte) (int, error) {
 }
 
 func (w *AtomicWriter) Close() error {
-	tmp, err := os.CreateTemp("", "atomic")
+	// Stage the temp file in the destination's directory so the final rename
+	// stays on the same filesystem; renaming across filesystems fails with EXDEV.
+	tmp, err := os.CreateTemp(filepath.Dir(w.filename), "atomic")
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}

--- a/ops/internal/fs/atomic_test.go
+++ b/ops/internal/fs/atomic_test.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,6 +26,25 @@ func TestAtomicWrite(t *testing.T) {
 	require.Empty(t, originalHandleData)
 
 	actData, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	require.EqualValues(t, expData, actData)
+}
+
+// TestAtomicWriteSeparateTempDir ensures AtomicWrite does not depend on the
+// system temp dir, which may live on a different filesystem than the
+// destination. When it does, the final os.Rename fails with EXDEV
+// ("invalid cross-device link"). We reproduce that dependency by pointing the
+// system temp dir at an unusable path: AtomicWrite must still succeed by
+// staging its temp file alongside the destination.
+func TestAtomicWriteSeparateTempDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TMPDIR", filepath.Join(dir, "nonexistent"))
+
+	dest := filepath.Join(dir, "out.txt")
+	expData := []byte("hello, world")
+	require.NoError(t, AtomicWrite(dest, 0o644, expData))
+
+	actData, err := os.ReadFile(dest)
 	require.NoError(t, err)
 	require.EqualValues(t, expData, actData)
 }


### PR DESCRIPTION
`AtomicWrite` staged its temp file in the system temp dir, then renamed it onto the destination. A cross-filesystem rename fails with `EXDEV` ("invalid cross-device link") — e.g. running `codegen` from a worktree under `/home` while `TMPDIR` is `/tmp`. Now stages the temp file in the destination's directory, so the rename is same-filesystem and atomic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
