### PR TITLE
sepolia-devnet-2: Remove unused op_contracts_manager_addr

### DIFF
--- a/superchain/configs/sepolia-devnet-2/superchain.toml
+++ b/superchain/configs/sepolia-devnet-2/superchain.toml
@@ -1,6 +1,5 @@
 name = "sepolia-devnet-2"
 superchain_config_addr = "0x289d2A1b1AE6E0470D8B72E53B6E3f485f251DBb"
-op_contracts_manager_addr = "0xe5dF58eAf094F1FdA718c62dF709b81c41f80491"
 
 [hardforks]
 


### PR DESCRIPTION
Removes the `op_contracts_manager_addr` field from the superchain config.

It is a dead field: nothing reads it. Grepping superchain-registry, superchain-ops, and the monorepo finds only the struct definitions and the write sites (`ops/internal/manage/staging.go`, superchain-ops `import_devnet`) — no readers. Tools source the OPCM elsewhere:
- op-deployer / op-chain-ops read the release-versioned OPCM from `validation/standard/standard-versions-*.toml` (`op_contracts_manager`).
- superchain-ops OPCM tasks read `[addresses] OPCM` from each task `config.toml`.

`sepolia-devnet-2` was the only superchain config that carried the field (mainnet and sepolia never set it, confirming it is optional), so this drops the single stale entry.

Supersedes the earlier revision of this PR that bumped the value to the v8.0.0-rc.2 OPCM.