### PR TITLE
Add kona-client v1.7.0-rc.1 prestates

### DIFF
--- a/validation/standard/standard-prestates.toml
+++ b/validation/standard/standard-prestates.toml
@@ -424,3 +424,11 @@ hash="0x0337ecb3604c0b40c352e0c7711beb17a212d583f4fe956fd8d66e29ad5f9025"
 [[prestates."1.6.0"]]
 type="cannon64-kona-interop"
 hash="0x03e3a42cf9a1d116f414206c465c6cdb74556136090e7c9556329403da0f310f"
+
+[[prestates."1.7.0-rc.1"]]
+type="cannon64-kona"
+hash="0x03a1947e65164afc92530d2608ac4657f7d21123da194742f10d16d62709e5e5"
+
+[[prestates."1.7.0-rc.1"]]
+type="cannon64-kona-interop"
+hash="0x03571d7f8e9b7736a677cb9a7e399f16572b5b22bb56d5b3112fcf7d1d0cccca"


### PR DESCRIPTION
Publishes the reproducible absolute prestates for `kona-client/v1.7.0-rc.1`, built from commit `e982ee6a14`.

Built with `just reproducible-kona-prestate` (Docker). Both hashes are already served from
`https://storage.googleapis.com/oplabs-network-data/proofs/kona/cannon`.

`latest_stable` / `latest_rc` are intentionally unchanged — those track op-program versions,
not kona-client. Note the `1.7.0-rc.1` key already carries op-program's `cannon64` / `interop`
entries; the kona-specific type names keep the four entries distinct.
