### PR TITLE
ops: enforce Ethereum DA for new public registry entries

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -16,7 +16,7 @@ If you are deploying a standard chain, it _must_ be deployed with `op-deployer` 
 the [docs](https://docs.optimism.io/chain-operators/tools/op-deployer) for more information on how to use it.
 
 > [!TIP]
-> We recommend that most chains use `op-deployer`. `op-deployer` can be configured to support L3s, alt-DA and custom gas token chains.
+> We recommend that most chains use `op-deployer`. `op-deployer` can be configured to support L3s and custom gas token chains.
 > If you do not use `op-deployer`, you will need to manually create your config file.
 > See [Adding a custom chain](#adding-a-custom-chain) below for more.
 
@@ -94,7 +94,7 @@ A member of our team will review your PR. When ready, we will generate code from
 ## Adding a custom chain
 
 We **strongly recommend** that you use `op-deployer` to deploy your chain.
-`op-deployer` can be configured to create L3s, alt-DA and custom gas token chains.
+`op-deployer` can be configured to create L3s and custom gas token chains.
 (See the [`op-deployer` docs](https://devdocs.optimism.io/op-deployer/) for more.)
 However, if your chain requires further modifications, you may need to use a custom deployment method and
 manually create the files needed to add your chain to the Superchain Registry.
@@ -194,7 +194,8 @@ The first part of the config contains important metadata about your chain. These
 - `sequencer_rpc`: Sequencer RPC endpoint for your chain.
 - `explorer`: Block explorer for your chain.
 - `governed_by_optimism`: For custom chains, this must be `false`.
-- `data_availability_type`: Which data availability layer your chain uses. Can be `eth-da` or `alt-da`.
+- `data_availability_type`: Must be `eth-da` for new chains. Existing `alt-da` values are retained as legacy network
+  metadata and are not accepted for new registry entries.
 - `chain_id`: Your chain ID. Must match the ID specified in [ethereum-lists/chains](https://github.com/ethereum-lists/chains).
 - `deployment_tx_hash`: Transaction hash of the transaction generated to deploy your chain.
 - `deployment_l1_contracts_version`: Must match the OP Contracts version tag that was used to deploy your L1 contracts.

--- a/ops/cmd/check_chainlist/main.go
+++ b/ops/cmd/check_chainlist/main.go
@@ -23,6 +23,15 @@ func mainErr() error {
 		return fmt.Errorf("failed to get working directory: %w", err)
 	}
 
+	chainCfgs, err := manage.CollectChainConfigs(paths.SuperchainConfigsDir(wd))
+	if err != nil {
+		return fmt.Errorf("failed to collect registry chain configs: %w", err)
+	}
+	if err := manage.ValidateRegistryDataAvailability(chainCfgs); err != nil {
+		return fmt.Errorf("invalid registry data availability: %w", err)
+	}
+	output.WriteOK("registry data availability check passed")
+
 	stagedChainCfgs, err := manage.StagedChainConfigs(wd)
 	if errors.Is(err, manage.ErrNoStagedConfig) {
 		output.WriteOK("no staged chain config found, exiting")
@@ -30,6 +39,11 @@ func mainErr() error {
 	}
 	if err != nil {
 		return fmt.Errorf("failed to get staged chain configs: %w", err)
+	}
+	for _, chainCfg := range stagedChainCfgs {
+		if err := manage.ValidateNewChainDataAvailability(&chainCfg.Chain); err != nil {
+			return fmt.Errorf("invalid data availability for staged chain %s: %w", chainCfg.ShortName, err)
+		}
 	}
 
 	globalChainData, err := manage.FetchGlobalChainIDs()

--- a/ops/cmd/sync_staging/main.go
+++ b/ops/cmd/sync_staging/main.go
@@ -116,6 +116,10 @@ func action(cliCtx *cli.Context) error {
 
 	var chainIds []uint64
 	for _, chainCfg := range stagedChainCfgs {
+		if err := manage.ValidateNewChainDataAvailability(&chainCfg.Chain); err != nil {
+			return fmt.Errorf("invalid data availability for staged chain %s: %w", chainCfg.ShortName, err)
+		}
+
 		genesisFilename := path.Join(stagingDir, chainCfg.ShortName+".json.zst")
 		genesis, err := manage.ReadGenesis(wd, genesisFilename)
 		if err != nil {

--- a/ops/internal/config/chain.go
+++ b/ops/internal/config/chain.go
@@ -47,10 +47,11 @@ type Chain struct {
 	Hardforks            Hardforks           `toml:"hardforks"`
 	Interop              *Interop            `toml:"interop,omitempty"`
 	Optimism             Optimism            `toml:"optimism"`
-	AltDA                *AltDA              `toml:"alt_da"`
-	Genesis              Genesis             `toml:"genesis"`
-	Roles                Roles               `toml:"roles"`
-	Addresses            Addresses           `toml:"addresses"`
+	// AltDA is retained only to decode existing registry entries. New staged chains must use Ethereum DA.
+	AltDA     *AltDA    `toml:"alt_da"`
+	Genesis   Genesis   `toml:"genesis"`
+	Roles     Roles     `toml:"roles"`
+	Addresses Addresses `toml:"addresses"`
 }
 
 func (c Chain) ChainListEntry(superchain Superchain, shortName string) ChainListEntry {
@@ -106,6 +107,7 @@ type SystemConfig struct {
 	BlobBaseFeeScalar *uint64            `json:"blobBaseFeeScalar,omitempty" toml:"blobBaseFeeScalar,omitempty"`
 }
 
+// AltDA contains compatibility metadata for existing registry entries.
 type AltDA struct {
 	DaChallengeContractAddress ChecksummedAddress `toml:"da_challenge_contract_address"`
 	DaChallengeWindow          uint64             `toml:"da_challenge_window"`
@@ -148,7 +150,8 @@ type Addresses struct {
 	MIPS                              *ChecksummedAddress `toml:"MIPS,omitempty" json:"MIPS,omitempty"`
 	PermissionedDisputeGame           *ChecksummedAddress `toml:"PermissionedDisputeGame,omitempty" json:"PermissionedDisputeGame,omitempty"`
 	PreimageOracle                    *ChecksummedAddress `toml:"PreimageOracle,omitempty" json:"PreimageOracle,omitempty"`
-	DAChallengeAddress                *ChecksummedAddress `toml:"DAChallengeAddress,omitempty" json:"DAChallengeAddress,omitempty"`
+	// DAChallengeAddress is retained only to detect and reject legacy staged configs.
+	DAChallengeAddress *ChecksummedAddress `toml:"DAChallengeAddress,omitempty" json:"DAChallengeAddress,omitempty"`
 }
 
 type AddressesJSON jsonutil.LazySortedJsonMap[string, *AddressesWithRoles]

--- a/ops/internal/config/chain_test.go
+++ b/ops/internal/config/chain_test.go
@@ -42,7 +42,6 @@ func TestAddressesWithRoles_Marshaling(t *testing.T) {
 			MIPS:                              NewChecksummedAddress(common.Address{'O'}),
 			PermissionedDisputeGame:           NewChecksummedAddress(common.Address{'P'}),
 			PreimageOracle:                    NewChecksummedAddress(common.Address{'Q'}),
-			DAChallengeAddress:                nil,
 		},
 		Roles: Roles{
 			SystemConfigOwner: NewChecksummedAddress(common.Address{'S'}),
@@ -61,4 +60,37 @@ func TestAddressesWithRoles_Marshaling(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, json.NewEncoder(&buf).Encode(testData))
 	require.JSONEq(t, string(expData), buf.String())
+}
+
+func TestLegacyAltDAMarshaling(t *testing.T) {
+	const legacy = `data_availability_type = "alt-da"
+
+[alt_da]
+  da_challenge_contract_address = "0x97A2dA87d3439b172e6DD027220e01c9Cb565B80"
+  da_challenge_window = 3600
+  da_resolve_window = 3600
+  da_commitment_type = "KeccakCommitment"
+`
+
+	var chain Chain
+	require.NoError(t, toml.Unmarshal([]byte(legacy), &chain))
+	require.NotNil(t, chain.AltDA)
+	require.Equal(t, uint64(3600), chain.AltDA.DaChallengeWindow)
+
+	var buf bytes.Buffer
+	require.NoError(t, toml.NewEncoder(&buf).Encode(chain))
+
+	var roundTrip Chain
+	require.NoError(t, toml.Unmarshal(buf.Bytes(), &roundTrip))
+	require.Equal(t, chain.AltDA, roundTrip.AltDA)
+}
+
+func TestLegacyDAChallengeAddressUnmarshaling(t *testing.T) {
+	const legacy = `[addresses]
+  DAChallengeAddress = "0x97A2dA87d3439b172e6DD027220e01c9Cb565B80"
+`
+
+	var chain Chain
+	require.NoError(t, toml.Unmarshal([]byte(legacy), &chain))
+	require.NotNil(t, chain.Addresses.DAChallengeAddress)
 }

--- a/ops/internal/deployer/deployer.go
+++ b/ops/internal/deployer/deployer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -14,6 +15,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -22,6 +24,8 @@ var versionsJSON []byte
 
 // contractVersions maps contract versions to deployer versions
 var contractVersions map[string]string
+
+var ErrUnsupportedDataAvailability = errors.New("Alt-DA is not supported for new registry entries")
 
 type BinaryPicker interface {
 	Path() string
@@ -162,14 +166,67 @@ func (d *OpDeployer) runCommand(args ...string) ([]byte, error) {
 	return output, nil
 }
 
-// inspectCommand runs an inspect command and unmarshals the output
+func (d *OpDeployer) inspectCommandRaw(workdir, chainId, subcommand string) ([]byte, error) {
+	return d.runCommand("inspect", subcommand, "--workdir", workdir, chainId)
+}
+
+func decodeInspectOutput(subcommand string, output []byte, result interface{}) error {
+	if err := json.Unmarshal(output, result); err != nil {
+		return fmt.Errorf("failed to parse op-deployer inspect %s output: %w", subcommand, err)
+	}
+	return nil
+}
+
+// inspectCommand runs an inspect command and unmarshals the output.
 func (d *OpDeployer) inspectCommand(workdir, chainId, subcommand string, result interface{}) error {
-	output, err := d.runCommand("inspect", subcommand, "--workdir", workdir, chainId)
+	output, err := d.inspectCommandRaw(workdir, chainId, subcommand)
 	if err != nil {
 		return err
 	}
-	if err := json.Unmarshal(output, result); err != nil {
-		return fmt.Errorf("failed to parse op-deployer inspect %s output: %w", subcommand, err)
+	return decodeInspectOutput(subcommand, output, result)
+}
+
+type legacyAltDADeployConfig struct {
+	UseAltDA                   bool           `json:"useAltDA"`
+	DACommitmentType           string         `json:"daCommitmentType"`
+	DAChallengeWindow          uint64         `json:"daChallengeWindow"`
+	DAResolveWindow            uint64         `json:"daResolveWindow"`
+	DABondSize                 uint64         `json:"daBondSize"`
+	DAResolverRefundPercentage uint64         `json:"daResolverRefundPercentage"`
+	DAChallengeProxy           common.Address `json:"daChallengeProxy"`
+}
+
+func (c legacyAltDADeployConfig) isSet() bool {
+	return c.UseAltDA ||
+		c.DACommitmentType != "" ||
+		c.DAChallengeWindow != 0 ||
+		c.DAResolveWindow != 0 ||
+		c.DABondSize != 0 ||
+		c.DAResolverRefundPercentage != 0 ||
+		c.DAChallengeProxy != (common.Address{})
+}
+
+func rejectLegacyAltDADeployConfig(output []byte) error {
+	var legacy legacyAltDADeployConfig
+	if err := decodeInspectOutput("deploy-config", output, &legacy); err != nil {
+		return err
+	}
+	if legacy.isSet() {
+		return ErrUnsupportedDataAvailability
+	}
+	return nil
+}
+
+func rejectLegacyAltDARollupConfig(output []byte) error {
+	var compatibility struct {
+		AltDA json.RawMessage `json:"alt_da"`
+	}
+	if err := decodeInspectOutput("rollup", output, &compatibility); err != nil {
+		return err
+	}
+	altDA := bytes.TrimSpace(compatibility.AltDA)
+	if len(altDA) != 0 && !bytes.Equal(altDA, []byte("null")) {
+		return ErrUnsupportedDataAvailability
 	}
 	return nil
 }
@@ -260,8 +317,16 @@ func (d *OpDeployer) InspectRollup(statePath, chainId string) (*rollup.Config, e
 	}
 	defer os.RemoveAll(workdir)
 
+	output, err := d.inspectCommandRaw(workdir, chainId, "rollup")
+	if err != nil {
+		return nil, err
+	}
+	if err := rejectLegacyAltDARollupConfig(output); err != nil {
+		return nil, err
+	}
+
 	var rollupConfig rollup.Config
-	if err := d.inspectCommand(workdir, chainId, "rollup", &rollupConfig); err != nil {
+	if err := decodeInspectOutput("rollup", output, &rollupConfig); err != nil {
 		return nil, err
 	}
 
@@ -275,8 +340,16 @@ func (d *OpDeployer) InspectDeployConfig(statePath, chainId string) (*genesis.De
 	}
 	defer os.RemoveAll(workdir)
 
+	output, err := d.inspectCommandRaw(workdir, chainId, "deploy-config")
+	if err != nil {
+		return nil, err
+	}
+	if err := rejectLegacyAltDADeployConfig(output); err != nil {
+		return nil, err
+	}
+
 	var deployConfig genesis.DeployConfig
-	if err := d.inspectCommand(workdir, chainId, "deploy-config", &deployConfig); err != nil {
+	if err := decodeInspectOutput("deploy-config", output, &deployConfig); err != nil {
 		return nil, err
 	}
 

--- a/ops/internal/deployer/deployer_test.go
+++ b/ops/internal/deployer/deployer_test.go
@@ -116,6 +116,70 @@ func TestVersionsMapInitialization(t *testing.T) {
 	require.Equal(t, actualVersion, expectedVersion)
 }
 
+func TestRejectLegacyAltDADeployConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		wantErr bool
+	}{
+		{name: "absent", output: `{}`},
+		{
+			name: "disabled zero values",
+			output: `{
+				"useAltDA": false,
+				"daCommitmentType": "",
+				"daChallengeWindow": 0,
+				"daResolveWindow": 0,
+				"daBondSize": 0,
+				"daResolverRefundPercentage": 0
+			}`,
+		},
+		{name: "enabled", output: `{"useAltDA":true}`, wantErr: true},
+		{name: "commitment type", output: `{"daCommitmentType":"KeccakCommitment"}`, wantErr: true},
+		{name: "challenge window", output: `{"daChallengeWindow":1}`, wantErr: true},
+		{name: "resolve window", output: `{"daResolveWindow":1}`, wantErr: true},
+		{name: "bond size", output: `{"daBondSize":1}`, wantErr: true},
+		{name: "resolver refund", output: `{"daResolverRefundPercentage":1}`, wantErr: true},
+		{name: "zero challenge proxy", output: `{"daChallengeProxy":"0x0000000000000000000000000000000000000000"}`},
+		{name: "challenge proxy", output: `{"daChallengeProxy":"0x1111111111111111111111111111111111111111"}`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := rejectLegacyAltDADeployConfig([]byte(tt.output))
+			if tt.wantErr {
+				require.ErrorIs(t, err, ErrUnsupportedDataAvailability)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRejectLegacyAltDARollupConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		wantErr bool
+	}{
+		{name: "absent", output: `{}`},
+		{name: "null", output: `{"alt_da":null}`},
+		{name: "empty object", output: `{"alt_da":{}}`, wantErr: true},
+		{name: "configured", output: `{"alt_da":{"da_commitment_type":"KeccakCommitment"}}`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := rejectLegacyAltDARollupConfig([]byte(tt.output))
+			if tt.wantErr {
+				require.ErrorIs(t, err, ErrUnsupportedDataAvailability)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestBinaryInvocation(t *testing.T) {
 	cacheDir := os.Getenv("DEPLOYER_CACHE_DIR")
 	require.NotEmpty(t, cacheDir)

--- a/ops/internal/deployer/state.go
+++ b/ops/internal/deployer/state.go
@@ -1,6 +1,7 @@
 package deployer
 
 import (
+	"bytes"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/ethereum-optimism/superchain-registry/validation"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/superchain"
 	"github.com/hashicorp/go-multierror"
 	"github.com/tomwright/dasel"
@@ -45,17 +47,84 @@ var standardV4_0Intent []byte
 var standardV4_1Intent []byte
 
 func ReadOpaqueStateFile(p string) (OpaqueState, error) {
-	f, err := os.Open(p)
+	data, err := os.ReadFile(p)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open JSON file: %w", err)
 	}
-	defer f.Close()
 
 	var out OpaqueState
-	if err := json.NewDecoder(f).Decode(&out); err != nil {
+	if err := json.Unmarshal(data, &out); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
 	}
+	if err := rejectLegacyAltDAState(data); err != nil {
+		return nil, err
+	}
 	return out, nil
+}
+
+type legacyAltDAState struct {
+	AppliedIntent struct {
+		Chains []struct {
+			DangerousAltDAConfig json.RawMessage `json:"dangerousAltDAConfig"`
+		} `json:"chains"`
+	} `json:"appliedIntent"`
+	OpChainDeployments []struct {
+		DataAvailabilityChallengeProxyAddress json.RawMessage `json:"dataAvailabilityChallengeProxyAddress"`
+		DataAvailabilityChallengeImplAddress  json.RawMessage `json:"dataAvailabilityChallengeImplAddress"`
+		AltDAChallengeProxy                   json.RawMessage `json:"AltDAChallengeProxy"`
+		AltDAChallengeImpl                    json.RawMessage `json:"AltDAChallengeImpl"`
+	} `json:"opChainDeployments"`
+}
+
+func rejectLegacyAltDAState(data []byte) error {
+	var legacy legacyAltDAState
+	if err := json.Unmarshal(data, &legacy); err != nil {
+		return fmt.Errorf("failed to inspect legacy Alt-DA state: %w", err)
+	}
+
+	for i, chain := range legacy.AppliedIntent.Chains {
+		rawConfig := bytes.TrimSpace(chain.DangerousAltDAConfig)
+		if len(rawConfig) == 0 || bytes.Equal(rawConfig, []byte("null")) {
+			continue
+		}
+		var cfg legacyAltDADeployConfig
+		if err := json.Unmarshal(rawConfig, &cfg); err != nil {
+			return fmt.Errorf("%w: invalid dangerousAltDAConfig for chain %d: %w", ErrUnsupportedDataAvailability, i, err)
+		}
+		if cfg.isSet() {
+			return fmt.Errorf("%w: applied intent chain %d contains dangerousAltDAConfig", ErrUnsupportedDataAvailability, i)
+		}
+	}
+
+	for i, chain := range legacy.OpChainDeployments {
+		addresses := []struct {
+			name string
+			raw  json.RawMessage
+		}{
+			{"dataAvailabilityChallengeProxyAddress", chain.DataAvailabilityChallengeProxyAddress},
+			{"dataAvailabilityChallengeImplAddress", chain.DataAvailabilityChallengeImplAddress},
+			{"AltDAChallengeProxy", chain.AltDAChallengeProxy},
+			{"AltDAChallengeImpl", chain.AltDAChallengeImpl},
+		}
+		for _, address := range addresses {
+			if legacyAltDAAddressIsSet(address.raw) {
+				return fmt.Errorf("%w: deployed chain %d contains %s", ErrUnsupportedDataAvailability, i, address.name)
+			}
+		}
+	}
+	return nil
+}
+
+func legacyAltDAAddressIsSet(raw json.RawMessage) bool {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return false
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return true
+	}
+	return !common.IsHexAddress(value) || common.HexToAddress(value) != (common.Address{})
 }
 
 type StateMerger = func(state OpaqueState) (OpaqueMap, OpaqueState, error)

--- a/ops/internal/deployer/state_test.go
+++ b/ops/internal/deployer/state_test.go
@@ -42,3 +42,90 @@ func TestMergeState(t *testing.T) {
 		})
 	}
 }
+
+func TestReadOpaqueStateAcceptsEmptyLegacyAltDA(t *testing.T) {
+	for _, filename := range []string{
+		"testdata/v1-state-input.json",
+		"testdata/v2-state-input.json",
+		"testdata/v3-state-input.json",
+		"configs/v4-state.json",
+	} {
+		t.Run(filename, func(t *testing.T) {
+			_, err := ReadOpaqueStateFile(filename)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestRejectLegacyAltDAState(t *testing.T) {
+	const address = "0x1111111111111111111111111111111111111111"
+	tests := []struct {
+		name  string
+		state string
+	}{
+		{
+			name:  "enabled config",
+			state: `{"appliedIntent":{"chains":[{"dangerousAltDAConfig":{"useAltDA":true}}]}}`,
+		},
+		{
+			name:  "disabled config with commitment",
+			state: `{"appliedIntent":{"chains":[{"dangerousAltDAConfig":{"useAltDA":false,"daCommitmentType":"KeccakCommitment"}}]}}`,
+		},
+		{
+			name:  "config on later chain",
+			state: `{"appliedIntent":{"chains":[{}, {"dangerousAltDAConfig":{"daChallengeWindow":1}}]}}`,
+		},
+		{
+			name:  "legacy proxy address",
+			state: `{"opChainDeployments":[{"dataAvailabilityChallengeProxyAddress":"` + address + `"}]}`,
+		},
+		{
+			name:  "legacy implementation address",
+			state: `{"opChainDeployments":[{"dataAvailabilityChallengeImplAddress":"` + address + `"}]}`,
+		},
+		{
+			name:  "v4 proxy address",
+			state: `{"opChainDeployments":[{"AltDAChallengeProxy":"` + address + `"}]}`,
+		},
+		{
+			name:  "v4 implementation address on later chain",
+			state: `{"opChainDeployments":[{}, {"AltDAChallengeImpl":"` + address + `"}]}`,
+		},
+		{
+			name:  "malformed address",
+			state: `{"opChainDeployments":[{"AltDAChallengeProxy":"not-an-address"}]}`,
+		},
+		{
+			name:  "empty address",
+			state: `{"opChainDeployments":[{"AltDAChallengeProxy":""}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := rejectLegacyAltDAState([]byte(tt.state))
+			require.ErrorIs(t, err, ErrUnsupportedDataAvailability)
+		})
+	}
+}
+
+func TestRejectLegacyAltDAStateAllowsAbsentAndZeroValues(t *testing.T) {
+	const state = `{
+		"appliedIntent": {"chains": [{"dangerousAltDAConfig": {
+			"useAltDA": false,
+			"daCommitmentType": "",
+			"daChallengeWindow": 0,
+			"daResolveWindow": 0,
+			"daBondSize": 0,
+			"daResolverRefundPercentage": 0
+		}}]},
+		"opChainDeployments": [{
+			"dataAvailabilityChallengeProxyAddress": "0x0000000000000000000000000000000000000000",
+			"dataAvailabilityChallengeImplAddress": "0x0000000000000000000000000000000000000000",
+			"AltDAChallengeProxy": null,
+			"AltDAChallengeImpl": "0x0000000000000000000000000000000000000000"
+		}]
+	}`
+
+	require.NoError(t, rejectLegacyAltDAState([]byte(state)))
+}

--- a/ops/internal/manage/staging.go
+++ b/ops/internal/manage/staging.go
@@ -63,17 +63,6 @@ func InflateChainConfig(opd *deployer.OpDeployer, st deployer.OpaqueState, state
 		EIP1559DenominatorCanyon: dc.EIP1559DenominatorCanyon,
 	}
 
-	if dc.UseAltDA {
-		cfg.AltDA = &config.AltDA{
-			DaChallengeContractAddress: config.ChecksummedAddress(dc.DAChallengeProxy),
-			DaChallengeWindow:          dc.DAChallengeWindow,
-			DaResolveWindow:            dc.DAResolveWindow,
-			DaCommitmentType:           dc.DACommitmentType,
-		}
-		cfg.Addresses.DAChallengeAddress = config.NewChecksummedAddress(dc.DAChallengeProxy)
-		cfg.DataAvailabilityType = "alt-da"
-	}
-
 	cfg.Genesis = config.Genesis{
 		L2Time: rollup.Genesis.L2Time,
 		L1: config.GenesisRef{

--- a/ops/internal/manage/validation.go
+++ b/ops/internal/manage/validation.go
@@ -15,14 +15,88 @@ import (
 const chainListUrl = "https://chainid.network/chains_mini.json"
 
 var (
-	ErrDuplicateChainID    = fmt.Errorf("duplicate chain ID")
-	ErrDuplicateShortName  = fmt.Errorf("duplicate short name")
-	ErrGenesisHashMismatch = fmt.Errorf("genesis hash mismatch")
+	ErrDuplicateChainID            = fmt.Errorf("duplicate chain ID")
+	ErrDuplicateShortName          = fmt.Errorf("duplicate short name")
+	ErrGenesisHashMismatch         = fmt.Errorf("genesis hash mismatch")
+	ErrUnsupportedDataAvailability = fmt.Errorf("unsupported data availability for new registry entry")
 )
+
+// legacyAltDAChains identifies the existing deployed networks whose registry
+// metadata must remain readable. No new entries may be added to this list.
+var legacyAltDAChains = map[string]uint64{
+	"mainnet/automata":            65536,
+	"mainnet/celo":                42220,
+	"mainnet/cyber":               7560,
+	"mainnet/fraxtal":             252,
+	"mainnet/funki":               33979,
+	"mainnet/lyra":                957,
+	"mainnet/orderly":             291,
+	"mainnet/redstone":            690,
+	"mainnet/silent-data-mainnet": 380929,
+	"mainnet/xterio-eth":          2702128,
+	"sepolia/celo-sep":            11142220,
+	"sepolia/funki":               3397901,
+}
 
 type GlobalChainIDs struct {
 	ChainIDs   map[uint64]bool
 	ShortNames map[string]bool
+}
+
+// ValidateNewChainDataAvailability restricts registry intake to Ethereum DA without changing existing chain records.
+func ValidateNewChainDataAvailability(cfg *config.Chain) error {
+	if cfg.DataAvailabilityType != "eth-da" {
+		return fmt.Errorf(
+			"%w: data_availability_type must be %q, got %q",
+			ErrUnsupportedDataAvailability,
+			"eth-da",
+			cfg.DataAvailabilityType,
+		)
+	}
+	if cfg.AltDA != nil {
+		return fmt.Errorf("%w: alt_da must not be configured", ErrUnsupportedDataAvailability)
+	}
+	if cfg.Addresses.DAChallengeAddress != nil {
+		return fmt.Errorf("%w: addresses.DAChallengeAddress must not be configured", ErrUnsupportedDataAvailability)
+	}
+	return nil
+}
+
+// ValidateRegistryDataAvailability enforces Ethereum DA for the complete
+// registry tree while preserving the exact set of existing legacy networks.
+func ValidateRegistryDataAvailability(chains []DiskChainConfig) error {
+	seenLegacy := make(map[string]bool, len(legacyAltDAChains))
+	for _, chain := range chains {
+		key := fmt.Sprintf("%s/%s", chain.Superchain, chain.ShortName)
+		legacyChainID, isLegacy := legacyAltDAChains[key]
+		if !isLegacy {
+			if err := ValidateNewChainDataAvailability(chain.Config); err != nil {
+				return fmt.Errorf("chain %s: %w", key, err)
+			}
+			continue
+		}
+
+		if chain.Config.ChainID != legacyChainID {
+			return fmt.Errorf("legacy Alt-DA chain %s must have chain ID %d, got %d", key, legacyChainID, chain.Config.ChainID)
+		}
+		if chain.Config.DataAvailabilityType != "alt-da" {
+			return fmt.Errorf("legacy Alt-DA chain %s must retain data_availability_type %q", key, "alt-da")
+		}
+		if chain.Config.Addresses.DAChallengeAddress != nil {
+			return fmt.Errorf("legacy Alt-DA chain %s contains retired addresses.DAChallengeAddress", key)
+		}
+		if seenLegacy[key] {
+			return fmt.Errorf("legacy Alt-DA chain %s appears more than once", key)
+		}
+		seenLegacy[key] = true
+	}
+
+	for key := range legacyAltDAChains {
+		if !seenLegacy[key] {
+			return fmt.Errorf("legacy Alt-DA chain %s is missing from the registry", key)
+		}
+	}
+	return nil
 }
 
 func ValidateUniqueness(

--- a/ops/internal/manage/validation_test.go
+++ b/ops/internal/manage/validation_test.go
@@ -1,6 +1,8 @@
 package manage
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/ethereum-optimism/superchain-registry/ops/internal/config"
@@ -8,6 +10,146 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/stretchr/testify/require"
 )
+
+func TestValidateNewChainDataAvailability(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config.Chain
+		wantErr bool
+	}{
+		{
+			name: "ethereum da",
+			cfg: config.Chain{
+				DataAvailabilityType: "eth-da",
+			},
+		},
+		{
+			name: "alternative da type",
+			cfg: config.Chain{
+				DataAvailabilityType: "alt-da",
+			},
+			wantErr: true,
+		},
+		{
+			name: "legacy metadata",
+			cfg: config.Chain{
+				DataAvailabilityType: "eth-da",
+				AltDA:                &config.AltDA{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "legacy challenge address",
+			cfg: config.Chain{
+				DataAvailabilityType: "eth-da",
+				Addresses: config.Addresses{
+					DAChallengeAddress: new(config.ChecksummedAddress),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "missing type",
+			cfg:     config.Chain{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNewChainDataAvailability(&tt.cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.True(t, errors.Is(err, ErrUnsupportedDataAvailability))
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func legacyRegistryFixture(t *testing.T) []DiskChainConfig {
+	t.Helper()
+	chains := make([]DiskChainConfig, 0, len(legacyAltDAChains))
+	for key, chainID := range legacyAltDAChains {
+		parts := strings.Split(key, "/")
+		require.Len(t, parts, 2)
+		chains = append(chains, DiskChainConfig{
+			Superchain: config.Superchain(parts[0]),
+			ShortName:  parts[1],
+			Config: &config.Chain{
+				ChainID:              chainID,
+				DataAvailabilityType: "alt-da",
+			},
+		})
+	}
+	return chains
+}
+
+func TestValidateRegistryDataAvailability(t *testing.T) {
+	t.Run("existing legacy chains", func(t *testing.T) {
+		require.NoError(t, ValidateRegistryDataAvailability(legacyRegistryFixture(t)))
+	})
+
+	t.Run("legacy chain cannot migrate without allowlist update", func(t *testing.T) {
+		chains := legacyRegistryFixture(t)
+		chains[0].Config.DataAvailabilityType = "eth-da"
+		require.Error(t, ValidateRegistryDataAvailability(chains))
+	})
+
+	t.Run("duplicate legacy chain", func(t *testing.T) {
+		chains := legacyRegistryFixture(t)
+		chains = append(chains, chains[0])
+		require.Error(t, ValidateRegistryDataAvailability(chains))
+	})
+
+	tests := []struct {
+		name  string
+		chain DiskChainConfig
+	}{
+		{
+			name: "new alt-da chain",
+			chain: DiskChainConfig{
+				Superchain: "mainnet",
+				ShortName:  "new-alt-da",
+				Config: &config.Chain{
+					ChainID:              123456789,
+					DataAvailabilityType: "alt-da",
+				},
+			},
+		},
+		{
+			name: "legacy chain ID under another name",
+			chain: DiskChainConfig{
+				Superchain: "mainnet",
+				ShortName:  "renamed-automata",
+				Config: &config.Chain{
+					ChainID:              65536,
+					DataAvailabilityType: "alt-da",
+				},
+			},
+		},
+		{
+			name: "new ethereum da chain with legacy metadata",
+			chain: DiskChainConfig{
+				Superchain: "mainnet",
+				ShortName:  "new-eth-da",
+				Config: &config.Chain{
+					ChainID:              123456790,
+					DataAvailabilityType: "eth-da",
+					AltDA:                &config.AltDA{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chains := append(legacyRegistryFixture(t), tt.chain)
+			require.Error(t, ValidateRegistryDataAvailability(chains))
+		})
+	}
+}
 
 func TestValidateGenesisIntegrity(t *testing.T) {
 	t.Run("validates genesis successfully", func(t *testing.T) {

--- a/validation/standard/standard-config-params-mainnet.toml
+++ b/validation/standard/standard-config-params-mainnet.toml
@@ -1,6 +1,5 @@
 # Standard Chain Config Parameters
 [rollup_config]
-# alt_da must be nil
 seq_window_size = [3600, 3600]
 block_time = [1, 2]
 

--- a/validation/standard/standard-config-params-sepolia.toml
+++ b/validation/standard/standard-config-params-sepolia.toml
@@ -1,6 +1,5 @@
 # Standard Chain Config Parameters
 [rollup_config]
-# alt_da must be nil
 seq_window_size = [3600, 3600]
 block_time = [1, 2]
 


### PR DESCRIPTION
Requires Ethereum DA for new registry entries built from the public OSS release, while preserving exact metadata for 12 existing Alt-DA chains. Rejects old op-deployer Alt-DA state before it can be silently rewritten.

Companion to ethereum-optimism/optimism#22668 and ethereum-optimism/specs#935.