### PR TITLE
validation: add sepolia versions for op-contracts/v8.0.0-pcdtest

### DIFF
--- a/validation/standard/standard-versions-sepolia.toml
+++ b/validation/standard/standard-versions-sepolia.toml
@@ -3,6 +3,27 @@
 #   * proxied             : specify a standard "implementation_address"
 #   * neither             : specify neither a standard "address" nor "implementation_address"
 
+# Test release for predictive chain deployments.
+# https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv8.0.0-pcdtest
+# WARNING: This is not a production release.
+["op-contracts/v8.0.0-pcdtest"]
+system_config = { version = "4.0.0", implementation_address = "0x670b850a235a6fa98cd7a195eb139d0277e471fa" }
+fault_dispute_game = { version = "2.4.2" }
+permissioned_dispute_game = { version = "2.4.0" }
+mips = { version = "1.10.1", address = "0xacc005dcd857b401e4732e6f7837135a22825cfa" }
+optimism_portal = { version = "5.8.0", implementation_address = "0x1005217ad392dc64cef501fa1777a27d42166748" }
+anchor_state_registry = { version = "3.9.0", implementation_address = "0x8f40cc98d694ab986f026c5383a181fcc9b6b281" }
+delayed_weth = { version = "1.5.1", implementation_address = "0xe440cc08a71694c8229323803f59024e3144630e" }
+eth_lockbox = { version = "1.3.1", implementation_address = "0xb3a24db07038b51962026329b62e7a965d56a6ad" }
+dispute_game_factory = { version = "1.6.1", implementation_address = "0x72b971717e088b59f26d4236be222adb6acd393b" }
+preimage_oracle = { version = "1.1.5", address = "0x1e1d73536a081ef2f355d29794547a9770aeb1e0" }
+l1_cross_domain_messenger = { version = "2.11.1", implementation_address = "0x59d497530b00062f40950ba8eab88868bf7f86f0" }
+l1_erc721_bridge = { version = "2.9.1", implementation_address = "0x9f164f1d02a81e06d639e55f65a87f0070e3cb2e" }
+l1_standard_bridge = { version = "2.8.2", implementation_address = "0xb37a11aadf167b2f0b8dd85372de4bc66cd4a891" }
+optimism_mintable_erc20_factory = { version = "1.11.0", implementation_address = "0xaabea75da509fa518fd8a91eae4be5813b829b12" }
+op_contracts_manager = { version = "8.0.0", address = "0x01bf7b87b0ab322a3a051941b043665b680b53e3" }
+superchain_config = { version = "2.4.3", implementation_address = "0x5570b1f2b97b1e35b5c6f9ee76f6cf02c9917504" }
+
 # https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv8.0.0-rc.2
 # protocol_versions is absent because the ProtocolVersions contract was removed from the monorepo,
 # so this release no longer deploys it.


### PR DESCRIPTION
Adds the `["op-contracts/v8.0.0-pcdtest"]` entry to `standard-versions-sepolia.toml` for the PCD E2E Testing([op-contracts/v8.0.0-pcdtest](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv8.0.0-pcdtest), commit `a71116c`).

Sepolia only.

## Source of the values

Addresses come from the `op-deployer bootstrap implementations` output. Every recorded address was checked against Sepolia: `version()` on each address equals the version in this entry and equals the `@custom:semver` in the tagged source.

## Test plan

`go test ./...` in `validation` passes (this decodes both standard-versions files through the Go decoder).
