### PR TITLE
fixing karst upgrade gas flag

### DIFF
--- a/superchain/configs/mainnet/metal.toml
+++ b/superchain/configs/mainnet/metal.toml
@@ -22,7 +22,7 @@ max_sequencer_drift = 600
   isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
   jovian_time = 1764691201 # Tue 2 Dec 2025 16:00:01 UTC
   karst_time = 1783526401 # Wed 8 Jul 2026 16:00:01 UTC
-  keep_karst_upgrade_gas = true
+  keep_karst_upgrade_gas = false
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/metal.toml
+++ b/superchain/configs/mainnet/metal.toml
@@ -22,7 +22,6 @@ max_sequencer_drift = 600
   isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
   jovian_time = 1764691201 # Tue 2 Dec 2025 16:00:01 UTC
   karst_time = 1783526401 # Wed 8 Jul 2026 16:00:01 UTC
-  keep_karst_upgrade_gas = false
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/mode.toml
+++ b/superchain/configs/mainnet/mode.toml
@@ -22,7 +22,7 @@ max_sequencer_drift = 600
   isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
   jovian_time = 1764691201 # Tue 2 Dec 2025 16:00:01 UTC
   karst_time = 1783526401 # Wed 8 Jul 2026 16:00:01 UTC
-  keep_karst_upgrade_gas = true
+  keep_karst_upgrade_gas = false
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/mode.toml
+++ b/superchain/configs/mainnet/mode.toml
@@ -22,7 +22,6 @@ max_sequencer_drift = 600
   isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
   jovian_time = 1764691201 # Tue 2 Dec 2025 16:00:01 UTC
   karst_time = 1783526401 # Wed 8 Jul 2026 16:00:01 UTC
-  keep_karst_upgrade_gas = false
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/zora.toml
+++ b/superchain/configs/mainnet/zora.toml
@@ -22,7 +22,7 @@ max_sequencer_drift = 600
   isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
   jovian_time = 1764691201 # Tue 2 Dec 2025 16:00:01 UTC
   karst_time = 1783526401 # Wed 8 Jul 2026 16:00:01 UTC
-  keep_karst_upgrade_gas = true
+  keep_karst_upgrade_gas = false
 
 [optimism]
   eip1559_elasticity = 6

--- a/superchain/configs/mainnet/zora.toml
+++ b/superchain/configs/mainnet/zora.toml
@@ -22,7 +22,6 @@ max_sequencer_drift = 600
   isthmus_time = 1746806401 # Fri 9 May 2025 16:00:01 UTC
   jovian_time = 1764691201 # Tue 2 Dec 2025 16:00:01 UTC
   karst_time = 1783526401 # Wed 8 Jul 2026 16:00:01 UTC
-  keep_karst_upgrade_gas = false
 
 [optimism]
   eip1559_elasticity = 6


### PR DESCRIPTION
Mode, Metal, and Zora Mainnets sequencers activated Karst without using the superchain registry or configuring this flag in op-node's rollup config. The value defaulted to null and resulted in `keep_karst_upgrade_gas=false`. So node operators who are using the network flags for these networks will have issues. This change will need to be worked into new node releases.