### PR TITLE
ops: support OPCM v2 import state

### DIFF
--- a/ops/cmd/import_devnet/main.go
+++ b/ops/cmd/import_devnet/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 
 	"github.com/ethereum-optimism/superchain-registry/ops/internal/deployer"
 	"github.com/ethereum-optimism/superchain-registry/ops/internal/manage"
@@ -13,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/superchain-registry/ops/internal/report"
 
 	"github.com/urfave/cli/v2"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -46,6 +48,22 @@ var (
 		Value:   "",
 	}
 )
+
+type manifestChainID int64
+
+func (id *manifestChainID) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Tag {
+	case "!!int", "!!str":
+		parsed, err := strconv.ParseInt(value.Value, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid chain_id %q: %w", value.Value, err)
+		}
+		*id = manifestChainID(parsed)
+		return nil
+	default:
+		return fmt.Errorf("invalid chain_id type %s", value.Tag)
+	}
+}
 
 func main() {
 	app := &cli.App{
@@ -89,8 +107,8 @@ func action(cliCtx *cli.Context) error {
 		Name string `yaml:"name"`
 		L2   struct {
 			Chains []struct {
-				Name    string `yaml:"name"`
-				ChainID int64  `yaml:"chain_id"`
+				Name    string          `yaml:"name"`
+				ChainID manifestChainID `yaml:"chain_id"`
 			} `yaml:"chains"`
 		} `yaml:"l2"`
 	}
@@ -125,7 +143,7 @@ func action(cliCtx *cli.Context) error {
 			return fmt.Errorf("failed to read chain id: %w", err)
 		}
 		chain := m.L2.Chains[i]
-		if chain.ChainID != int64(chainID) {
+		if int64(chain.ChainID) != int64(chainID) {
 			return fmt.Errorf("chain ID mismatch for chain at index %d : manifest %d, state %d",
 				i,
 				chain.ChainID, chainID)

--- a/ops/internal/deployer/deployer.go
+++ b/ops/internal/deployer/deployer.go
@@ -73,7 +73,11 @@ func WithReleaseBinary(binDir string, l1ContractsRelease string) (*FixedBinaryPi
 }
 
 func VersionedBinaryPath(binDir string, deployerVersion string) string {
-	return filepath.Join(binDir, fmt.Sprintf("op-deployer_%s", strings.TrimPrefix(deployerVersion, "op-deployer/")))
+	version := strings.TrimPrefix(deployerVersion, "op-deployer/")
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+	return filepath.Join(binDir, fmt.Sprintf("op-deployer_%s", version))
 }
 
 func init() {

--- a/ops/internal/deployer/deployer_test.go
+++ b/ops/internal/deployer/deployer_test.go
@@ -116,6 +116,10 @@ func TestVersionsMapInitialization(t *testing.T) {
 	require.Equal(t, actualVersion, expectedVersion)
 }
 
+func TestVersionedBinaryPathAcceptsBareVersion(t *testing.T) {
+	require.Equal(t, filepath.Join("cache", "op-deployer_v0.7.0-rc.1"), VersionedBinaryPath("cache", "0.7.0-rc.1"))
+}
+
 func TestBinaryInvocation(t *testing.T) {
 	cacheDir := os.Getenv("DEPLOYER_CACHE_DIR")
 	require.NotEmpty(t, cacheDir)

--- a/ops/internal/deployer/opaque_map.go
+++ b/ops/internal/deployer/opaque_map.go
@@ -218,6 +218,7 @@ func (om OpaqueState) ReadSuperchainConfigProxy() (common.Address, error) {
 
 func (om OpaqueState) ReadOpcmImpl() (common.Address, error) {
 	return om.queryAddress(
+		"implementationsDeployment.OpcmV2Impl",
 		"implementationsDeployment.OpcmImpl",
 		"implementationsDeployment.opcmAddress",
 	)

--- a/ops/internal/deployer/opaque_map_test.go
+++ b/ops/internal/deployer/opaque_map_test.go
@@ -1,0 +1,21 @@
+package deployer
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadOpcmImplSupportsV2State(t *testing.T) {
+	expected := common.HexToAddress("0x80dcec9d21ce25b895ed26ca4ac8feb88c159eec")
+	state := OpaqueState{
+		"implementationsDeployment": map[string]any{
+			"OpcmV2Impl": expected.Hex(),
+		},
+	}
+
+	actual, err := state.ReadOpcmImpl()
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}

--- a/ops/internal/deployer/state.go
+++ b/ops/internal/deployer/state.go
@@ -61,8 +61,8 @@ func ReadOpaqueStateFile(p string) (OpaqueState, error) {
 type StateMerger = func(state OpaqueState) (OpaqueMap, OpaqueState, error)
 
 func GetStateMerger(version string) (StateMerger, error) {
-	// Extract version string (e.g., "0.4.5" from "op-deployer/v0.4.5")
-	re := regexp.MustCompile(`op-deployer/v(\d+\.\d+\.\d+)`)
+	// Extract version string (e.g., "0.4.5" from "op-deployer/v0.4.5").
+	re := regexp.MustCompile(`(?:op-deployer/)?v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)`)
 	match := re.FindStringSubmatch(version)
 	if len(match) < 2 {
 		return nil, fmt.Errorf("invalid deployer version format: %s", version)
@@ -82,7 +82,7 @@ func GetStateMerger(version string) (StateMerger, error) {
 		{">= 0.2.0, < 0.3.0", MergeStateV2},
 		{">= 0.3.0, < 0.4.0", MergeStateV3},
 		{">= 0.4.0, < 0.4.5", MergeStateV4_0},
-		{">= 0.4.5", MergeStateV4_1},
+		{">= 0.4.5-0", MergeStateV4_1},
 	}
 
 	for _, c := range constraints {

--- a/ops/internal/deployer/state_test.go
+++ b/ops/internal/deployer/state_test.go
@@ -42,3 +42,9 @@ func TestMergeState(t *testing.T) {
 		})
 	}
 }
+
+func TestGetStateMergerAcceptsBareReleaseCandidate(t *testing.T) {
+	merger, err := GetStateMerger("0.7.0-rc.1")
+	require.NoError(t, err)
+	require.Equal(t, fmt.Sprintf("%p", MergeStateV4_1), fmt.Sprintf("%p", merger))
+}


### PR DESCRIPTION
## Summary
- read `implementationsDeployment.OpcmV2Impl` when importing newer op-deployer state
- accept bare/prerelease op-deployer versions like `0.7.0-rc.1`
- accept quoted `chain_id` values in devnet manifests

## Verification
- `go test ./internal/deployer -run 'Test(ReadOpcmImplSupportsV2State|GetStateMergerAcceptsBareReleaseCandidate|VersionedBinaryPathAcceptsBareVersion|MergeState|AutodetectBinary|VersionsMapInitialization)'`\n- `go run ./cmd/import_devnet/main.go --state-filename /Users/jacobelias/workspace/ethereum-optimism/devnets-private/stg/sepolia-dev-1/op-deployer/state.json --manifest-path /Users/jacobelias/workspace/ethereum-optimism/devnets-private/stg/sepolia-dev-1/manifest.yaml --op-deployer-version=0.7.0-rc.1 --l1-contracts-version=op-contracts/v7.0.0-rc.4`