### PR TITLE
Add Plataberget superchain target

### DIFF
--- a/CHAINS.md
+++ b/CHAINS.md
@@ -35,6 +35,10 @@
 | World Chain | ❌ | ❌ | https://worldchain-mainnet.explorer.alchemy.com/ | `https://worldchain-mainnet.g.alchemy.com/public` | `https://worldchain-mainnet-sequencer.g.alchemy.com` |
 | Xterio Chain (ETH) | ❌ | ❌ | https://eth.xterscan.io/ | `https://xterio-eth.alt.technology/` | `https://xterio-eth.alt.technology/` |
 | Zora | ✅ | ✅ | https://explorer.zora.energy | `https://rpc.zora.energy` | `https://rpc.zora.energy` |
+### plataberget
+
+| Chain Name | OP Governed[^1] | Superchain Hardforks[^2] | Explorer | Public RPC | Sequencer RPC
+|---|---|---|---|---|---|
 ### sepolia
 
 | Chain Name | OP Governed[^1] | Superchain Hardforks[^2] | Explorer | Public RPC | Sequencer RPC

--- a/superchain/configs/plataberget/superchain.toml
+++ b/superchain/configs/plataberget/superchain.toml
@@ -1,0 +1,10 @@
+name = "Plataberget"
+superchain_config_addr = "0x8c46E7CD3Dca25e740A25A0687E3A2A71AEC746c"
+op_contracts_manager_addr = "0x08bEcd0Af79C1929aC4077035a46061B2a7C67bD"
+
+[hardforks]
+
+[l1]
+  chain_id = 7091047534
+  public_rpc = "https://rpc.plataberget.ethpandaops.io/"
+  explorer = ""


### PR DESCRIPTION
## Summary

Adds the Plataberget superchain target on the Glamsterdam devnet-8 L1. These are the shared contracts used by the netchef-managed `glamsterdam-defense-0` testnet from [devnets-private#1516](https://github.com/ethereum-optimism/devnets-private/pull/1516).

## L1

- Chain ID: `7091047534`
- Public RPC: `https://rpc.plataberget.ethpandaops.io/`
- Genesis hash: `0xee33ef92bbabcf07bcf44fea1d18a7925c5f7f9da8f81334ea19b0f3cb892b31`

## Shared contracts

- SuperchainConfig proxy: `0x8c46E7CD3Dca25e740A25A0687E3A2A71AEC746c`
- OPContractsManager: `0x08bEcd0Af79C1929aC4077035a46061B2a7C67bD`
- OPCM version: `7.1.17`

Both addresses have deployed code on the configured L1. The SuperchainConfig is unpaused, and its guardian and ProxyAdmin owner are both `0x107781Bc6FA8f66B843f4216fd6D5862D3aa4fcd`.

This PR adds only the superchain target. Registering individual L2 chains can happen independently.

## Validation

- Parsed and selected the target with registry `codegen --superchains plataberget`; the configured RPC matched L1 chain ID `7091047534`
- `go test ./internal/config ./internal/manage ./internal/paths` from `ops/`
- `go test ./...` from `validation/`
- Verified live chain ID, genesis hash, deployed bytecode, OPCM version, ProxyAdmin owner, guardian, and paused state
- `git diff --check`
