### PR TITLE
validation: Add sepolia standard versions for op-contracts/v8.0.0-rc.2

### DIFF
--- a/validation/standard/standard-versions-sepolia.toml
+++ b/validation/standard/standard-versions-sepolia.toml
@@ -3,7 +3,7 @@
 #   * proxied             : specify a standard "implementation_address"
 #   * neither             : specify neither a standard "address" nor "implementation_address"
 
-# Upgrade 20 https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv8.0.0-rc.2
+# https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv8.0.0-rc.2
 # protocol_versions is absent because the ProtocolVersions contract was removed from the monorepo,
 # so this release no longer deploys it.
 ["op-contracts/v8.0.0-rc.2"]

--- a/validation/standard/standard-versions-sepolia.toml
+++ b/validation/standard/standard-versions-sepolia.toml
@@ -3,6 +3,27 @@
 #   * proxied             : specify a standard "implementation_address"
 #   * neither             : specify neither a standard "address" nor "implementation_address"
 
+# Upgrade 20 https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv8.0.0-rc.2
+# protocol_versions is absent because the ProtocolVersions contract was removed from the monorepo,
+# so this release no longer deploys it.
+["op-contracts/v8.0.0-rc.2"]
+system_config = { version = "4.0.0", implementation_address = "0x670b850a235a6fa98cd7a195eb139d0277e471fa" }
+fault_dispute_game = { version = "2.4.2" }
+permissioned_dispute_game = { version = "2.4.0" }
+mips = { version = "1.10.1", address = "0xacc005dcd857b401e4732e6f7837135a22825cfa" }
+optimism_portal = { version = "5.8.0", implementation_address = "0x1005217ad392dc64cef501fa1777a27d42166748" }
+anchor_state_registry = { version = "3.9.0", implementation_address = "0x8f40cc98d694ab986f026c5383a181fcc9b6b281" }
+delayed_weth = { version = "1.5.1", implementation_address = "0xe440cc08a71694c8229323803f59024e3144630e" }
+eth_lockbox = { version = "1.3.1", implementation_address = "0xb3a24db07038b51962026329b62e7a965d56a6ad" }
+dispute_game_factory = { version = "1.6.1", implementation_address = "0x72b971717e088b59f26d4236be222adb6acd393b" }
+preimage_oracle = { version = "1.1.5", address = "0x1e1d73536a081ef2f355d29794547a9770aeb1e0" }
+l1_cross_domain_messenger = { version = "2.11.1", implementation_address = "0x59d497530b00062f40950ba8eab88868bf7f86f0" }
+l1_erc721_bridge = { version = "2.9.1", implementation_address = "0x9f164f1d02a81e06d639e55f65a87f0070e3cb2e" }
+l1_standard_bridge = { version = "2.8.2", implementation_address = "0xb37a11aadf167b2f0b8dd85372de4bc66cd4a891" }
+optimism_mintable_erc20_factory = { version = "1.11.0", implementation_address = "0xaabea75da509fa518fd8a91eae4be5813b829b12" }
+op_contracts_manager = { version = "8.0.0", address = "0xda83150fd745d35bb347a7afaf2d7af1d1e8b2b6" }
+superchain_config = { version = "2.4.3", implementation_address = "0x5570b1f2b97b1e35b5c6f9ee76f6cf02c9917504" }
+
 # https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv7.0.0-rc.4
 # Contracts have not been redeployed since v7.0.0-rc.3 (deploy-script-only changes).
 ["op-contracts/v7.0.0-rc.4"]


### PR DESCRIPTION
Adds the `["op-contracts/v8.0.0-rc.2"]` entry to `standard-versions-sepolia.toml` for the U20 release candidate ([op-contracts/v8.0.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv8.0.0-rc.2), commit `7799a24`).

Sepolia only. The mainnet entry follows once the implementations are deployed there.

## Source of the values

Addresses come from the `op-deployer bootstrap implementations` output (`just deploy-opcm` at the tag). Every recorded address was checked against Sepolia: `version()` on each address equals the version in this entry and equals the `@custom:semver` in the tagged source.

Changed since v7.0.0-rc.4:

| Contract | Version | Address |
| --- | --- | --- |
| system_config | 3.14.2 -> 4.0.0 | `0x670b850a235a6fa98cd7a195eb139d0277e471fa` |
| optimism_portal | 5.6.1 -> 5.8.0 | `0x1005217ad392dc64cef501fa1777a27d42166748` |
| superchain_config | 2.4.2 -> 2.4.3 | `0x5570b1f2b97b1e35b5c6f9ee76f6cf02c9917504` |
| op_contracts_manager | 7.1.17 -> 8.0.0 | `0xda83150fd745d35bb347a7afaf2d7af1d1e8b2b6` |

All other contracts have unchanged bytecode, so CREATE2 returned the same addresses as v7.0.0-rc.4. `fault_dispute_game` (2.4.2) and `permissioned_dispute_game` (2.4.0) stay version-only, as in earlier entries.

## Two things to note

1. `protocol_versions` is absent. `ProtocolVersions.sol` was removed from the monorepo (ethereum-optimism/optimism#20527), so the release no longer deploys it. This is the first entry without that key.
2. The deploy output also contains addresses with no field in `validation.VersionConfig`, so they are not recorded here: `superFaultDisputeGameImpl` (0.8.0), `superPermissionedDisputeGameImpl` (1.0.0), `opcmContainer`, `opcmUtils`, `opcmMigrator`, `opcmStandardValidator` (2.12.0) and `storageSetterImpl` (1.2.2). Earlier releases produced the same extra addresses and also omitted them, so this PR keeps the schema unchanged. Extending `VersionConfig` for the super-root games can be a separate decision.

## Test plan

`go test ./...` in `validation` passes (this decodes both standard-versions files through the Go decoder).
