### PR TITLE
sepolia-devnet-2: remove protocol versions address

### DIFF
--- a/superchain/configs/sepolia-devnet-2/superchain.toml
+++ b/superchain/configs/sepolia-devnet-2/superchain.toml
@@ -1,5 +1,4 @@
 name = "sepolia-devnet-2"
-protocol_versions_addr = "0x0da9edA252F1339e864bABC47D8E78147eAb85Bc"
 superchain_config_addr = "0x289d2A1b1AE6E0470D8B72E53B6E3f485f251DBb"
 op_contracts_manager_addr = "0xe5dF58eAf094F1FdA718c62dF709b81c41f80491"
 


### PR DESCRIPTION
## Summary

Remove the deprecated `protocol_versions_addr` entry from `sepolia-devnet-2`'s `superchain.toml`.

## Why

`sepolia-devnet-2` was created with OPCM v2, and the ProtocolVersions contract path has been deprecated/removed from the Go plumbing. No other current superchain-level config in this registry includes `protocol_versions_addr`, and the registry tooling's `SuperchainDefinition` no longer models or emits that field.

Keeping this one-off key causes downstream strict config decoders to either fail or add legacy handling for a field this network should not need. Removing it keeps the registry entry aligned with the current OPCM v2 config shape.

## Validation

- `rg -n "protocol_versions_addr" superchain/configs -g '*.toml'` returns no matches
- `just check-chainlist`
