### PR TITLE
ci: prune removed superchains during codegen

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,19 +155,16 @@ jobs:
               # Extract the superchain name (directory between configs/ and the filename)
               SUPERCHAIN_NAME=$(echo "$file" | sed -n 's|^superchain/configs/\([^/]*\)/.*$|\1|p')
 
-              # If this is a superchain.toml file, skip it
-              if [[ "$file" == *"superchain.toml" ]]; then
+              # A changed path whose superchain definition no longer exists represents
+              # the removal of an entire superchain.
+              if [ ! -f "superchain/configs/$SUPERCHAIN_NAME/superchain.toml" ]; then
+                echo "Found removed superchain $SUPERCHAIN_NAME"
                 continue
               fi
 
-              if [ ! -d "superchain/configs/$SUPERCHAIN_NAME" ]; then
-                if [ "$SUPERCHAIN_NAME" = "rehearsal-0-bn" ]; then
-                  echo "Skipping deleted development superchain $SUPERCHAIN_NAME"
-                  continue
-                fi
-
-                echo "Deleted superchain $SUPERCHAIN_NAME is not allowed"
-                exit 1
+              # If this is a superchain.toml file, skip it
+              if [[ "$file" == *"superchain.toml" ]]; then
+                continue
               fi
 
               # Check if this superchain is already in our list
@@ -189,13 +186,21 @@ jobs:
               go run ./cmd/codegen \
                 --l1-rpc-urls="$OP_CI_SEPOLIA_L1_RPC_URL,$OP_CI_MAINNET_L1_RPC_URL" \
                 --superchains="$SUPERCHAINS"
+            else
+              # No surviving changed superchain is available to trigger codegen.
+              echo "Pruning generated entries for removed superchains\n"
+              go run ./cmd/codegen --prune-removed
             fi
 
             if [ -n "$(git status --porcelain)" ]; then
               echo "\n❌ Changes detected after running codegen. Run the following command locally and commit the changes:\n"
-              echo "go run ./cmd/codegen \\"
-              echo "  --l1-rpc-urls=\"<urls>\" \\"
-              echo "  --superchains=\"$SUPERCHAINS\""
+              if [ -n "$SUPERCHAINS" ]; then
+                echo "go run ./cmd/codegen \\"
+                echo "  --l1-rpc-urls=\"<urls>\" \\"
+                echo "  --superchains=\"$SUPERCHAINS\""
+              else
+                echo "go run ./cmd/codegen --prune-removed"
+              fi
               echo ""
               echo "These are the expected changes:"
               git diff

--- a/ops/cmd/codegen/main.go
+++ b/ops/cmd/codegen/main.go
@@ -14,10 +14,9 @@ import (
 
 var (
 	L1RPCURLsFlag = &cli.StringSliceFlag{
-		Name:     "l1-rpc-urls",
-		Usage:    "comma-separated list of L1 RPC URLs (only need multiple if fetching from multiple superchains)",
-		EnvVars:  []string{"L1_RPC_URLS"},
-		Required: true,
+		Name:    "l1-rpc-urls",
+		Usage:   "comma-separated list of L1 RPC URLs (only need multiple if fetching from multiple superchains)",
+		EnvVars: []string{"L1_RPC_URLS"},
 	}
 	ChainIDFlag = &cli.Uint64SliceFlag{
 		Name:  "chain-ids",
@@ -26,6 +25,10 @@ var (
 	SuperchainsFlag = &cli.StringSliceFlag{
 		Name:  "superchains",
 		Usage: "comma-separated list of superchains to update (cannot provide both chain-ids and superchains flags, default to all superchains if not provided)",
+	}
+	PruneRemovedFlag = &cli.BoolFlag{
+		Name:  "prune-removed",
+		Usage: "remove generated entries for chain configs that no longer exist without fetching on-chain data",
 	}
 )
 
@@ -37,6 +40,7 @@ func main() {
 			L1RPCURLsFlag,
 			ChainIDFlag,
 			SuperchainsFlag,
+			PruneRemovedFlag,
 		},
 		Action: CodegenCLI,
 	}
@@ -50,6 +54,7 @@ func CodegenCLI(cliCtx *cli.Context) error {
 	l1RpcUrls := cliCtx.StringSlice("l1-rpc-urls")
 	chainIds := cliCtx.Uint64Slice("chain-ids")
 	superchainsRaw := cliCtx.StringSlice("superchains")
+	pruneRemoved := cliCtx.Bool("prune-removed")
 	// Filter out empty strings from superchains
 	var superchains []string
 	for _, sc := range superchainsRaw {
@@ -61,11 +66,26 @@ func CodegenCLI(cliCtx *cli.Context) error {
 	if len(chainIds) > 0 && len(superchains) > 0 {
 		return fmt.Errorf("cannot provide both chain-ids and superchains flags")
 	}
+	if pruneRemoved && (len(chainIds) > 0 || len(superchains) > 0) {
+		return fmt.Errorf("cannot provide chain-ids or superchains with prune-removed")
+	}
 
 	lgr := log.NewLogger(log.NewTerminalHandlerWithLevel(os.Stderr, log.LevelInfo, false))
 	wd, err := paths.FindRepoRoot()
 	if err != nil {
 		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+	if pruneRemoved {
+		if err := manage.PruneRemovedChains(lgr, wd); err != nil {
+			return fmt.Errorf("error pruning removed chains: %w", err)
+		}
+		return nil
+	}
+	if len(l1RpcUrls) == 0 {
+		return fmt.Errorf("l1-rpc-urls is required unless prune-removed is set")
+	}
+	if err := manage.ValidateRequiredSuperchains(wd); err != nil {
+		return err
 	}
 
 	var onchainCfgs map[uint64]script.ChainConfig

--- a/ops/internal/manage/codegen_test.go
+++ b/ops/internal/manage/codegen_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -260,4 +261,73 @@ func TestCodegenSyncer_SyncAll(t *testing.T) {
 
 	_, err = os.Stat(filepath.Join(tempDir, "CHAINS.md"))
 	require.NoError(t, err)
+}
+
+func TestCodegenSyncer_SyncAllUpdatesExistingAndPrunesRemovedChain(t *testing.T) {
+	inputDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	copyFile := func(src, dst string) {
+		t.Helper()
+		data, err := os.ReadFile(src)
+		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0o755))
+		require.NoError(t, os.WriteFile(dst, data, 0o644))
+	}
+
+	for _, filename := range []string{"superchain.toml", "op.toml", "testchain.toml"} {
+		copyFile(
+			filepath.Join("testdata", "superchain", "configs", "sepolia", filename),
+			filepath.Join(inputDir, "superchain", "configs", "sepolia", filename),
+		)
+	}
+
+	const removedChainID = uint64(999)
+	chainList := loadTestChainList(t)
+	chainList = append(chainList, config.ChainListEntry{ChainID: removedChainID})
+	chainListData, err := json.Marshal(chainList)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(paths.ChainListJsonFile(inputDir), chainListData, 0o644))
+
+	addresses := loadTestAddressesJSON(t)
+	addresses[strconv.FormatUint(removedChainID, 10)] = &config.AddressesWithRoles{}
+	addressesData, err := json.Marshal(addresses)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(paths.AddressesFile(inputDir)), 0o755))
+	require.NoError(t, os.WriteFile(paths.AddressesFile(inputDir), addressesData, 0o644))
+
+	chainCfgs := createTestChainConfigs(t)
+	var updatedChainID uint64
+	for chainID, chainCfg := range chainCfgs {
+		updatedChainID = chainID
+		chainCfg.FaultProofStatus = &script.FaultProofStatus{RespectedGameType: 0}
+		chainCfgs = map[uint64]script.ChainConfig{chainID: chainCfg}
+		break
+	}
+
+	lgr := log.NewLogger(log.DiscardHandler())
+	syncer, err := NewCodegenSyncer(lgr, inputDir, chainCfgs, WithOutputDirectory(outputDir))
+	require.NoError(t, err)
+	require.NoError(t, syncer.SyncAll())
+
+	data, err := os.ReadFile(paths.ChainListJsonFile(outputDir))
+	require.NoError(t, err)
+	var gotChainList []config.ChainListEntry
+	require.NoError(t, json.Unmarshal(data, &gotChainList))
+
+	foundUpdatedChain := false
+	for _, entry := range gotChainList {
+		require.NotEqual(t, removedChainID, entry.ChainID)
+		if entry.ChainID == updatedChainID {
+			require.Equal(t, "permissionless", entry.FaultProofs.Status)
+			foundUpdatedChain = true
+		}
+	}
+	require.True(t, foundUpdatedChain)
+
+	data, err = os.ReadFile(paths.AddressesFile(outputDir))
+	require.NoError(t, err)
+	var gotAddresses config.AddressesJSON
+	require.NoError(t, json.Unmarshal(data, &gotAddresses))
+	require.NotContains(t, gotAddresses, strconv.FormatUint(removedChainID, 10))
 }

--- a/ops/internal/manage/prune_removed.go
+++ b/ops/internal/manage/prune_removed.go
@@ -1,0 +1,41 @@
+package manage
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ethereum-optimism/optimism/op-fetcher/pkg/fetcher/fetch/script"
+	"github.com/ethereum-optimism/superchain-registry/ops/internal/config"
+	"github.com/ethereum-optimism/superchain-registry/ops/internal/paths"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var requiredSuperchains = []config.Superchain{
+	config.MainnetSuperchain,
+	config.SepoliaSuperchain,
+}
+
+func ValidateRequiredSuperchains(wd string) error {
+	for _, superchain := range requiredSuperchains {
+		configPath := paths.SuperchainConfig(wd, superchain)
+		if _, err := os.Stat(configPath); err != nil {
+			return fmt.Errorf("required superchain %s is missing its superchain config: %w", superchain, err)
+		}
+	}
+	return nil
+}
+
+func PruneRemovedChains(lgr log.Logger, wd string) error {
+	if err := ValidateRequiredSuperchains(wd); err != nil {
+		return err
+	}
+
+	syncer, err := NewCodegenSyncer(lgr, wd, make(map[uint64]script.ChainConfig))
+	if err != nil {
+		return fmt.Errorf("error creating codegen syncer: %w", err)
+	}
+	if err := syncer.SyncAll(); err != nil {
+		return fmt.Errorf("error syncing codegen: %w", err)
+	}
+	return nil
+}

--- a/ops/internal/manage/prune_removed_test.go
+++ b/ops/internal/manage/prune_removed_test.go
@@ -1,0 +1,63 @@
+package manage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum-optimism/superchain-registry/ops/internal/config"
+	"github.com/ethereum-optimism/superchain-registry/ops/internal/paths"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func writeRequiredSuperchainConfigs(t *testing.T, wd string) {
+	t.Helper()
+	for _, superchain := range requiredSuperchains {
+		dir := paths.SuperchainDir(wd, superchain)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(paths.SuperchainConfig(wd, superchain), []byte(""), 0o644))
+	}
+}
+
+func TestValidateRequiredSuperchains(t *testing.T) {
+	wd := t.TempDir()
+	writeRequiredSuperchainConfigs(t, wd)
+	require.NoError(t, ValidateRequiredSuperchains(wd))
+
+	require.NoError(t, os.Remove(paths.SuperchainConfig(wd, config.MainnetSuperchain)))
+	err := ValidateRequiredSuperchains(wd)
+	require.ErrorContains(t, err, "required superchain mainnet")
+}
+
+func TestPruneRemovedChains(t *testing.T) {
+	wd := t.TempDir()
+	writeRequiredSuperchainConfigs(t, wd)
+
+	chainList := []config.ChainListEntry{{ChainID: 123}}
+	chainListJSON, err := json.Marshal(chainList)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(paths.ChainListJsonFile(wd), chainListJSON, 0o644))
+
+	addresses := config.AddressesJSON{"123": {}}
+	addressesJSON, err := json.Marshal(addresses)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(paths.AddressesFile(wd)), 0o755))
+	require.NoError(t, os.WriteFile(paths.AddressesFile(wd), addressesJSON, 0o644))
+
+	lgr := log.NewLogger(log.DiscardHandler())
+	require.NoError(t, PruneRemovedChains(lgr, wd))
+
+	var gotChainList []config.ChainListEntry
+	data, err := os.ReadFile(paths.ChainListJsonFile(wd))
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, &gotChainList))
+	require.Empty(t, gotChainList)
+
+	var gotAddresses config.AddressesJSON
+	data, err = os.ReadFile(paths.AddressesFile(wd))
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, &gotAddresses))
+	require.Empty(t, gotAddresses)
+}


### PR DESCRIPTION
## Summary

- replace the hardcoded `rehearsal-0-bn` CircleCI exception with generic removed-superchain handling
- add `codegen --prune-removed` to reconcile generated files without fetching on-chain data
- prevent removal of the required `mainnet` and `sepolia` superchain definitions
- use normal codegen when another changed superchain still exists, relying on its global pruning
- add regression coverage for updating one chain while pruning an unrelated removed chain