### PR TITLE
superchain: remove protocol_versions_addr

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,12 +46,11 @@ l1:
   public_rpc: https://ethereum-goerli-rpc.allthatnode.com
   explorer: https://eth-goerli.blockscout.com
 
-protocol_versions_addr: null # todo
 superchain_config_addr: null # todo
 EOF
 ```
 
-Superchain-wide configuration, like the `ProtocolVersions` contract address, should be configured here when available.
+Superchain-wide configuration, like the `SuperchainConfig` contract address, should be configured here when available.
 
 ## `superchain` Go Module
 

--- a/ops/internal/config/superchain.go
+++ b/ops/internal/config/superchain.go
@@ -69,7 +69,6 @@ func getL1ChainId(ctx context.Context, rpcURL string) (uint64, error) {
 
 type SuperchainDefinition struct {
 	Name                   string              `toml:"name"`
-	ProtocolVersionsAddr   *ChecksummedAddress `toml:"protocol_versions_addr"`
 	SuperchainConfigAddr   *ChecksummedAddress `toml:"superchain_config_addr"`
 	OPContractsManagerAddr *ChecksummedAddress `toml:"op_contracts_manager_addr"`
 	Hardforks              Hardforks           `toml:"hardforks"`

--- a/ops/internal/deployer/opaque_map.go
+++ b/ops/internal/deployer/opaque_map.go
@@ -202,13 +202,6 @@ func (om OpaqueState) ReadPermissionedDisputeGameImpl(idx int) (common.Address, 
 	)
 }
 
-func (om OpaqueState) ReadProtocolVersionsProxy() (common.Address, error) {
-	return om.queryAddress(
-		"superchainContracts.ProtocolVersionsProxy",
-		"superchainDeployment.protocolVersionsProxyAddress",
-	)
-}
-
 func (om OpaqueState) ReadSuperchainConfigProxy() (common.Address, error) {
 	return om.queryAddress(
 		"superchainContracts.SuperchainConfigProxy",

--- a/ops/internal/deployer/state.go
+++ b/ops/internal/deployer/state.go
@@ -453,7 +453,6 @@ func standardState(l1ChainID uint64, semver validation.Semver, data []byte) (Opa
 
 	root := dasel.New(state)
 	mustPutLowerString(root, "superchainDeployment.superchainConfigProxyAddress", sc.SuperchainConfigAddr)
-	mustPutLowerString(root, "superchainDeployment.protocolVersionsProxyAddress", sc.ProtocolVersionsAddr)
 	if stdVals.OPContractsManager != nil && stdVals.OPContractsManager.Address != nil {
 		mustPutLowerString(root, "implementationsDeployment.opcmAddress", stdVals.OPContractsManager.Address)
 	}

--- a/ops/internal/deployer/testdata/v1-state-output.json
+++ b/ops/internal/deployer/testdata/v1-state-output.json
@@ -5,7 +5,7 @@
     "proxyAdminAddress": "0x0000000000000000000000000000000000000000",
     "superchainConfigProxyAddress": "0xc2be75506d5724086deb7245bd260cc9753911be",
     "superchainConfigImplAddress": "0x0000000000000000000000000000000000000000",
-    "protocolVersionsProxyAddress": "0x79add5713b383daa0a138d3c4780c7a1804a8090",
+    "protocolVersionsProxyAddress": "0x0000000000000000000000000000000000000000",
     "protocolVersionsImplAddress": "0x0000000000000000000000000000000000000000"
   },
   "implementationsDeployment": {

--- a/ops/internal/deployer/testdata/v2-state-output.json
+++ b/ops/internal/deployer/testdata/v2-state-output.json
@@ -5,7 +5,7 @@
     "proxyAdminAddress": "0x0000000000000000000000000000000000000000",
     "superchainConfigProxyAddress": "0xc2be75506d5724086deb7245bd260cc9753911be",
     "superchainConfigImplAddress": "0x0000000000000000000000000000000000000000",
-    "protocolVersionsProxyAddress": "0x79add5713b383daa0a138d3c4780c7a1804a8090",
+    "protocolVersionsProxyAddress": "0x0000000000000000000000000000000000000000",
     "protocolVersionsImplAddress": "0x0000000000000000000000000000000000000000"
   },
   "implementationsDeployment": {

--- a/ops/internal/deployer/testdata/v3-state-output.json
+++ b/ops/internal/deployer/testdata/v3-state-output.json
@@ -5,7 +5,7 @@
     "proxyAdminAddress": "0x0000000000000000000000000000000000000000",
     "superchainConfigProxyAddress": "0xc2be75506d5724086deb7245bd260cc9753911be",
     "superchainConfigImplAddress": "0x0000000000000000000000000000000000000000",
-    "protocolVersionsProxyAddress": "0x79add5713b383daa0a138d3c4780c7a1804a8090",
+    "protocolVersionsProxyAddress": "0x0000000000000000000000000000000000000000",
     "protocolVersionsImplAddress": "0x0000000000000000000000000000000000000000"
   },
   "implementationsDeployment": {

--- a/ops/internal/manage/staging.go
+++ b/ops/internal/manage/staging.go
@@ -178,10 +178,6 @@ var (
 )
 
 func InflateSuperchainDefinition(name string, st deployer.OpaqueState) (*config.SuperchainDefinition, error) {
-	protocolVersionsProxyAddress, err := st.ReadProtocolVersionsProxy()
-	if err != nil {
-		return nil, fmt.Errorf("failed to read protocol versions proxy address: %w", err)
-	}
 	superchainConfigProxyAddress, err := st.ReadSuperchainConfigProxy()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read superchain config proxy address: %w", err)
@@ -198,7 +194,6 @@ func InflateSuperchainDefinition(name string, st deployer.OpaqueState) (*config.
 
 	sD := config.SuperchainDefinition{
 		Name:                   name,
-		ProtocolVersionsAddr:   config.NewChecksummedAddress(protocolVersionsProxyAddress),
 		SuperchainConfigAddr:   config.NewChecksummedAddress(superchainConfigProxyAddress),
 		OPContractsManagerAddr: config.NewChecksummedAddress(opcmAddress),
 		Hardforks:              config.Hardforks{}, // superchain wide hardforks are added after chains are in the registry.

--- a/ops/internal/manage/testdata/superchain/configs/sepolia/superchain.toml
+++ b/ops/internal/manage/testdata/superchain/configs/sepolia/superchain.toml
@@ -1,5 +1,4 @@
 name = "Sepolia"
-protocol_versions_addr = "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
 superchain_config_addr = "0xC2Be75506d5724086DEB7245bd260Cc9753911Be"
 op_contracts_manager_proxy_addr = "0xF564eEA7960EA244bfEbCBbB17858748606147bf"
 

--- a/superchain/configs/mainnet/superchain.toml
+++ b/superchain/configs/mainnet/superchain.toml
@@ -1,5 +1,4 @@
 name = "Mainnet"
-protocol_versions_addr = "0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935"
 superchain_config_addr = "0x95703e0982140D16f8ebA6d158FccEde42f04a4C"
 safer_safes_addr = "0xA8447329e52F64AED2bFc9E7a2506F7D369f483a"
 

--- a/superchain/configs/rehearsal-0-bn/superchain.toml
+++ b/superchain/configs/rehearsal-0-bn/superchain.toml
@@ -1,5 +1,4 @@
 name = "rehearsal-0-bn"
-protocol_versions_addr = "0x72B9c5a159B0dEE8331a268791aa432619693c06"
 superchain_config_addr = "0x672F11f34b7bE67C13A6FCba819c339bc3B0a585"
 op_contracts_manager_addr = "0x0fcD165e2531C934a186e3a412D58Daa241E0Ad0"
 

--- a/superchain/configs/sepolia-dev-0/superchain.toml
+++ b/superchain/configs/sepolia-dev-0/superchain.toml
@@ -1,5 +1,4 @@
 name = "Sepolia Dev 0"
-protocol_versions_addr = "0x252CbE9517F731C618961D890D534183822dcC8d"
 superchain_config_addr = "0x02d91Cf852423640d93920BE0CAdceC0E7A00FA7"
 
 [hardforks]

--- a/superchain/configs/sepolia/superchain.toml
+++ b/superchain/configs/sepolia/superchain.toml
@@ -1,5 +1,4 @@
 name = "Sepolia"
-protocol_versions_addr = "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
 superchain_config_addr = "0xC2Be75506d5724086DEB7245bd260Cc9753911Be"
 safer_safes_addr = "0xA8447329e52F64AED2bFc9E7a2506F7D369f483a"
 


### PR DESCRIPTION
op-node no longer reads the ProtocolVersions contract (ProtocolVersion signaling was removed from the monorepo), so the superchain-wide `protocol_versions_addr` is dead data.

Removes the field from `SuperchainDefinition`, all `superchain/configs/*/superchain.toml`, and the deployer/staging plumbing that filled it. The merged op-deployer state now carries a zero `protocolVersionsProxyAddress` — it's only fed to op-deployer for genesis/L1 inspection, which never read it; goldens updated.

**Scope is limited to the dead superchain-wide address.** The `protocol_versions` standard-versions entries and the `protocolVersionsOwner` role stay — standard-versions is append-only history (21 past releases deployed the contract) and the role still feeds op-deployer intent generation for older releases. A future contract-drop release just omits `protocol_versions` from its new block; it doesn't make these removable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
